### PR TITLE
Only use trait objects for helpers with context

### DIFF
--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -54,8 +54,7 @@ fn main() {
     // reimplement uptime in eBPF, in Rust. Because why not.
 
     vm.set_program(prog2).unwrap();
-    vm.register_helper(helpers::BPF_KTIME_GETNS_IDX,
-                       Box::new(helpers::BPFTimeGetNS::default())).unwrap();
+    vm.register_helper(helpers::BPF_KTIME_GETNS_IDX, helpers::bpf_time_getns).unwrap();
 
     let time;
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -426,8 +426,19 @@ pub const BPF_CLS_MASK    : u8 = 0x07;
 /// Mask to extract the arithmetic operation code from an instruction operation code.
 pub const BPF_ALU_OP_MASK : u8 = 0xf0;
 
-/// Helper function
-pub trait Helper {
+/// Helper function without context.
+pub type HelperFunction = fn(
+    u64,
+    u64,
+    u64,
+    u64,
+    u64,
+    &[MemoryRegion],
+    &[MemoryRegion],
+) -> Result<u64, Error>;
+
+/// Helper with context
+pub trait HelperObject {
     /// Call the helper function
     #[allow(clippy::too_many_arguments)]
     fn call(
@@ -440,6 +451,14 @@ pub trait Helper {
         &[MemoryRegion],
         &[MemoryRegion],
     ) -> Result<u64, Error>;
+}
+
+/// Contains the helper
+pub enum Helper<'a> {
+    /// Function
+    Function(HelperFunction),
+    /// Trait object
+    Object(Box<dyn HelperObject + 'a>)
 }
 
 /// An eBPF instruction.

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -459,7 +459,7 @@ impl<'a> JitMemory<'a> {
 
     fn jit_compile(&mut self, prog: &[u8],
                    _helpers: &HashMap<u32,
-                   Box<dyn ebpf::Helper + 'a>>) -> Result<(), Error> {
+                   ebpf::Helper<'a>>) -> Result<(), Error> {
         emit_push(self, RBP);
         emit_push(self, RBX);
         emit_push(self, R13);
@@ -879,7 +879,7 @@ impl<'a> std::fmt::Debug for JitMemory<'a> {
 }
 
 // In the end, this is the only thing we export
-pub fn compile<'a>(prog: &'a [u8], helpers: &HashMap<u32, Box<dyn ebpf::Helper + 'a>>)
+pub fn compile<'a>(prog: &'a [u8], helpers: &HashMap<u32, ebpf::Helper<'a>>)
     -> Result<JitProgram, Error> {
 
     // TODO: check how long the page must be to be sure to support an eBPF program of maximum

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -276,7 +276,7 @@ fn test_vm_call() {
         call 0
         exit").unwrap();
     let mut vm = EbpfVm::new(Some(&prog)).unwrap();
-    vm.register_helper(0, Box::new(helpers::GatherBytes::default())).unwrap();
+    vm.register_helper(0, helpers::gather_bytes).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0102030405);
 }
 
@@ -294,7 +294,7 @@ fn test_vm_call_memfrob() {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
     ];
     let mut vm = EbpfVm::new(Some(&prog)).unwrap();
-    vm.register_helper(1, Box::new(helpers::Memfrob::default())).unwrap();
+    vm.register_helper(1, helpers::memfrob).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x102292e2f2c0708);
 }
 
@@ -1390,8 +1390,8 @@ fn test_vm_stack2() {
         xor r0, 0x2a2a2a2a
         exit").unwrap();
     let mut vm = EbpfVm::new(Some(&prog)).unwrap();
-    vm.register_helper(0, Box::new(helpers::GatherBytes::default())).unwrap();
-    vm.register_helper(1, Box::new(helpers::Memfrob::default())).unwrap();
+    vm.register_helper(0, helpers::gather_bytes).unwrap();
+    vm.register_helper(1, helpers::memfrob).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x01020304);
 }
 
@@ -1467,7 +1467,7 @@ fn test_vm_string_stack() {
         mov r0, 0x0
         exit").unwrap();
     let mut vm = EbpfVm::new(Some(&prog)).unwrap();
-    vm.register_helper(4, Box::new(helpers::Strcmp::default())).unwrap();
+    vm.register_helper(4, helpers::strcmp).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
 }
 


### PR DESCRIPTION
Only use trait objects when conveying context, otherwise, it's inefficient 