### PR TITLE
Add support for helper contexts

### DIFF
--- a/examples/load_elf.rs
+++ b/examples/load_elf.rs
@@ -118,7 +118,7 @@ fn main() {
     let mut vm = EbpfVmFixedMbuff::new(Some(prog), 0x40, 0x50).unwrap();
     vm.register_helper(helpers::BPF_TRACE_PRINTK_IDX, helpers::bpf_trace_printf).unwrap();
 
-    let res = vm.execute_program(packet1).unwrap();
+    let res = vm.execute_program(packet1, &[], &[]).unwrap();
     println!("Packet #1, program returned: {:?} ({:#x})", res, res);
     assert_eq!(res, 0xffffffff);
 
@@ -133,7 +133,7 @@ fn main() {
 
     #[cfg(windows)]
     {
-        let res = vm.execute_program(packet2).unwrap();
+        let res = vm.execute_program(packet2, &[], &[]).unwrap();
         println!("Packet #2, program returned: {:?} ({:#x})", res, res);
         assert_eq!(res, 0);
     }

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -44,7 +44,7 @@ fn main() {
     // Create a VM: this one takes no data. Load prog1 in it.
     let mut vm = EbpfVmNoData::new(Some(prog1)).unwrap();
     // Execute prog1.
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 
     // As struct EbpfVmNoData does not takes any memory area, its return value is mostly
     // deterministic. So we know prog1 will always return 3. There is an exception: when it uses
@@ -68,7 +68,7 @@ fn main() {
 
     #[cfg(windows)]
     {
-        time = vm.execute_program().unwrap();
+        time = vm.execute_program(&[], &[]).unwrap();
     }
 
     let days    =  time / 10u64.pow(9)  / 60   / 60  / 24;

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -22,8 +22,9 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 use MemoryRegion;
-use std::io::Error;
+use std::any::Any;
 use std::fmt;
+use std::io::Error;
 use byteorder::{ByteOrder, LittleEndian};
 use hash32::{Hash, Hasher, Murmur3Hasher};
 
@@ -399,10 +400,19 @@ pub const BPF_CLS_MASK    : u8 = 0x07;
 pub const BPF_ALU_OP_MASK : u8 = 0xf0;
 
 /// Prototype of an eBPF helper function.
-pub type HelperFunction = fn (u64, u64, u64, u64, u64) -> u64;
+pub type HelperFunction = fn (u64, u64, u64, u64, u64, &mut Option<Box<Any>>) -> u64;
 
 /// Prototype of an eBPF helper verification function.
-pub type HelperVerifier = fn (u64, u64, u64, u64, u64, &[MemoryRegion], &[MemoryRegion]) -> Result<(()), Error>;
+pub type HelperVerifier = fn (
+    u64,
+    u64,
+    u64,
+    u64,
+    u64,
+    &mut Option<Box<Any>>,
+    &[MemoryRegion],
+    &[MemoryRegion],
+) -> Result<(()), Error>;
 
 /// eBPF Helper pair
 /// 
@@ -419,6 +429,8 @@ pub struct Helper {
     pub verifier: Option<HelperVerifier>,
     /// Actual helper function that does the work
     pub function: HelperFunction,
+    /// Context passed to both the verifier and the function
+    pub context: Option<Box<Any>>,
 }
 
 /// An eBPF instruction.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -26,6 +26,7 @@
 extern crate libc;
 
 use std::u64;
+use std::any::Any;
 use time;
 
 // Helpers associated to kernel helpers
@@ -44,7 +45,7 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// ```
 /// use solana_rbpf::helpers;
 ///
-/// let t = helpers::bpf_time_getns(0, 0, 0, 0, 0);
+/// let t = helpers::bpf_time_getns(0, 0, 0, 0, 0, &mut None);
 /// let d =  t / 10u64.pow(9)  / 60   / 60  / 24;
 /// let h = (t / 10u64.pow(9)  / 60   / 60) % 24;
 /// let m = (t / 10u64.pow(9)  / 60 ) % 60;
@@ -54,7 +55,14 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
-pub fn bpf_time_getns (unused1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
+pub fn bpf_time_getns (
+    unused1: u64,
+    unused2: u64,
+    unused3: u64,
+    unused4: u64,
+    unused5: u64,
+    unused6: &mut Option<Box<Any>>
+) -> u64 {
     time::precise_time_ns()
 }
 
@@ -75,7 +83,7 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// ```
 /// use solana_rbpf::helpers;
 ///
-/// let res = helpers::bpf_trace_printf(0, 0, 1, 15, 32);
+/// let res = helpers::bpf_trace_printf(0, 0, 1, 15, 32, &mut None);
 /// assert_eq!(res as usize, "bpf_trace_printf: 0x1, 0xf, 0x20\n".len());
 /// ```
 ///
@@ -101,7 +109,14 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// program is run.
 #[allow(dead_code)]
 #[allow(unused_variables)]
-pub fn bpf_trace_printf (unused1: u64, unused2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
+pub fn bpf_trace_printf (
+    unused1: u64,
+    unused2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    unused6: &mut Option<Box<Any>>
+) -> u64 {
     println!("bpf_trace_printf: {:#x}, {:#x}, {:#x}", arg3, arg4, arg5);
     let size_arg = | x | {
         if x == 0 {
@@ -125,10 +140,18 @@ pub fn bpf_trace_printf (unused1: u64, unused2: u64, arg3: u64, arg4: u64, arg5:
 /// ```
 /// use solana_rbpf::helpers;
 ///
-/// let gathered = helpers::gather_bytes(0x11, 0x22, 0x33, 0x44, 0x55);
+/// let gathered = helpers::gather_bytes(0x11, 0x22, 0x33, 0x44, 0x55, &mut None);
 /// assert_eq!(gathered, 0x1122334455);
 /// ```
-pub fn gather_bytes (arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
+#[allow(unused_variables)]
+pub fn gather_bytes (
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    unused: &mut Option<Box<Any>>
+) -> u64 {
     arg1.wrapping_shl(32) |
        arg2.wrapping_shl(24) |
        arg3.wrapping_shl(16) |
@@ -148,13 +171,20 @@ pub fn gather_bytes (arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u
 /// let val: u64 = 0x112233;
 /// let val_ptr = &val as *const u64;
 ///
-/// helpers::memfrob(val_ptr as u64, 8, 0, 0, 0);
+/// helpers::memfrob(val_ptr as u64, 8, 0, 0, 0, &mut None);
 /// assert_eq!(val, 0x2a2a2a2a2a3b0819);
-/// helpers::memfrob(val_ptr as u64, 8, 0, 0, 0);
+/// helpers::memfrob(val_ptr as u64, 8, 0, 0, 0, &mut None);
 /// assert_eq!(val, 0x112233);
 /// ```
 #[allow(unused_variables)]
-pub fn memfrob (ptr: u64, len: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
+pub fn memfrob (
+    ptr: u64,
+    len: u64, 
+    unused3: u64,
+    unused4: u64,
+    unused5: u64,
+    unused6: &mut Option<Box<Any>>
+) -> u64 {
     for i in 0..len {
         unsafe {
             let mut p = (ptr + i) as *mut u8;
@@ -193,12 +223,19 @@ pub fn memfrob (ptr: u64, len: u64, unused3: u64, unused4: u64, unused5: u64) ->
 /// ```
 /// use solana_rbpf::helpers;
 ///
-/// let x = helpers::sqrti(9, 0, 0, 0, 0);
+/// let x = helpers::sqrti(9, 0, 0, 0, 0, &mut None);
 /// assert_eq!(x, 3);
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
-pub fn sqrti (arg1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
+pub fn sqrti (
+    arg1: u64,
+    unused2: u64,
+    unused3: u64,
+    unused4: u64,
+    unused5: u64,
+    unused6: &mut Option<Box<Any>>
+) -> u64 {
     (arg1 as f64).sqrt() as u64
 }
 
@@ -212,12 +249,19 @@ pub fn sqrti (arg1: u64, unused2: u64, unused3: u64, unused4: u64, unused5: u64)
 /// let foo = "This is a string.".as_ptr() as u64;
 /// let bar = "This is another sting.".as_ptr() as u64;
 ///
-/// assert!(helpers::strcmp(foo, foo, 0, 0, 0) == 0);
-/// assert!(helpers::strcmp(foo, bar, 0, 0, 0) != 0);
+/// assert!(helpers::strcmp(foo, foo, 0, 0, 0, &mut None) == 0);
+/// assert!(helpers::strcmp(foo, bar, 0, 0, 0, &mut None) != 0);
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
-pub fn strcmp (arg1: u64, arg2: u64, arg3: u64, unused4: u64, unused5: u64) -> u64 {
+pub fn strcmp (
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    unused4: u64,
+    unused5: u64,
+    unused6: &mut Option<Box<Any>>
+) -> u64 {
     // C-like strcmp, maybe shorter than converting the bytes to string and comparing?
     if arg1 == 0 || arg2 == 0 {
         return u64::MAX;
@@ -260,12 +304,19 @@ pub fn strcmp (arg1: u64, arg2: u64, arg3: u64, unused4: u64, unused5: u64) -> u
 ///     libc::srand(time::precise_time_ns() as u32)
 /// }
 ///
-/// let n = solana_rbpf::helpers::rand(3, 6, 0, 0, 0);
+/// let n = solana_rbpf::helpers::rand(3, 6, 0, 0, 0, &mut None);
 /// assert!(3 <= n && n <= 6);
 /// ```
 #[allow(dead_code)]
 #[allow(unused_variables)]
-pub fn rand (min: u64, max: u64, unused3: u64, unused4: u64, unused5: u64) -> u64 {
+pub fn rand (
+    min: u64,
+    max: u64,
+    unused3: u64,
+    unused4: u64,
+    unused5: u64,
+    unused6: &mut Option<Box<Any>>
+) -> u64 {
     let mut n = unsafe {
         (libc::rand() as u64).wrapping_shl(32) + libc::rand() as u64
     };

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -36,7 +36,7 @@ fn test_verifier_err_div_by_zero_imm() {
         div32 r0, 0
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_verifier_err_endian_size() {
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
     let mut vm = EbpfVmNoData::new(Some(prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_verifier_err_incomplete_lddw() { // Note: ubpf has test-err-incomplete-l
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
     let mut vm = EbpfVmNoData::new(Some(prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_verifier_err_infinite_loop() {
         ja -1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn test_verifier_err_invalid_reg_dst() {
         mov r11, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_verifier_err_invalid_reg_src() {
         mov r0, r11
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_verifier_err_jmp_lddw() {
         lddw r0, 0x1122334455667788
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn test_verifier_err_jmp_out() {
         ja +2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn test_verifier_err_no_exit() {
     let prog = assemble("
         mov32 r0, 0").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_verifier_err_too_many_instructions() {
     prog.append(&mut vec![ 0x95, 0, 0, 0, 0, 0, 0, 0 ]);
 
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn test_verifier_err_unknown_opcode() {
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
     let mut vm = EbpfVmNoData::new(Some(prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -154,5 +154,5 @@ fn test_verifier_err_write_r10() {
         mov r10, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -40,7 +40,7 @@ fn test_vm_add() {
         add32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn test_vm_alu64_arith() {
         div r0, r4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x2a);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x2a);
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn test_vm_alu64_bit() {
         xor r0, r2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x11);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn test_vm_alu_arith() {
         div32 r0, r4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x2a);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x2a);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn test_vm_alu_bit() {
         xor32 r0, r2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x11);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn test_vm_arsh32_high_shift() {
         arsh32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x4);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4);
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn test_vm_arsh() {
         arsh32 r0, 16
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xffff8000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffff8000);
 }
 
 #[test]
@@ -185,7 +185,7 @@ fn test_vm_arsh64() {
         arsh r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xfffffffffffffff8);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffffffffff8);
 }
 
 #[test]
@@ -197,7 +197,7 @@ fn test_vm_arsh_reg() {
         arsh32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xffff8000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffff8000);
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn test_vm_be16() {
         0x11, 0x22
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1122);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
 }
 
 #[test]
@@ -223,7 +223,7 @@ fn test_vm_be16_high() {
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1122);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
 }
 
 #[test]
@@ -236,7 +236,7 @@ fn test_vm_be32() {
         0x11, 0x22, 0x33, 0x44
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x11223344);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
 }
 
 #[test]
@@ -249,7 +249,7 @@ fn test_vm_be32_high() {
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x11223344);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn test_vm_be64() {
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1122334455667788);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn test_vm_call() {
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
     vm.register_helper(0, helpers::gather_bytes).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x0102030405);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0102030405);
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn test_vm_call_memfrob() {
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
     vm.register_helper(1, helpers::memfrob).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x102292e2f2c0708);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x102292e2f2c0708);
 }
 
 // TODO: helpers::trash_registers needs asm!().
@@ -317,7 +317,7 @@ fn test_vm_call_memfrob() {
     //];
     //let mut vm = EbpfVmNoData::new(Some(prog)).unwrap();
     //vm.register_helper(2, helpers::trash_registers);
-    //assert_eq!(vm.execute_program().unwrap(), 0x4321);
+    //assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4321);
 //}
 
 #[test]
@@ -328,7 +328,7 @@ fn test_vm_div32_high_divisor() {
         div32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn test_vm_div32_imm() {
         div32 r0, 4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -349,7 +349,7 @@ fn test_vm_div32_reg() {
         div32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -360,7 +360,7 @@ fn test_vm_div64_imm() {
         div r0, 4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x300000000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x300000000);
 }
 
 #[test]
@@ -372,7 +372,7 @@ fn test_vm_div64_reg() {
         div r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x300000000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x300000000);
 }
 
 #[test]
@@ -383,7 +383,7 @@ fn test_vm_early_exit() {
         mov r0, 4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 // uBPF limits the number of user functions at 64. We don't.
@@ -403,7 +403,7 @@ fn test_vm_err_call_unreg() {
         call 63
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -415,7 +415,7 @@ fn test_vm_err_div64_by_zero_reg() {
         div r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -427,7 +427,7 @@ fn test_vm_err_div_by_zero_reg() {
         div32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -439,7 +439,7 @@ fn test_vm_err_mod64_by_zero_reg() {
         mod r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -451,7 +451,7 @@ fn test_vm_err_mod_by_zero_reg() {
         mod32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 // With the introduction of call frames there may be stack regions
@@ -464,7 +464,7 @@ fn test_vm_err_stack_out_of_bound() {
         stb [r10-0x4000], 0
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    vm.execute_program().unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -473,7 +473,7 @@ fn test_vm_exit() {
         mov r0, 0
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x0);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -484,7 +484,7 @@ fn test_vm_ja() {
         mov r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -499,7 +499,7 @@ fn test_vm_jeq_imm() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -515,7 +515,7 @@ fn test_vm_jeq_reg() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -530,7 +530,7 @@ fn test_vm_jge_imm() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -546,7 +546,7 @@ fn test_vm_jle_imm() {
         mov32 r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -564,7 +564,7 @@ fn test_vm_jle_reg() {
         mov r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -579,7 +579,7 @@ fn test_vm_jgt_imm() {
         mov32 r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -596,7 +596,7 @@ fn test_vm_jgt_reg() {
         mov r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -611,7 +611,7 @@ fn test_vm_jlt_imm() {
         mov32 r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -628,7 +628,7 @@ fn test_vm_jlt_reg() {
         mov r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -642,7 +642,7 @@ fn test_vm_jit_bounce() {
         mov r0, r9
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -658,7 +658,7 @@ fn test_vm_jne_reg() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -673,7 +673,7 @@ fn test_vm_jset_imm() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -689,7 +689,7 @@ fn test_vm_jset_reg() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -705,7 +705,7 @@ fn test_vm_jsge_imm() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -723,7 +723,7 @@ fn test_vm_jsge_reg() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -739,7 +739,7 @@ fn test_vm_jsle_imm() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -758,7 +758,7 @@ fn test_vm_jsle_reg() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -773,7 +773,7 @@ fn test_vm_jsgt_imm() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -789,7 +789,7 @@ fn test_vm_jsgt_reg() {
         mov32 r0, 2
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -804,7 +804,7 @@ fn test_vm_jslt_imm() {
         mov32 r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -821,7 +821,7 @@ fn test_vm_jslt_reg() {
         mov32 r0, 1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -829,7 +829,7 @@ fn test_vm_lddw() {
     let prog = assemble("lddw r0, 0x1122334455667788
                          exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1122334455667788);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -838,7 +838,7 @@ fn test_vm_lddw2() {
         lddw r0, 0x0000000080000000
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x80000000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x80000000);
 }
 
 #[test]
@@ -880,7 +880,7 @@ fn test_vm_ldxb_all() {
         0x08, 0x09
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x9876543210);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x9876543210);
 }
 
 #[test]
@@ -892,7 +892,7 @@ fn test_vm_ldxb() {
         0xaa, 0xbb, 0x11, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -905,7 +905,7 @@ fn test_vm_ldxdw() {
         0x77, 0x88, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x8877665544332211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -958,7 +958,7 @@ fn test_vm_ldxh_all() {
         0x00, 0x08, 0x00, 0x09
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x9876543210);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x9876543210);
 }
 
 #[test]
@@ -1001,7 +1001,7 @@ fn test_vm_ldxh_all2() {
         0x01, 0x00, 0x02, 0x00
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x3ff);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x3ff);
 }
 
 #[test]
@@ -1013,7 +1013,7 @@ fn test_vm_ldxh() {
         0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x2211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
 }
 
 #[test]
@@ -1027,7 +1027,7 @@ fn test_vm_ldxh_same_reg() {
         0xff, 0xff
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1234);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1234);
 }
 
 #[test]
@@ -1072,7 +1072,7 @@ fn test_vm_ldxw_all() {
         0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x030f0f);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x030f0f);
 }
 
 #[test]
@@ -1084,7 +1084,7 @@ fn test_vm_ldxw() {
         0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1097,7 +1097,7 @@ fn test_vm_le16() {
         0x22, 0x11
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1122);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
 }
 
 #[test]
@@ -1110,7 +1110,7 @@ fn test_vm_le32() {
         0x44, 0x33, 0x22, 0x11
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x11223344);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
 }
 
 #[test]
@@ -1123,7 +1123,7 @@ fn test_vm_le64() {
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1122334455667788);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -1134,7 +1134,7 @@ fn test_vm_lsh_reg() {
         lsh r0, r7
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x10);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x10);
 }
 
 #[test]
@@ -1146,7 +1146,7 @@ fn test_vm_mod() {
         mod32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x5);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x5);
 }
 
 #[test]
@@ -1156,7 +1156,7 @@ fn test_vm_mod32() {
         mod32 r0, 3
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x0);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1172,7 +1172,7 @@ fn test_vm_mod64() {
         mod r0, 0x658f1778
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x30ba5a04);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x30ba5a04);
 }
 
 #[test]
@@ -1182,7 +1182,7 @@ fn test_vm_mov() {
         mov32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1192,7 +1192,7 @@ fn test_vm_mul32_imm() {
         mul32 r0, 4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xc);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xc);
 }
 
 #[test]
@@ -1203,7 +1203,7 @@ fn test_vm_mul32_reg() {
         mul32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xc);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xc);
 }
 
 #[test]
@@ -1214,7 +1214,7 @@ fn test_vm_mul32_reg_overflow() {
         mul32 r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x4);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4);
 }
 
 #[test]
@@ -1224,7 +1224,7 @@ fn test_vm_mul64_imm() {
         mul r0, 4
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x100000004);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x100000004);
 }
 
 #[test]
@@ -1235,7 +1235,7 @@ fn test_vm_mul64_reg() {
         mul r0, r1
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x100000004);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x100000004);
 }
 
 #[test]
@@ -1252,7 +1252,7 @@ fn test_vm_mul_loop() {
         jne r1, 0x0, -3
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x75db9c97);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x75db9c97);
 }
 
 #[test]
@@ -1262,7 +1262,7 @@ fn test_vm_neg64() {
         neg r0
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xfffffffffffffffe);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffffffffffe);
 }
 
 #[test]
@@ -1272,7 +1272,7 @@ fn test_vm_neg() {
         neg32 r0
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xfffffffe);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffe);
 }
 
 #[test]
@@ -1295,7 +1295,7 @@ fn test_vm_prime() {
         jne r4, 0x0, -10
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1306,7 +1306,7 @@ fn test_vm_rhs32() {
         rsh32 r0, 8
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x00ffffff);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x00ffffff);
 }
 
 #[test]
@@ -1317,7 +1317,7 @@ fn test_vm_rsh_reg() {
         rsh r0, r7
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1333,7 +1333,7 @@ fn test_vm_stack() {
         ldxdw r0, [r2-16]
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0xcd);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xcd);
 }
 
 #[test]
@@ -1358,7 +1358,7 @@ fn test_vm_stack2() {
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
     vm.register_helper(0, helpers::gather_bytes).unwrap();
     vm.register_helper(1, helpers::memfrob).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x01020304);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x01020304);
 }
 
 #[test]
@@ -1371,7 +1371,7 @@ fn test_vm_stb() {
         0xaa, 0xbb, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -1385,7 +1385,7 @@ fn test_vm_stdw() {
         0xff, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1398,7 +1398,7 @@ fn test_vm_sth() {
         0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x2211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
 }
 
 #[test]
@@ -1434,7 +1434,7 @@ fn test_vm_string_stack() {
         exit").unwrap();
     let mut vm = EbpfVmNoData::new(Some(&prog)).unwrap();
     vm.register_helper(4, helpers::strcmp).unwrap();
-    assert_eq!(vm.execute_program().unwrap(), 0x0);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1447,7 +1447,7 @@ fn test_vm_stw() {
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1461,7 +1461,7 @@ fn test_vm_stxb() {
         0xaa, 0xbb, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -1490,7 +1490,7 @@ fn test_vm_stxb_all() {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0xf0f2f3f4f5f6f7f8);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0xf0f2f3f4f5f6f7f8);
 }
 
 #[test]
@@ -1508,7 +1508,7 @@ fn test_vm_stxb_all2() {
         0xff, 0xff
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0xf1f9);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0xf1f9);
 }
 
 #[test]
@@ -1540,7 +1540,7 @@ fn test_vm_stxb_chain() {
         0x00, 0x00
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x2a);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2a);
 }
 
 #[test]
@@ -1557,7 +1557,7 @@ fn test_vm_stxdw() {
         0xff, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x8877665544332211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -1571,7 +1571,7 @@ fn test_vm_stxh() {
         0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x2211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
 }
 
 #[test]
@@ -1585,7 +1585,7 @@ fn test_vm_stxw() {
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1618,7 +1618,7 @@ fn test_vm_subnet() {
         0x03, 0x00
     ];
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1);
 }
 
 
@@ -1663,7 +1663,7 @@ fn test_vm_tcp_port80_match() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let mut vm = EbpfVmRaw::new(Some(prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1685,7 +1685,7 @@ fn test_vm_tcp_port80_nomatch() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let mut vm = EbpfVmRaw::new(Some(prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1707,7 +1707,7 @@ fn test_vm_tcp_port80_nomatch_ethertype() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let mut vm = EbpfVmRaw::new(Some(prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1729,7 +1729,7 @@ fn test_vm_tcp_port80_nomatch_proto() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let mut vm = EbpfVmRaw::new(Some(prog)).unwrap();
-    assert_eq!(vm.execute_program(mem).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1737,7 +1737,7 @@ fn test_vm_tcp_sack_match() {
     let mut mem = TCP_SACK_MATCH.to_vec();
     let prog = assemble(TCP_SACK_ASM).unwrap();
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem.as_mut_slice()).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(mem.as_mut_slice(), &[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1745,5 +1745,5 @@ fn test_vm_tcp_sack_nomatch() {
     let mut mem = TCP_SACK_NOMATCH.to_vec();
     let prog = assemble(TCP_SACK_ASM).unwrap();
     let mut vm = EbpfVmRaw::new(Some(&prog)).unwrap();
-    assert_eq!(vm.execute_program(mem.as_mut_slice()).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem.as_mut_slice(), &[], &[]).unwrap(), 0x0);
 }


### PR DESCRIPTION
Add support for helper functions to carry along a caller provided context structure.  Used initially to support dynamic memory allocaations via helper functions.