### PR TITLE
Remove trace! call that incurs overhead even when not enabled for this module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,12 +443,12 @@ impl<'a> EbpfVm<'a> {
         let mut pc: usize = entry;
         self.last_insn_count = 0;
         while pc * ebpf::INSN_SIZE < prog.len() {
-            trace!("    BPF: {:5?} {:016x?} frame {:?} pc {:4?} {}",
-                   self.last_insn_count,
-                   reg,
-                   frames.get_frame_index(),
-                   pc + ebpf::ELF_INSN_DUMP_OFFSET,
-                   disassembler::to_insn_vec(&prog[pc * ebpf::INSN_SIZE..])[0].desc);
+            // trace!("    BPF: {:5?} {:016x?} frame {:?} pc {:4?} {}",
+            //        self.last_insn_count,
+            //        reg,
+            //        frames.get_frame_index(),
+            //        pc + ebpf::ELF_INSN_DUMP_OFFSET,
+            //        disassembler::to_insn_vec(&prog[pc * ebpf::INSN_SIZE..])[0].desc);
             let insn = ebpf::get_insn(prog, pc);
             let dst = insn.dst as usize;
             let src = insn.src as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use std::u32;
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use elf::EBpfElf;
-use log::{trace, debug};
+use log::debug;
 use ebpf::HelperContext;
 use memory_region::{MemoryRegion, translate_addr};
 


### PR DESCRIPTION
The `trace!` call commented out in this PR is an instruction-level debug message that shows details of the registers and what instruction is being executed, and is very useful to debug BPF programs.

Unfortunately, the logging crates used enable the formatting of this message even when the `trace` level is not enabled for this module.  In particular, if `trace` is enabled for any module (even one that does not exist) then this `trace!` message is formatted (but not printed).

The overhead formatting this message incurs a very large overhead and leads to transactions failing because they are taking too long.