### PR TITLE
Report instruction # same as obj dump

### DIFF
--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -44,6 +44,10 @@ pub const FIRST_SCRATCH_REG: usize = 6;
 pub const SCRATCH_REGS: usize = 4;
 /// Max BPF to BPF call depth
 pub const MAX_CALL_DEPTH: usize = 10;
+/// ELF dump instruction offset
+/// Instruction numbers typically start at 29 in the ELF dump, use this offset
+/// when reporting so that trace aligns with the dump.
+pub const ELF_INSN_DUMP_OFFSET: usize = 29;
 
 // eBPF op codes.
 // See also https://www.kernel.org/doc/Documentation/networking/filter.txt

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -212,7 +212,7 @@ impl EBpfElf {
             format!(
                 "Error: Unresolved symbol ({}) at instruction #{:?} (ELF file offset {:#x})",
                 name,
-                file_offset / ebpf::INSN_SIZE,
+                file_offset / ebpf::INSN_SIZE + ebpf::ELF_INSN_DUMP_OFFSET,
                 file_offset
             ),
         ))?
@@ -255,7 +255,10 @@ impl EBpfElf {
                 if insn_idx < 0 || insn_idx as usize >= prog.len() / ebpf::INSN_SIZE {
                     Err(Error::new(
                         ErrorKind::Other,
-                        format!("Error: Relative jump at instruction {} is out of bounds", i),
+                        format!(
+                            "Error: Relative jump at instruction {} is out of bounds",
+                            i + ebpf::ELF_INSN_DUMP_OFFSET
+                        ),
                     ))?;
                 }
                 // use the instruction index as the key
@@ -267,7 +270,7 @@ impl EBpfElf {
                         ErrorKind::Other,
                         format!(
                             "Error: Relocation hash collision while encoding instruction {}",
-                            i
+                            i + ebpf::ELF_INSN_DUMP_OFFSET
                         ),
                     ))?;
                 }
