### PR TITLE
Fixes address translation of LD_ABS and LD_IND in vm execute_program_inner

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -353,6 +353,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
         instruction_meter.consume(self.last_insn_count);
         result
     }
+
     #[rustfmt::skip]
     fn execute_program_inner<I: InstructionMeter>(
         &mut self,
@@ -437,46 +438,46 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
 
             match insn.opc {
 
-                                // BPF_LD class
-                // Since this pointer is constant, and since we already know it (mem), do not
-                // bother re-fetching it, just use mem already.
+                // BPF_LD class
+                // Since this pointer is constant, and since we already know it (ebpf::MM_INPUT_START), do not
+                // bother re-fetching it, just use ebpf::MM_INPUT_START already.
                 ebpf::LD_ABS_B   => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add((insn.imm as u32) as u64);
-                    let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u8;
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add((insn.imm as u32) as u64);
+                    let host_ptr = translate_load_addr(vm_addr, 1, pc)? as *const u8;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_ABS_H   =>  {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add((insn.imm as u32) as u64);
-                    let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u16;
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add((insn.imm as u32) as u64);
+                    let host_ptr = translate_load_addr(vm_addr, 2, pc)? as *const u16;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_ABS_W   => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add((insn.imm as u32) as u64);
-                    let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u32;
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add((insn.imm as u32) as u64);
+                    let host_ptr = translate_load_addr(vm_addr, 4, pc)? as *const u32;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_ABS_DW  => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add((insn.imm as u32) as u64);
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add((insn.imm as u32) as u64);
                     let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u64;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_IND_B   => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
-                    let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u8;
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
+                    let host_ptr = translate_load_addr(vm_addr, 1, pc)? as *const u8;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_IND_H   => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
-                    let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u16;
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
+                    let host_ptr = translate_load_addr(vm_addr, 2, pc)? as *const u16;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_IND_W   => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
-                    let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u32;
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
+                    let host_ptr = translate_load_addr(vm_addr, 4, pc)? as *const u32;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },
                 ebpf::LD_IND_DW  => {
-                    let vm_addr = (mem.as_ptr() as u64).saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
+                    let vm_addr = ebpf::MM_INPUT_START.saturating_add(reg[src]).saturating_add((insn.imm as u32) as u64);
                     let host_ptr = translate_load_addr(vm_addr, 8, pc)? as *const u64;
                     reg[0] = unsafe { *host_ptr as u64 };
                 },

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -112,6 +112,21 @@ use thiserror::Error;
 // Cargo.toml file (see comments above), so here we use just the hardcoded bytecode instructions
 // instead.
 
+#[cfg(not(windows))]
+#[test]
+fn test_vm_ldabsb() {
+    let prog = &[
+        0x30, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    ];
+    let mut mem = [
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    ];
+    let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
+    assert_eq!(vm.execute_program(&mut mem, &[], &[]).unwrap(), 0x33);
+}
+
 #[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]


### PR DESCRIPTION
- vm_addr was actually the host address based on mem.as_ptr().
- len was always 8 bytes, even for smaller accesses, causing the regions bounds check to fail.

Note: Also, adds a separate test of vm LD_ABS to demonstrate the bug. The test can be recombined with the jit test later again.