### PR TITLE
Rework error handling to return user defined errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +419,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -589,6 +605,7 @@ dependencies = [
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -605,6 +622,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -655,6 +682,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +735,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -796,8 +846,10 @@ dependencies = [
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
+"checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
 "checksum rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
@@ -819,17 +871,21 @@ dependencies = [
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e3711fd1c4e75b3eff12ba5c40dba762b6b65c5476e8174c1a664772060c49bf"
+"checksum thiserror-impl 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ elfkit = "0.0.6"
 num-traits = "0.2.5"
 hash32 = "0.1.0"
 log = "0.4.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -10,6 +10,7 @@
 extern crate solana_rbpf;
 use solana_rbpf::helpers;
 use solana_rbpf::{EbpfVm};
+use solana_rbpf::user_error::UserError;
 
 // The main objectives of this example is to show:
 //
@@ -42,7 +43,7 @@ fn main() {
     ];
 
     // Create a VM: this one takes no data. Load prog1 in it.
-    let mut vm = EbpfVm::new(Some(prog1)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(prog1)).unwrap();
     // Execute prog1.
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
 

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -1,0 +1,13 @@
+//! This module defines an example user error definition
+
+use crate::{ebpf::UserDefinedError, verifier::VerifierError};
+use thiserror::Error;
+
+/// User defined error
+#[derive(Debug, Error)]
+pub enum UserError {
+    /// Verifier error
+    #[error("VerifierError")]
+    VerifierError(VerifierError),
+}
+impl UserDefinedError for UserError {}

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -27,103 +27,113 @@ extern crate solana_rbpf;
 use solana_rbpf::assembler::assemble;
 use solana_rbpf::ebpf;
 use solana_rbpf::EbpfVm;
+use solana_rbpf::verifier::{check, VerifierError};
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: division by 0 (insn #1)")]
+#[should_panic(expected = "UserError(DivisionByZero(1))")]
 fn test_verifier_err_div_by_zero_imm() {
     let prog = assemble("
         mov32 r0, 1
         div32 r0, 0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: unsupported argument for LE/BE (insn #0)")]
+#[should_panic(expected = "UserError(UnsupportedLEBEArgument(0))")]
 fn test_verifier_err_endian_size() {
     let prog = &[
         0xdc, 0x01, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
         0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: incomplete LD_DW instruction (insn #0)")]
+#[should_panic(expected = "UserError(IncompleteLDDW(0))")]
 fn test_verifier_err_incomplete_lddw() { // Note: ubpf has test-err-incomplete-lddw2, which is the same
     let prog = &[
         0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55,
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: infinite loop")]
+#[should_panic(expected = "UserError(InfiniteLoop(0))")]
 fn test_verifier_err_infinite_loop() {
     let prog = assemble("
         ja -1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: invalid destination register (insn #0)")]
+#[should_panic(expected = "UserError(InvalidDestinationRegister(0))")]
 fn test_verifier_err_invalid_reg_dst() {
     let prog = assemble("
         mov r11, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: invalid source register (insn #0)")]
+#[should_panic(expected = "UserError(InvalidSourceRegister(0))")]
 fn test_verifier_err_invalid_reg_src() {
     let prog = assemble("
         mov r0, r11
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: jump to middle of LD_DW at #2 (insn #0)")]
+#[should_panic(expected = "UserError(JumpToMiddleOfLDDW(2, 0))")]
 fn test_verifier_err_jmp_lddw() {
     let prog = assemble("
         ja +1
         lddw r0, 0x1122334455667788
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: jump out of code to #3 (insn #0)")]
+#[should_panic(expected = "UserError(JumpOutOfCode(3, 0))")]
 fn test_verifier_err_jmp_out() {
     let prog = assemble("
         ja +2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: program does not end with “EXIT” instruction")]
+#[should_panic(expected = "UserError(InvalidLastInstruction)")]
 fn test_verifier_err_no_exit() {
     let prog = assemble("
         mov32 r0, 0").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: eBPF program length limited to 65536, here 65537")]
+#[should_panic(expected = "UserError(ProgramTooLarge(65537))")]
 fn test_verifier_err_too_many_instructions() {
     let mut prog = (0..(65536 * ebpf::INSN_SIZE)).map( |x| match x % 8 {
             0 => 0xb7,
@@ -132,27 +142,30 @@ fn test_verifier_err_too_many_instructions() {
     }).collect::<Vec<u8>>();
     prog.append(&mut vec![ 0x95, 0, 0, 0, 0, 0, 0, 0 ]);
 
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: unknown eBPF opcode 0x6 (insn #0)")]
+#[should_panic(expected = "UserError(UnknownOpCode(6, 0))")]
 fn test_verifier_err_unknown_opcode() {
     let prog = &[
         0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "[Verifier] Error: cannot write into register r10 (insn #0)")]
+#[should_panic(expected = "UserError(CannotWriteR10(0))")]
 fn test_verifier_err_write_r10() {
     let prog = assemble("
         mov r10, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<VerifierError>::new(Some(&prog)).unwrap();
+    vm.set_verifier(check).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -29,6 +29,7 @@ mod common;
 
 use solana_rbpf::{helpers, EbpfVm};
 use solana_rbpf::assembler::assemble;
+use solana_rbpf::user_error::UserError;
 use common::{TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH};
 
 #[test]
@@ -39,7 +40,7 @@ fn test_vm_add() {
         add32 r0, 1
         add32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
 }
 
@@ -65,7 +66,7 @@ fn test_vm_alu64_arith() {
         div r0, 2
         div r0, r4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x2a);
 }
 
@@ -95,7 +96,7 @@ fn test_vm_alu64_bit() {
         xor r0, 0x03
         xor r0, r2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x11);
 }
 
@@ -121,7 +122,7 @@ fn test_vm_alu_arith() {
         div32 r0, 2
         div32 r0, r4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x2a);
 }
 
@@ -149,7 +150,7 @@ fn test_vm_alu_bit() {
         xor32 r0, 0x03
         xor32 r0, r2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x11);
 }
 
@@ -160,7 +161,7 @@ fn test_vm_arsh32_high_shift() {
         lddw r1, 0x100000001
         arsh32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x4);
 }
 
@@ -171,7 +172,7 @@ fn test_vm_arsh() {
         lsh32 r0, 28
         arsh32 r0, 16
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffff8000);
 }
 
@@ -184,7 +185,7 @@ fn test_vm_arsh64() {
         mov32 r1, 5
         arsh r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xfffffffffffffff8);
 }
 
@@ -196,7 +197,7 @@ fn test_vm_arsh_reg() {
         lsh32 r0, 28
         arsh32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffff8000);
 }
 
@@ -209,7 +210,7 @@ fn test_vm_be16() {
     let mem = &mut [
         0x11, 0x22
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
 }
 
@@ -222,7 +223,7 @@ fn test_vm_be16_high() {
     let mem = &mut [
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
 }
 
@@ -235,7 +236,7 @@ fn test_vm_be32() {
     let mem = &mut [
         0x11, 0x22, 0x33, 0x44
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
 }
 
@@ -248,7 +249,7 @@ fn test_vm_be32_high() {
     let mem = &mut [
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
 }
 
@@ -261,7 +262,7 @@ fn test_vm_be64() {
     let mem = &mut [
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122334455667788);
 }
 
@@ -275,7 +276,7 @@ fn test_vm_call() {
         mov r5, 5
         call 0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.register_helper(0, helpers::gather_bytes).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0102030405);
 }
@@ -293,7 +294,7 @@ fn test_vm_call_memfrob() {
     let mem = &mut [
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.register_helper(1, helpers::memfrob).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x102292e2f2c0708);
 }
@@ -316,7 +317,7 @@ fn test_vm_call_memfrob() {
 //         0x4f, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 //         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 //     ];
-//     let mut vm = EbpfVm::new(Some(prog)).unwrap();
+//     let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
 //     vm.register_helper(2, helpers::trash_registers, None);
 //     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x4321);
 // }
@@ -328,7 +329,7 @@ fn test_vm_div32_high_divisor() {
         lddw r1, 0x100000004
         div32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
 }
 
@@ -338,7 +339,7 @@ fn test_vm_div32_imm() {
         lddw r0, 0x10000000c
         div32 r0, 4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
 }
 
@@ -349,7 +350,7 @@ fn test_vm_div32_reg() {
         mov r1, 4
         div32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
 }
 
@@ -360,7 +361,7 @@ fn test_vm_div64_imm() {
         lsh r0, 32
         div r0, 4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x300000000);
 }
 
@@ -372,7 +373,7 @@ fn test_vm_div64_reg() {
         mov r1, 4
         div r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x300000000);
 }
 
@@ -383,7 +384,7 @@ fn test_vm_early_exit() {
         exit
         mov r0, 4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
 }
 
@@ -393,7 +394,7 @@ fn test_vm_early_exit() {
 //}
 
 #[test]
-#[should_panic(expected = "Error: Unresolved symbol at instruction #34")]
+#[should_panic(expected = "UnresolvedSymbol(34)")]
 fn test_vm_err_call_unreg() {
     let prog = assemble("
         mov r1, 1
@@ -403,55 +404,55 @@ fn test_vm_err_call_unreg() {
         mov r5, 5
         call 63
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "Error: division by 0")]
+#[should_panic(expected = "DivideByZero")]
 fn test_vm_err_div64_by_zero_reg() {
     let prog = assemble("
         mov32 r0, 1
         mov32 r1, 0
         div r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "Error: division by 0")]
+#[should_panic(expected = "DivideByZero")]
 fn test_vm_err_div_by_zero_reg() {
     let prog = assemble("
         mov32 r0, 1
         mov32 r1, 0
         div32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "Error: division by 0")]
+#[should_panic(expected = "DivideByZero")]
 fn test_vm_err_mod64_by_zero_reg() {
     let prog = assemble("
         mov32 r0, 1
         mov32 r1, 0
         mod r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "Error: division by 0")]
+#[should_panic(expected = "DivideByZero")]
 fn test_vm_err_mod_by_zero_reg() {
     let prog = assemble("
         mov32 r0, 1
         mov32 r1, 0
         mod32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
@@ -459,12 +460,12 @@ fn test_vm_err_mod_by_zero_reg() {
 // above or below the current stack, to test out of bounds we have to 
 // try significantly further away
 #[test]
-#[should_panic(expected = "Error: out of bounds memory store (insn #29)")]
+#[should_panic(expected = "AccessViolation(\"store\", 29")]
 fn test_vm_err_stack_out_of_bound() {
     let prog = assemble("
         stb [r10-0x4000], 0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.execute_program(&[], &[], &[]).unwrap();
 }
 
@@ -473,7 +474,7 @@ fn test_vm_exit() {
     let prog = assemble("
         mov r0, 0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
 }
 
@@ -484,7 +485,7 @@ fn test_vm_ja() {
         ja +1
         mov r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -499,7 +500,7 @@ fn test_vm_jeq_imm() {
         jeq r1, 0xb, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -515,7 +516,7 @@ fn test_vm_jeq_reg() {
         jeq r1, r2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -530,7 +531,7 @@ fn test_vm_jge_imm() {
         jge r1, 0xb, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -546,7 +547,7 @@ fn test_vm_jle_imm() {
         exit
         mov32 r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -564,7 +565,7 @@ fn test_vm_jle_reg() {
         exit
         mov r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -579,7 +580,7 @@ fn test_vm_jgt_imm() {
         exit
         mov32 r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -596,7 +597,7 @@ fn test_vm_jgt_reg() {
         exit
         mov r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -611,7 +612,7 @@ fn test_vm_jlt_imm() {
         exit
         mov32 r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -628,7 +629,7 @@ fn test_vm_jlt_reg() {
         exit
         mov r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -642,7 +643,7 @@ fn test_vm_jit_bounce() {
         mov r9, r8
         mov r0, r9
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -658,7 +659,7 @@ fn test_vm_jne_reg() {
         jne r1, r2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -673,7 +674,7 @@ fn test_vm_jset_imm() {
         jset r1, 0x8, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -689,7 +690,7 @@ fn test_vm_jset_reg() {
         jset r1, r2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -705,7 +706,7 @@ fn test_vm_jsge_imm() {
         jsge r1, -1, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -723,7 +724,7 @@ fn test_vm_jsge_reg() {
         jsge r1, r2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -739,7 +740,7 @@ fn test_vm_jsle_imm() {
         jsle r1, -2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -758,7 +759,7 @@ fn test_vm_jsle_reg() {
         jsle r1, r2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -773,7 +774,7 @@ fn test_vm_jsgt_imm() {
         jsgt r1, -1, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -789,7 +790,7 @@ fn test_vm_jsgt_reg() {
         jsgt r1, r2, +1
         mov32 r0, 2
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -804,7 +805,7 @@ fn test_vm_jslt_imm() {
         exit
         mov32 r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -821,7 +822,7 @@ fn test_vm_jslt_reg() {
         exit
         mov32 r0, 1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -829,7 +830,7 @@ fn test_vm_jslt_reg() {
 fn test_vm_lddw() {
     let prog = assemble("lddw r0, 0x1122334455667788
                          exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1122334455667788);
 }
 
@@ -838,7 +839,7 @@ fn test_vm_lddw2() {
     let prog = assemble("
         lddw r0, 0x0000000080000000
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x80000000);
 }
 
@@ -880,7 +881,7 @@ fn test_vm_ldxb_all() {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
         0x08, 0x09
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x9876543210);
 }
 
@@ -892,7 +893,7 @@ fn test_vm_ldxb() {
     let mem = &mut [
         0xaa, 0xbb, 0x11, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
 }
 
@@ -905,12 +906,12 @@ fn test_vm_ldxdw() {
         0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
         0x77, 0x88, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x8877665544332211);
 }
 
 #[test]
-#[should_panic(expected = "Error: out of bounds memory load (insn #29),")]
+#[should_panic(expected = "AccessViolation(\"load\", 29")]
 fn test_vm_ldxdw_oob() {
     let prog = assemble("
         ldxdw r0, [r1+6]
@@ -919,7 +920,7 @@ fn test_vm_ldxdw_oob() {
         0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
         0x77, 0x88, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x8877665544332211);
 }
 
@@ -972,7 +973,7 @@ fn test_vm_ldxh_all() {
         0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07,
         0x00, 0x08, 0x00, 0x09
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x9876543210);
 }
 
@@ -1015,7 +1016,7 @@ fn test_vm_ldxh_all2() {
         0x00, 0x10, 0x00, 0x20, 0x00, 0x40, 0x00, 0x80,
         0x01, 0x00, 0x02, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x3ff);
 }
 
@@ -1027,7 +1028,7 @@ fn test_vm_ldxh() {
     let mem = &mut [
         0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
 }
 
@@ -1041,7 +1042,7 @@ fn test_vm_ldxh_same_reg() {
     let mem = &mut [
         0xff, 0xff
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1234);
 }
 
@@ -1086,7 +1087,7 @@ fn test_vm_ldxw_all() {
         0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, 0x00,
         0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x030f0f);
 }
 
@@ -1098,7 +1099,7 @@ fn test_vm_ldxw() {
     let mem = &mut [
         0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
@@ -1111,7 +1112,7 @@ fn test_vm_le16() {
     let mem = &mut [
         0x22, 0x11
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
 }
 
@@ -1124,7 +1125,7 @@ fn test_vm_le32() {
     let mem = &mut [
         0x44, 0x33, 0x22, 0x11
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
 }
 
@@ -1137,7 +1138,7 @@ fn test_vm_le64() {
     let mem = &mut [
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122334455667788);
 }
 
@@ -1148,7 +1149,7 @@ fn test_vm_lsh_reg() {
         mov r7, 4
         lsh r0, r7
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x10);
 }
 
@@ -1160,7 +1161,7 @@ fn test_vm_mod() {
         mov32 r1, 13
         mod32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x5);
 }
 
@@ -1170,7 +1171,7 @@ fn test_vm_mod32() {
         lddw r0, 0x100000003
         mod32 r0, 3
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
 }
 
@@ -1186,7 +1187,7 @@ fn test_vm_mod64() {
         mod r0, r1
         mod r0, 0x658f1778
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x30ba5a04);
 }
 
@@ -1196,7 +1197,7 @@ fn test_vm_mov() {
         mov32 r1, 1
         mov32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -1205,7 +1206,7 @@ fn test_vm_mov32_imm_large() {
     let prog = assemble("
         mov32 r0, -1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffffffff);
 }
 
@@ -1215,7 +1216,7 @@ fn test_vm_mov_large() {
         mov32 r1, -1
         mov32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffffffff);
 }
 
@@ -1225,7 +1226,7 @@ fn test_vm_mul32_imm() {
         mov r0, 3
         mul32 r0, 4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xc);
 }
 
@@ -1236,7 +1237,7 @@ fn test_vm_mul32_reg() {
         mov r1, 4
         mul32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xc);
 }
 
@@ -1247,7 +1248,7 @@ fn test_vm_mul32_reg_overflow() {
         mov r1, 4
         mul32 r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x4);
 }
 
@@ -1257,7 +1258,7 @@ fn test_vm_mul64_imm() {
         mov r0, 0x40000001
         mul r0, 4
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x100000004);
 }
 
@@ -1268,7 +1269,7 @@ fn test_vm_mul64_reg() {
         mov r1, 4
         mul r0, r1
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x100000004);
 }
 
@@ -1285,7 +1286,7 @@ fn test_vm_mul_loop() {
         add r1, -1
         jne r1, 0x0, -3
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x75db9c97);
 }
 
@@ -1295,7 +1296,7 @@ fn test_vm_neg64() {
         mov32 r0, 2
         neg r0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xfffffffffffffffe);
 }
 
@@ -1305,7 +1306,7 @@ fn test_vm_neg() {
         mov32 r0, 2
         neg32 r0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xfffffffe);
 }
 
@@ -1328,7 +1329,7 @@ fn test_vm_prime() {
         mov r0, 0x0
         jne r4, 0x0, -10
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -1339,7 +1340,7 @@ fn test_vm_rhs32() {
         sub r0, 1
         rsh32 r0, 8
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x00ffffff);
 }
 
@@ -1350,7 +1351,7 @@ fn test_vm_rsh_reg() {
         mov r7, 4
         rsh r0, r7
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
 }
 
@@ -1366,7 +1367,7 @@ fn test_vm_stack1() {
         add r2, r1
         ldxdw r0, [r2-16]
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xcd);
 }
 
@@ -1389,7 +1390,7 @@ fn test_vm_stack2() {
         call 0
         xor r0, 0x2a2a2a2a
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.register_helper(0, helpers::gather_bytes).unwrap();
     vm.register_helper(1, helpers::memfrob).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x01020304);
@@ -1404,7 +1405,7 @@ fn test_vm_stb() {
     let mem = &mut [
         0xaa, 0xbb, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
 }
 
@@ -1418,7 +1419,7 @@ fn test_vm_stdw() {
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
@@ -1431,7 +1432,7 @@ fn test_vm_sth() {
     let mem = &mut [
         0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
 }
 
@@ -1466,7 +1467,7 @@ fn test_vm_string_stack() {
         jeq r1, r6, +1
         mov r0, 0x0
         exit").unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     vm.register_helper(4, helpers::strcmp).unwrap();
     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
 }
@@ -1480,7 +1481,7 @@ fn test_vm_stw() {
     let mem = &mut [
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
@@ -1494,7 +1495,7 @@ fn test_vm_stxb() {
     let mem = &mut [
         0xaa, 0xbb, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
 }
 
@@ -1523,7 +1524,7 @@ fn test_vm_stxb_all() {
     let mem = &mut [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0xf0f2f3f4f5f6f7f8);
 }
 
@@ -1541,7 +1542,7 @@ fn test_vm_stxb_all2() {
     let mem = &mut [
         0xff, 0xff
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0xf1f9);
 }
 
@@ -1573,7 +1574,7 @@ fn test_vm_stxb_chain() {
         0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2a);
 }
 
@@ -1590,7 +1591,7 @@ fn test_vm_stxdw() {
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x8877665544332211);
 }
 
@@ -1604,7 +1605,7 @@ fn test_vm_stxh() {
     let mem = &mut [
         0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
 }
 
@@ -1618,7 +1619,7 @@ fn test_vm_stxw() {
     let mem = &mut [
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
 }
 
@@ -1651,7 +1652,7 @@ fn test_vm_subnet() {
         0x27, 0x24, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03,
         0x03, 0x00
     ];
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1);
 }
 
@@ -1696,7 +1697,7 @@ fn test_vm_tcp_port80_match() {
         0x44, 0x44, 0x44, 0x44
     ];
     let prog = &PROG_TCP_PORT_80;
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1);
 }
 
@@ -1718,7 +1719,7 @@ fn test_vm_tcp_port80_nomatch() {
         0x44, 0x44, 0x44, 0x44
     ];
     let prog = &PROG_TCP_PORT_80;
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
 }
 
@@ -1740,7 +1741,7 @@ fn test_vm_tcp_port80_nomatch_ethertype() {
         0x44, 0x44, 0x44, 0x44
     ];
     let prog = &PROG_TCP_PORT_80;
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
 }
 
@@ -1762,7 +1763,7 @@ fn test_vm_tcp_port80_nomatch_proto() {
         0x44, 0x44, 0x44, 0x44
     ];
     let prog = &PROG_TCP_PORT_80;
-    let mut vm = EbpfVm::new(Some(prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
     assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
 }
 
@@ -1770,7 +1771,7 @@ fn test_vm_tcp_port80_nomatch_proto() {
 fn test_vm_tcp_sack_match() {
     let mut mem = TCP_SACK_MATCH.to_vec();
     let prog = assemble(TCP_SACK_ASM).unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem.as_mut_slice(), &[], &[]).unwrap(), 0x1);
 }
 
@@ -1778,6 +1779,6 @@ fn test_vm_tcp_sack_match() {
 fn test_vm_tcp_sack_nomatch() {
     let mut mem = TCP_SACK_NOMATCH.to_vec();
     let prog = assemble(TCP_SACK_ASM).unwrap();
-    let mut vm = EbpfVm::new(Some(&prog)).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(Some(&prog)).unwrap();
     assert_eq!(vm.execute_program(mem.as_mut_slice(), &[], &[]).unwrap(), 0x0);
 }


### PR DESCRIPTION
* Rework error handling to use `thiserror` rather then io:error.
  * Gets away from all errors being strings
  * This will improve performance by reducing the number of &str to String allocations
* Use generics to allow callers to return their own error definitions from functions they register with the VM.  This provides more flexibility for callers to return what they want and not have to do conversions from strings.  Also allows callers to return their native error codes from Helpers