### PR TITLE
Use binary search in address translation

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -395,6 +395,10 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
         };
         ro_regions.push(MemoryRegion::new_from_slice(prog, prog_addr));
 
+        // Sort regions by addr_vm for binary search
+        ro_regions.sort_by(|a, b| a.addr_vm.cmp(&b.addr_vm));
+        rw_regions.sort_by(|a, b| a.addr_vm.cmp(&b.addr_vm));
+
         // R1 points to beginning of input memory, R10 to the stack of the first frame
         let mut reg: [u64; 11] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, frames.get_stack_top()];
 


### PR DESCRIPTION
This gives logarithmic time complexity for address translation.

It also fixes the following bug:
If a region is mapped at the upper end of the vm address space (e.g. a stack), then one could circumvent the upper bounds check by accessing the max address.

self.addr_vm + self.len = 0xFFFFFFFFFFFFFFFF
vm_addr = 0xFFFFFFFFFFFFFFFF
vm_addr.saturating_add(len as u64) is still 0xFFFFFFFFFFFFFFFF
0xFFFFFFFFFFFFFFFF <= self.addr_vm + self.len

Thus, no error is detected and one can reach into the unmapped host address space behind the end of the mapping.