### PR TITLE
Fix JIT linear address translation

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -476,13 +476,12 @@ impl<'a> JitMemory<'a> {
         emit_push(self, R14);
         emit_push(self, R15);
 
-        // RDX: mem
-        // RCX: mem_len
-        // R8:  mem_offset
-        // R9:  mem_end_offset
+        // RDI: mem
+        // RSI: mem_len
+        // RDX: mem_offset
 
         // Save mem pointer for use with LD_ABS_* and LD_IND_* instructions
-        emit_mov(self, RDX, R10);
+        emit_mov(self, RDI, R10);
 
         if map_register(1) != RDX {
             emit_mov(self, RDX, map_register(1));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -755,14 +755,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
     /// vm.jit_compile();
     /// ```
     pub fn jit_compile(&mut self) -> Result<(), EbpfError<E>> {
-        let prog = {
-            if self.executable.get_ro_sections().is_ok() {
-                return Err(EbpfError::ReadOnlyDataUnsupported);
-            }
-            let (_, bytes) = self.executable.get_text_bytes()?;
-            bytes
-        };
-
+        let (_, prog) = self.executable.get_text_bytes()?;
         self.jit = Some(jit::compile(prog, &self.syscalls)?);
         Ok(())
     }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -105,25 +105,6 @@ use thiserror::Error;
 
 #[cfg(not(windows))]
 #[test]
-fn test_vm_ldabsb() {
-    let prog = assemble(
-        "
-        ldabsb 0x3
-        exit",
-    )
-    .unwrap();
-    let mem = [
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, //
-        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
-    ];
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&mem, &[], &[]).unwrap(), 0x33);
-}
-
-#[ignore] // TODO jit does not support address translation or syscalls
-#[cfg(not(windows))]
-#[test]
 fn test_vm_jit_ldabsb() {
     let prog = assemble(
         "
@@ -146,7 +127,6 @@ fn test_vm_jit_ldabsb() {
     };
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldabsh() {
@@ -171,7 +151,6 @@ fn test_vm_jit_ldabsh() {
     };
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldabsw() {
@@ -196,7 +175,6 @@ fn test_vm_jit_ldabsw() {
     };
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldabsdw() {
@@ -263,7 +241,6 @@ fn test_vm_err_ldabsb_nomem() {
     // Memory check not implemented for JIT yet.
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldindb() {
@@ -289,7 +266,6 @@ fn test_vm_jit_ldindb() {
     };
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldindh() {
@@ -315,7 +291,6 @@ fn test_vm_jit_ldindh() {
     };
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldindw() {
@@ -341,7 +316,6 @@ fn test_vm_jit_ldindw() {
     };
 }
 
-#[ignore] // TODO jit does not support address translation or syscalls
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldinddw() {


### PR DESCRIPTION
Changes calling convention to correctly receive mem parameter.
From Microsoft x64 to System V, AMD64, Solaris, Linux, FreeBSD, macOS.

Also removes the check in vm.rs jit_compile() which prevents the JIT tests from running.