### PR TITLE
Fix types, call verifier, and remove div/0 on valid mod operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 # Project metadata
 name = "solana_rbpf"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 
 # Additional metadata for packaging

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -75,6 +75,14 @@ impl EBpfElf {
             .filter(|section| section.name.starts_with(b".rodata"))
             .map(EBpfElf::content_to_bytes)
             .collect();
+        if let Ok(ref v) = rodata {
+                if v.is_empty() {
+                    Err(Error::new(
+                    ErrorKind::Other,
+                    "Error: No RO data",
+                ))?;
+            }
+        }
         rodata
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -377,7 +377,7 @@ fn muldivmod(jit: &mut JitMemory, pc: u16, opc: u8, src: u8, dst: u8, imm: i32) 
         }
 
         // jz div_by_zero
-        emit_jcc(jit, 0x84, TARGET_PC_DIV_BY_ZERO);
+        //emit_jcc(jit, 0x84, TARGET_PC_DIV_BY_ZERO);
     }
 
     if dst != RAX {

--- a/tests/ubpf_jit_x86_64.rs
+++ b/tests/ubpf_jit_x86_64.rs
@@ -430,62 +430,64 @@ fn test_jit_err_call_unreg() {
     unsafe { vm.execute_program_jit().unwrap(); }
 }
 
-// TODO: Should panic!() instead, but I could not make it panic in JIT-compiled code, so the
-// program returns -1 instead. We can make it write on stderr, though.
-#[test]
-//#[should_panic(expected = "[JIT] Error: division by 0")]
-fn test_jit_err_div64_by_zero_reg() {
-    let prog = assemble("
-        mov32 r0, 1
-        mov32 r1, 0
-        div r0, r1
-        exit").unwrap();
-    let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.jit_compile().unwrap();
-    unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
-}
+// TODO jit always puts a div by zero exception in for mod, removed div/0 for now but that
+// also breaks these test
+// // TODO: Should panic!() instead, but I could not make it panic in JIT-compiled code, so the
+// // program returns -1 instead. We can make it write on stderr, though.
+// #[test]
+// //#[should_panic(expected = "[JIT] Error: division by 0")]
+// fn test_jit_err_div64_by_zero_reg() {
+//     let prog = assemble("
+//         mov32 r0, 1
+//         mov32 r1, 0
+//         div r0, r1
+//         exit").unwrap();
+//     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
+//     vm.jit_compile().unwrap();
+//     unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
+// }
 
-// TODO: Same remark as above
-#[test]
-//#[should_panic(expected = "[JIT] Error: division by 0")]
-fn test_jit_err_div_by_zero_reg() {
-    let prog = assemble("
-        mov32 r0, 1
-        mov32 r1, 0
-        div32 r0, r1
-        exit").unwrap();
-    let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.jit_compile().unwrap();
-    unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
-}
+// // TODO: Same remark as above
+// #[test]
+// //#[should_panic(expected = "[JIT] Error: division by 0")]
+// fn test_jit_err_div_by_zero_reg() {
+//     let prog = assemble("
+//         mov32 r0, 1
+//         mov32 r1, 0
+//         div32 r0, r1
+//         exit").unwrap();
+//     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
+//     vm.jit_compile().unwrap();
+//     unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
+// }
 
-// TODO: Same remark as above
-#[test]
-//#[should_panic(expected = "[JIT] Error: division by 0")]
-fn test_jit_err_mod64_by_zero_reg() {
-    let prog = assemble("
-        mov32 r0, 1
-        mov32 r1, 0
-        mod r0, r1
-        exit").unwrap();
-    let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.jit_compile().unwrap();
-    unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
-}
+// // TODO: Same remark as above
+// #[test]
+// //#[should_panic(expected = "[JIT] Error: division by 0")]
+// fn test_jit_err_mod64_by_zero_reg() {
+//     let prog = assemble("
+//         mov32 r0, 1
+//         mov32 r1, 0
+//         mod r0, r1
+//         exit").unwrap();
+//     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
+//     vm.jit_compile().unwrap();
+//     unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
+// }
 
-// TODO: Same remark as above
-#[test]
-//#[should_panic(expected = "[JIT] Error: division by 0")]
-fn test_jit_err_mod_by_zero_reg() {
-    let prog = assemble("
-        mov32 r0, 1
-        mov32 r1, 0
-        mod32 r0, r1
-        exit").unwrap();
-    let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.jit_compile().unwrap();
-    unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
-}
+// // TODO: Same remark as above
+// #[test]
+// //#[should_panic(expected = "[JIT] Error: division by 0")]
+// fn test_jit_err_mod_by_zero_reg() {
+//     let prog = assemble("
+//         mov32 r0, 1
+//         mov32 r1, 0
+//         mod32 r0, r1
+//         exit").unwrap();
+//     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
+//     vm.jit_compile().unwrap();
+//     unsafe { assert_eq!(vm.execute_program_jit().unwrap(), 0xffffffffffffffff); }
+// }
 
 // TODO SKIP: JIT disabled for this testcase (stack oob check not implemented)
 // #[test]


### PR DESCRIPTION
- Set/get instruction count uses usize which should really only be used for pointers.  Switch to u64 instead
- Call verifier in all cases
- Remove div/0 when jitting code since it causes even valid mod operations to fail.  More investigation needed.  Following up with the original author (https://github.com/qmonnet/rbpf/issues/45)