### PR TITLE
Clear upper 32bits when using mov32 instruction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,7 +625,7 @@ impl<'a> EbpfVm<'a> {
                 },
                 ebpf::XOR32_IMM  =>   reg[dst] = (reg[dst] as u32             ^ insn.imm  as u32) as u64,
                 ebpf::XOR32_REG  =>   reg[dst] = (reg[dst] as u32             ^ reg[src]  as u32) as u64,
-                ebpf::MOV32_IMM  =>   reg[dst] = insn.imm                                         as u64,
+                ebpf::MOV32_IMM  =>   reg[dst] = insn.imm  as u32                                 as u64,
                 ebpf::MOV32_REG  =>   reg[dst] = (reg[src] as u32)                                as u64,
                 ebpf::ARSH32_IMM => { reg[dst] = (reg[dst] as i32).wrapping_shr(insn.imm  as u32) as u64; reg[dst] &= U32MAX; },
                 ebpf::ARSH32_REG => { reg[dst] = (reg[dst] as i32).wrapping_shr(reg[src]  as u32) as u64; reg[dst] &= U32MAX; },

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -1201,6 +1201,25 @@ fn test_vm_mov() {
 }
 
 #[test]
+fn test_vm_mov32_imm_large() {
+    let prog = assemble("
+        mov32 r0, -1
+        exit").unwrap();
+    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffffffff);
+}
+
+#[test]
+fn test_vm_mov_large() {
+    let prog = assemble("
+        mov32 r1, -1
+        mov32 r0, r1
+        exit").unwrap();
+    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffffffff);
+}
+
+#[test]
 fn test_vm_mul32_imm() {
     let prog = assemble("
         mov r0, 3


### PR DESCRIPTION
The mov32 instructions should clear the upper 32 bits and move imm into the lower 32 bits.  Rbpf uses an i32 for imm which was being sign-extended and placed into the 64bit register.  This resulted in the sign-extension extending into the upper 32 bits.

