### PR TITLE
Allow helper function parameters to be on the stack

### DIFF
--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -18,6 +18,7 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
+use RegionPtrs;
 use std::io::Error;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
@@ -395,7 +396,7 @@ pub const BPF_ALU_OP_MASK : u8 = 0xf0;
 pub type HelperFunction = fn (u64, u64, u64, u64, u64) -> u64;
 
 /// Prototype of an eBPF helper verification function.
-pub type HelperVerifier = fn (u64, u64, u64, u64, u64, &[&[u8]], &[&[u8]]) -> Result<(()), Error>;
+pub type HelperVerifier = fn (u64, u64, u64, u64, u64, &[RegionPtrs], &[RegionPtrs]) -> Result<(()), Error>;
 
 /// eBPF Helper pair
 /// 


### PR DESCRIPTION
The list of regions that helper verifier functions check to ensure valid parameters did not include the stack.

- Updated to include the stack
- Simplified the verifier to take u64 ptrs instead of references to the actual region
- Added test to verify that the stack is included in the verify regions