### PR TITLE
Support BPF register relative call instruction: `call <reg>`

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -290,8 +290,8 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::JSLT_REG   => { name = "jslt"; desc = jmp_reg_str(name, &insn); },
             ebpf::JSLE_IMM   => { name = "jsle"; desc = jmp_imm_str(name, &insn); },
             ebpf::JSLE_REG   => { name = "jsle"; desc = jmp_reg_str(name, &insn); },
-            ebpf::CALL       => { name = "call"; desc = format!("{} {:#x}", name, insn.imm); },
-            ebpf::TAIL_CALL  => { name = "tail_call"; desc = name.to_string(); },
+            ebpf::CALL_IMM   => { name = "call"; desc = format!("{} {:#x}", name, insn.imm); },
+            ebpf::CALL_REG   => { name = "callx"; desc = format!("{} {:#x}", name, insn.src); },
             ebpf::EXIT       => { name = "exit";      desc = name.to_string(); },
 
             _                => {

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -387,9 +387,9 @@ pub const JSLE_IMM   : u8 = BPF_JMP   | BPF_K   | BPF_JSLE;
 pub const JSLE_REG   : u8 = BPF_JMP   | BPF_X   | BPF_JSLE;
 
 /// BPF opcode: `call imm` /// helper function call to helper with key `imm`.
-pub const CALL       : u8 = BPF_JMP   | BPF_CALL;
+pub const CALL_IMM   : u8 = BPF_JMP   | BPF_CALL;
 /// BPF opcode: tail call.
-pub const TAIL_CALL  : u8 = BPF_JMP   | BPF_X | BPF_CALL;
+pub const CALL_REG   : u8 = BPF_JMP   | BPF_X | BPF_CALL;
 /// BPF opcode: `exit` /// `return r0`.
 pub const EXIT       : u8 = BPF_JMP   | BPF_EXIT;
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -774,7 +774,7 @@ impl<'a> JitMemory<'a> {
                     emit_cmp(self, src, dst);
                     emit_jcc(self, 0x8e, target_pc);
                 },
-                ebpf::CALL       => {
+                ebpf::CALL_IMM  => {
                     // For JIT, helpers in use MUST be registered at compile time. They can be
                     // updated later, but not created after compiling (we need the address of the
                     // helper function in the JIT-compiled program).
@@ -793,7 +793,7 @@ impl<'a> JitMemory<'a> {
                                                insn.imm as u32)))?;
                     };
                 },
-                ebpf::TAIL_CALL  => { unimplemented!() },
+                ebpf::CALL_REG  => { unimplemented!() },
                 ebpf::EXIT       => {
                     if insn_ptr != prog.len() / ebpf::INSN_SIZE - 1 {
                         emit_jmp(self, TARGET_PC_EXIT);

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -237,8 +237,8 @@ pub fn check(prog: &[u8]) -> Result<(), Error> {
             ebpf::JSLT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
             ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
             ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::CALL       => {},
-            ebpf::TAIL_CALL  => { unimplemented!() },
+            ebpf::CALL_IMM   => {},
+            ebpf::CALL_REG   => {},
             ebpf::EXIT       => {},
 
             _                => {

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -93,10 +93,15 @@ fn test_jeq() {
                Ok(vec![insn(ebpf::JEQ_REG, 1, 3, 8, 0)]));
 }
 
+#[test]
+fn test_call_reg() {
+    assert_eq!(asm("callx 3"), Ok(vec![insn(ebpf::CALL_REG, 0, 3, 0, 0)]));
+}
+
 // Example for InstructionType::Call.
 #[test]
-fn test_call() {
-    assert_eq!(asm("call 300"), Ok(vec![insn(ebpf::CALL, 0, 0, 0, 300)]));
+fn test_call_imm() {
+    assert_eq!(asm("call 300"), Ok(vec![insn(ebpf::CALL_IMM, 0, 0, 0, 300)]));
 }
 
 // Example for InstructionType::Endian.


### PR DESCRIPTION
Add support for BPF instruction `callx <reg>` which is a function call to pc + reg<src>.  The instruction uses opcode 0x8d