### PR TITLE
Call register uses imm

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -178,7 +178,7 @@ fn encode(inst_type: InstructionType, opc: u8, operands: &[Operand]) -> Result<I
             insn(opc | ebpf::BPF_K, dst, 0, off, imm)
         }
         (CallImm, Integer(imm), Nil, Nil) => insn(opc, 0, 0, 0, imm),
-        (CallReg, Integer(src), Nil, Nil) => insn(opc, 0, src, 0, 0),
+        (CallReg, Integer(imm), Nil, Nil) => insn(opc, 0, 0, 0, imm),
         (Endian(size), Register(dst), Nil, Nil) => insn(opc, dst, 0, 0, size),
         (LoadImm, Register(dst), Integer(imm), Nil) => insn(opc, dst, 0, 0, (imm << 32) >> 32),
         _ => Err(format!("Unexpected operands: {:?}", operands)),

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -291,7 +291,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             ebpf::JSLE_IMM   => { name = "jsle"; desc = jmp_imm_str(name, &insn); },
             ebpf::JSLE_REG   => { name = "jsle"; desc = jmp_reg_str(name, &insn); },
             ebpf::CALL_IMM   => { name = "call"; desc = format!("{} {:#x}", name, insn.imm); },
-            ebpf::CALL_REG   => { name = "callx"; desc = format!("{} {:#x}", name, insn.src); },
+            ebpf::CALL_REG   => { name = "callx"; desc = format!("{} {:#x}", name, insn.imm); },
             ebpf::EXIT       => { name = "exit";      desc = name.to_string(); },
 
             _                => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,6 +491,7 @@ impl<'a> EbpfVmMbuff<'a> {
     /// ```
     #[allow(unknown_lints)]
     #[allow(cyclomatic_complexity)]
+    #[allow(cognitive_complexity)]
     pub fn execute_program(&mut self, mem: &[u8], mbuff: &[u8]) -> Result<u64, Error> {
         const U32MAX: u64 = u32::MAX as u64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,8 +806,9 @@ impl<'a> EbpfVmMbuff<'a> {
                 ebpf::JSLE_REG   => if (reg[_dst] as i64) <= reg[_src] as i64 { pc = (pc as i16 + insn.off) as usize; },
 
                 ebpf::CALL_REG   => {
-                    println!("CALL_REG R{:?}[{:?}]", _src, reg[_src]);
-                    pc = reg[_src] as usize;
+                    let base_address = &prog[0] as *const _ as usize;
+                    let target_address = reg[insn.imm as usize] as usize;
+                    pc = (target_address - base_address) / ebpf::INSN_SIZE;
                 },
 
                 // Do not delegate the check to the verifier, since registered functions can be

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -95,7 +95,7 @@ fn test_jeq() {
 
 #[test]
 fn test_call_reg() {
-    assert_eq!(asm("callx 3"), Ok(vec![insn(ebpf::CALL_REG, 0, 3, 0, 0)]));
+    assert_eq!(asm("callx 3"), Ok(vec![insn(ebpf::CALL_REG, 0, 0, 0, 3)]));
 }
 
 // Example for InstructionType::Call.


### PR DESCRIPTION
Call register (callx) uses the instructions imm field to specify the register containing the address to