@@ -852,7 +855,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Error: Relative jump at instruction 0 is out of bounds")]
+    #[should_panic(expected = "Error: Relative jump at instruction 29 is out of bounds")]
     fn test_fixup_relative_calls_out_of_bounds_forward() {
         let mut calls: HashMap<u32, usize> = HashMap::new();
         // call +5
@@ -879,7 +882,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Error: Relative jump at instruction 5 is out of bounds")]
+    #[should_panic(expected = "Error: Relative jump at instruction 34 is out of bounds")]
     fn test_fixup_relative_calls_out_of_bounds_back() {
         let mut calls: HashMap<u32, usize> = HashMap::new();
         // call -7

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,9 +98,9 @@ struct CallFrame {
 /// call frames
 #[derive(Clone, Debug)]
 struct CallFrames {
-    stack:   Vec<u8>,
-    frame: usize,
-    frames:  Vec<CallFrame>,
+    stack:  Vec<u8>,
+    frame:  usize,
+    frames: Vec<CallFrame>,
 }
 impl CallFrames {
     /// New call frame, depth indicates maximum call depth
@@ -570,7 +570,7 @@ impl<'a> EbpfVmMbuff<'a> {
                      self.last_insn_count,
                      reg,
                      frames.get_frame_index(),
-                     pc + 29, // Instruction numbers typically start at 29 in the ELF dump, offset here so the trace aligns with the dump
+                     pc + ebpf::ELF_INSN_DUMP_OFFSET,
                      disassembler::to_insn_vec(&prog[pc * ebpf::INSN_SIZE..])[0].desc);
             let insn = ebpf::get_insn(prog, pc);
             let _dst = insn.dst as usize;
@@ -858,7 +858,8 @@ impl<'a> EbpfVmMbuff<'a> {
                         // Note: Raw BPF programs (without ELF relocations) cannot support relative calls
                         // because there is no way to determine if the imm refers to a helper or an offset
                         Err(Error::new(ErrorKind::Other,
-                                       format!("Error: Unresolved symbol at instruction #{:?}", pc - 1)))?;
+                                       format!("Error: Unresolved symbol at instruction #{:?}",
+                                               pc - 1 + ebpf::ELF_INSN_DUMP_OFFSET)))?;
                     }
                 },
                 ebpf::EXIT       => {
@@ -896,13 +897,17 @@ impl<'a> EbpfVmMbuff<'a> {
         if !regions.is_empty() {
             regions_string =  " regions".to_string();
             for region in regions.iter() {
-                regions_string = format!("{} \n{:#x}-{:#x}", regions_string, region.addr, region.addr + region.len);
+                regions_string = format!("{} \n{:#x}-{:#x}", regions_string, region.addr, region.addr + region.len - 1);
             }
         }
 
         Err(Error::new(ErrorKind::Other, format!(
             "Error: out of bounds memory {} (insn #{:?}), addr {:#x}/{:?} {}",
-            access_type, pc - 1, addr, len, regions_string
+            access_type,
+            pc - 1 + ebpf::ELF_INSN_DUMP_OFFSET,
+            addr,
+            len,
+            regions_string
         )))
     }
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -440,7 +440,7 @@ fn test_vm_jit_ldabsdw() {
 }
 
 #[test]
-#[should_panic(expected = "Error: out of bounds memory load (insn #0),")]
+#[should_panic(expected = "Error: out of bounds memory load (insn #29),")]
 fn test_vm_err_ldabsb_oob() {
     let prog = &[
         0x38, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00,
@@ -457,7 +457,7 @@ fn test_vm_err_ldabsb_oob() {
 }
 
 #[test]
-#[should_panic(expected = "Error: out of bounds memory load (insn #0),")]
+#[should_panic(expected = "Error: out of bounds memory load (insn #29),")]
 fn test_vm_err_ldabsb_nomem() {
     let prog = &[
         0x38, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
@@ -558,7 +558,7 @@ fn test_vm_jit_ldinddw() {
 }
 
 #[test]
-#[should_panic(expected = "Error: out of bounds memory load (insn #1),")]
+#[should_panic(expected = "Error: out of bounds memory load (insn #30),")]
 fn test_vm_err_ldindb_oob() {
     let prog = &[
         0xb7, 0x01, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
@@ -576,7 +576,7 @@ fn test_vm_err_ldindb_oob() {
 }
 
 #[test]
-#[should_panic(expected = "Error: out of bounds memory load (insn #1),")]
+#[should_panic(expected = "Error: out of bounds memory load (insn #30),")]
 fn test_vm_err_ldindb_nomem() {
     let prog = &[
         0xb7, 0x01, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
@@ -876,7 +876,7 @@ fn test_jit_call_helper_wo_verifier() {
 }
 
 #[test]
-#[should_panic(expected = "Error: Unresolved symbol at instruction #0")]
+#[should_panic(expected = "Error: Unresolved symbol at instruction #29")]
 fn test_symbol_unresolved() {
         let prog = &mut [
         0x85, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, // call -1
@@ -893,7 +893,7 @@ fn test_symbol_unresolved() {
 }
 
 #[test]
-#[should_panic(expected = "Error: Unresolved symbol (log_64) at instruction #520 (ELF file offset 0x1040)")]
+#[should_panic(expected = "Error: Unresolved symbol (log_64) at instruction #549 (ELF file offset 0x1040)")]
 fn test_symbol_unresolved_elf() {
     let mut file = File::open("tests/elfs/unresolved_helper.so").expect("file open failed");
     let mut elf = Vec::new();

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -392,7 +392,7 @@ fn test_vm_early_exit() {
 //}
 
 #[test]
-#[should_panic(expected = "Error: Unresolved symbol at instruction #5")]
+#[should_panic(expected = "Error: Unresolved symbol at instruction #34")]
 fn test_vm_err_call_unreg() {
     let prog = assemble("
         mov r1, 1
@@ -458,7 +458,7 @@ fn test_vm_err_mod_by_zero_reg() {
 // above or below the current stack, to test out of bounds we have to 
 // try significantly further away
 #[test]
-#[should_panic(expected = "Error: out of bounds memory store (insn #0)")]
+#[should_panic(expected = "Error: out of bounds memory store (insn #29)")]
 fn test_vm_err_stack_out_of_bound() {
     let prog = assemble("
         stb [r10-0x4000], 0


### PR DESCRIPTION
When analyzing an error message or dump the most common way is to look at the elf dump to find out what the instruction is.  When dumping ELFs with `llvm-obj-dump` the instructions are reported starting at #29 so align the rbpf reporting so that the user does not have to do a translation for each instruction they attempt to look up.  Especially painful when analyzing a full trace.