### PR TITLE
Cleanup program counter representation

### DIFF
--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -74,12 +74,9 @@ pub fn translate_addr<E: UserDefinedError>(
             );
         }
     }
-    if pc == 0 {
-        pc = 1;
-    };
     Err(EbpfError::AccessViolation(
         access_type.to_string(),
-        pc - 1 + ELF_INSN_DUMP_OFFSET,
+        pc + ELF_INSN_DUMP_OFFSET,
         vm_addr,
         len,
         regions_string,

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -780,7 +780,7 @@ fn test_oob_callx_low() {
 }
 
 #[test]
-#[should_panic(expected = "CallOutsideTextSegment(4, 18446744073709551615)")]
+#[should_panic(expected = "CallOutsideTextSegment(3, 18446744073709551615)")]
 fn test_oob_callx_high() {
     let prog = &mut [
         0xb7, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, // r0 = 0


### PR DESCRIPTION
In the execution loop the program counter served to both point to the next instruction and referred to the current as `pc -1` which was confusing.  Rework how the program counter variable is used so that `next_pc` is the next program counter and `pc` is the current.