### PR TITLE
JIT syscall

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -792,7 +792,7 @@ impl<'a> JitMemory<'a> {
                             let fat_ptr_ptr = std::mem::transmute::<_, *const *const SyscallTraitObject>(&boxed);
                             let fat_ptr = std::mem::transmute::<_, *const SyscallTraitObject>(*fat_ptr_ptr);
                             emit_load_imm(self, RSI, (*fat_ptr).data as i64);
-                            let vtable = std::mem::transmute::<_, &SyscallObjectVtable>((*fat_ptr).vtable);
+                            let vtable = std::mem::transmute::<_, &SyscallObjectVtable>(&*(*fat_ptr).vtable);
                             vtable.call
                         },
                         None => {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -60,7 +60,7 @@ enum OperandSize {
 const RAX: u8 = 0;
 const RCX: u8 = 1;
 const RDX: u8 = 2;
-const RBX: u8 = 3;
+// const RBX: u8 = 3;
 const RSP: u8 = 4;
 const RBP: u8 = 5;
 const RSI: u8 = 6;
@@ -496,7 +496,7 @@ impl<'a> JitMemory<'a> {
     fn jit_compile<E: UserDefinedError>(&mut self, prog: &[u8],
                    syscalls: &HashMap<u32,
                    Syscall<'a, E>>) -> Result<(), JITError> {
-        emit_push(self, RBX);
+        // emit_push(self, RBX);
         emit_push(self, RBP);
         emit_push(self, R12);
         emit_push(self, R13);
@@ -510,11 +510,7 @@ impl<'a> JitMemory<'a> {
         // Save mem pointer for use with LD_ABS_* and LD_IND_* instructions
         emit_mov(self, RDI, R10);
 
-        if map_register(1) != RDX {
-            emit_mov(self, RDX, map_register(1));
-        }
-
-        // Copy stack pointer to R10
+        // Copy stack pointer to RBP
         emit_mov(self, RSP, map_register(10));
 
         // Allocate stack space
@@ -833,7 +829,7 @@ impl<'a> JitMemory<'a> {
         emit_pop(self, R13);
         emit_pop(self, R12);
         emit_pop(self, RBP);
-        emit_pop(self, RBX);
+        // emit_pop(self, RBX);
 
         emit1(self, 0xc3); // ret
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -32,7 +32,7 @@ use std::{collections::HashMap, u32};
 pub type Verifier<E> = fn(prog: &[u8]) -> Result<(), E>;
 
 /// eBPF Jit-compiled program.
-pub type JitProgram = unsafe fn(*mut u8, usize, usize) -> u64;
+pub type JitProgram<E> = unsafe fn(*mut u8, usize) -> Result<u64, EbpfError<E>>;
 
 /// Syscall function without context.
 pub type SyscallFunction<E> =
@@ -135,7 +135,7 @@ impl InstructionMeter for DefaultInstructionMeter {
 /// ```
 pub struct EbpfVm<'a, E: UserDefinedError> {
     executable: &'a dyn Executable<E>,
-    jit: Option<JitProgram>,
+    jit: Option<JitProgram<E>>,
     syscalls: HashMap<u32, Syscall<'a, E>>,
     last_insn_count: u64,
     total_insn_count: u64,
@@ -802,7 +802,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
             _ => mem.as_ptr() as *mut u8,
         };
         match self.jit {
-            Some(jit) => Ok(jit(mem_ptr, mem.len(), 0)),
+            Some(jit) => jit(mem_ptr, mem.len()),
             None => Err(EbpfError::JITNotCompiled),
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -54,15 +54,23 @@ pub trait SyscallObject<E: UserDefinedError> {
     ) -> Result<u64, EbpfError<E>>;
 }
 
+/// A virtual method table for SyscallObject
 pub struct SyscallObjectVtable {
+    /// Drops the dyn trait object
     pub drop: fn(*const u8),
+    /// Size of the dyn trait object in bytes
     pub size: usize,
+    /// Alignment of the dyn trait object in bytes
     pub align: usize,
+    /// The call method of the SyscallObject
     pub call: *const u8,
 }
 
+/// A dyn trait fat pointer for SyscallObject
 pub struct SyscallTraitObject {
+    /// Pointer to the actual object
     pub data: *const u8,
+    /// Pointer to the virtual method table
     pub vtable: *const SyscallObjectVtable,
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -54,26 +54,6 @@ pub trait SyscallObject<E: UserDefinedError> {
     ) -> Result<u64, EbpfError<E>>;
 }
 
-/// A virtual method table for SyscallObject
-pub struct SyscallObjectVtable {
-    /// Drops the dyn trait object
-    pub drop: fn(*const u8),
-    /// Size of the dyn trait object in bytes
-    pub size: usize,
-    /// Alignment of the dyn trait object in bytes
-    pub align: usize,
-    /// The call method of the SyscallObject
-    pub call: *const u8,
-}
-
-/// A dyn trait fat pointer for SyscallObject
-pub struct SyscallTraitObject {
-    /// Pointer to the actual object
-    pub data: *const u8,
-    /// Pointer to the virtual method table
-    pub vtable: *const SyscallObjectVtable,
-}
-
 /// Contains the syscall
 pub enum Syscall<'a, E: UserDefinedError> {
     /// Function

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -87,7 +87,7 @@ struct DefaultInstructionMeter {}
 impl InstructionMeter for DefaultInstructionMeter {
     fn consume(&mut self, _amount: u64) {}
     fn get_remaining(&self) -> u64 {
-        u64::MAX
+        std::u64::MAX
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -54,6 +54,18 @@ pub trait SyscallObject<E: UserDefinedError> {
     ) -> Result<u64, EbpfError<E>>;
 }
 
+pub struct SyscallObjectVtable {
+    pub drop: fn(*const u8),
+    pub size: usize,
+    pub align: usize,
+    pub call: *const u8,
+}
+
+pub struct SyscallTraitObject {
+    pub data: *const u8,
+    pub vtable: *const SyscallObjectVtable,
+}
+
 /// Contains the syscall
 pub enum Syscall<'a, E: UserDefinedError> {
     /// Function

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -768,7 +768,7 @@ fn test_jit_call_syscall() {
         exit",
     )
     .unwrap();
-    LittleEndian::write_u32(&mut prog[11*4..12*4], ebpf::hash_symbol_name(b"log"));
+    LittleEndian::write_u32(&mut prog[44..48], ebpf::hash_symbol_name(b"log"));
 
     let mut mem = [72, 101, 108, 108, 111, 0];
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -103,6 +103,72 @@ use thiserror::Error;
 // Cargo.toml file (see comments above), so here we use just the hardcoded bytecode instructions
 // instead.
 
+fn bpf_syscall_string(
+    vm_addr: u64,
+    len: u64,
+    _arg3: u64,
+    _arg4: u64,
+    _arg5: u64,
+    ro_regions: &[MemoryRegion],
+    _rw_regions: &[MemoryRegion],
+) -> Result<u64, EbpfError<UserError>> {
+    let host_addr = translate_addr(vm_addr, len as usize, "Load", 0, ro_regions)?;
+    let c_buf: *const c_char = host_addr as *const c_char;
+    unsafe {
+        for i in 0..len {
+            let c = std::ptr::read(c_buf.offset(i as isize));
+            if c == 0 {
+                break;
+            }
+        }
+        let message = from_utf8(from_raw_parts(host_addr as *const u8, len as usize)).unwrap();
+        println!("log: {}", message);
+        Ok(0)
+    }
+}
+
+fn bpf_syscall_u64(
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    _ro_regions: &[MemoryRegion],
+    _rw_regions: &[MemoryRegion],
+) -> Result<u64, EbpfError<UserError>> {
+    println!(
+        "dump_64: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
+        arg1, arg2, arg3, arg4, arg5
+    );
+    Ok(0)
+}
+
+struct SyscallWithContext<'a> {
+    context: &'a mut u64,
+}
+impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
+    fn call(
+        &mut self,
+        arg1: u64,
+        arg2: u64,
+        arg3: u64,
+        arg4: u64,
+        arg5: u64,
+        _ro_regions: &[MemoryRegion],
+        _rw_regions: &[MemoryRegion],
+    ) -> Result<u64, EbpfError<UserError>> {
+        println!(
+            "SyscallWithContext: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
+            arg1, arg2, arg3, arg4, arg5
+        );
+        assert_eq!(*self.context, 42);
+        *self.context = 84;
+        Ok(0)
+    }
+}
+
+
+
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldabsb() {
@@ -594,46 +660,6 @@ fn test_get_total_instruction_count_with_syscall_capped() {
         .unwrap();
 }
 
-fn bpf_syscall_string(
-    vm_addr: u64,
-    len: u64,
-    _arg3: u64,
-    _arg4: u64,
-    _arg5: u64,
-    ro_regions: &[MemoryRegion],
-    _rw_regions: &[MemoryRegion],
-) -> Result<u64, EbpfError<UserError>> {
-    let host_addr = translate_addr(vm_addr, len as usize, "Load", 0, ro_regions)?;
-    let c_buf: *const c_char = host_addr as *const c_char;
-    unsafe {
-        for i in 0..len {
-            let c = std::ptr::read(c_buf.offset(i as isize));
-            if c == 0 {
-                break;
-            }
-        }
-        let message = from_utf8(from_raw_parts(host_addr as *const u8, len as usize)).unwrap();
-        println!("log: {}", message);
-        Ok(0)
-    }
-}
-
-fn bpf_syscall_u64(
-    arg1: u64,
-    arg2: u64,
-    arg3: u64,
-    arg4: u64,
-    arg5: u64,
-    _ro_regions: &[MemoryRegion],
-    _rw_regions: &[MemoryRegion],
-) -> Result<u64, EbpfError<UserError>> {
-    println!(
-        "dump_64: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
-        arg1, arg2, arg3, arg4, arg5
-    );
-    Ok(0)
-}
-
 #[test]
 fn test_load_elf() {
     let mut file = File::open("tests/elfs/noop.so").expect("file open failed");
@@ -685,7 +711,7 @@ fn test_symbol_relocation() {
     .unwrap();
     LittleEndian::write_u32(&mut prog[28..32], ebpf::hash_symbol_name(b"log"));
 
-    let mem = [72, 101, 108, 108, 111, 0];
+    let mem = [72, 101, 108, 108, 111];
 
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
@@ -726,7 +752,7 @@ fn test_null_string() {
     .unwrap();
     LittleEndian::write_u32(&mut prog[12..16], ebpf::hash_symbol_name(b"log"));
 
-    let mem = [72, 101, 108, 108, 111, 0];
+    let mem = [72, 101, 108, 108, 111];
 
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
@@ -746,7 +772,7 @@ fn test_syscall_string() {
     .unwrap();
     LittleEndian::write_u32(&mut prog[12..16], ebpf::hash_symbol_name(b"log"));
 
-    let mem = [72, 101, 108, 108, 111, 0];
+    let mem = [72, 101, 108, 108, 111];
 
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
@@ -756,7 +782,7 @@ fn test_syscall_string() {
 
 #[cfg(not(windows))]
 #[test]
-fn test_jit_call_syscall() {
+fn test_call_syscall() {
     let mut prog = assemble(
         "
         mov64 r1, 0xAA
@@ -771,14 +797,16 @@ fn test_jit_call_syscall() {
     .unwrap();
     LittleEndian::write_u32(&mut prog[44..48], ebpf::hash_symbol_name(b"log"));
 
-    let mut mem = [72, 101, 108, 108, 111, 0];
+    let mem1 = [];
+    let mut mem2 = mem1;
 
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
     vm.register_syscall_ex("log", bpf_syscall_u64).unwrap();
+    vm.execute_program(&mem1, &[], &[]).unwrap();
     vm.jit_compile().unwrap();
     unsafe {
-        assert_eq!(vm.execute_program_jit(&mut mem).unwrap(), 0);
+        assert_eq!(vm.execute_program_jit(&mut mem2).unwrap(), 0);
     }
 }
 
@@ -794,7 +822,7 @@ fn test_symbol_unresolved() {
     .unwrap();
     LittleEndian::write_u32(&mut prog[4..8], ebpf::hash_symbol_name(b"log"));
 
-    let mem = [72, 101, 108, 108, 111, 0];
+    let mem = [];
 
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
@@ -1021,41 +1049,28 @@ fn test_large_program() {
     }
 }
 
-struct SyscallWithContext<'a> {
-    context: &'a mut u64,
-}
-impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
-    fn call(
-        &mut self,
-        _arg1: u64,
-        _arg2: u64,
-        _arg3: u64,
-        _arg4: u64,
-        _arg5: u64,
-        _ro_regions: &[MemoryRegion],
-        _rw_regions: &[MemoryRegion],
-    ) -> Result<u64, EbpfError<UserError>> {
-        assert_eq!(*self.context, 42);
-        *self.context = 84;
-        Ok(0)
-    }
-}
-
 #[test]
 fn test_syscall_with_context() {
     let mut prog = assemble(
         "
-        mov64 r2, 0x5
+        mov64 r1, 0xAA
+        mov64 r2, 0xBB
+        mov64 r3, 0xCC
+        mov64 r4, 0xDD
+        mov64 r5, 0xEE
         call -0x1
         mov64 r0, 0x0
         exit",
     )
     .unwrap();
-    LittleEndian::write_u32(&mut prog[12..16], ebpf::hash_symbol_name(b"syscall"));
+    LittleEndian::write_u32(&mut prog[44..48], ebpf::hash_symbol_name(b"syscall"));
 
-    let mem = [72, 101, 108, 108, 111];
+    let mem1 = [];
+    let mut mem2 = mem1;
     let mut number = 42;
+
     {
+        let number_ptr = &mut number as *mut u64;
         let executable =
             EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
         let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
@@ -1066,7 +1081,12 @@ fn test_syscall_with_context() {
             }),
         )
         .unwrap();
-        vm.execute_program(&mem, &[], &[]).unwrap();
+        vm.execute_program(&mem1, &[], &[]).unwrap();
+        vm.jit_compile().unwrap();
+        unsafe {
+            *number_ptr = 42;
+            assert_eq!(vm.execute_program_jit(&mut mem2).unwrap(), 0);
+        }
     }
     assert_eq!(number, 84);
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -754,6 +754,7 @@ fn test_syscall_string() {
     vm.execute_program(&mem, &[], &[]).unwrap();
 }
 
+#[cfg(not(windows))]
 #[test]
 fn test_jit_call_syscall() {
     let mut prog = assemble(

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -167,8 +167,6 @@ impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
     }
 }
 
-
-
 #[cfg(not(windows))]
 #[test]
 fn test_vm_jit_ldabsb() {


### PR DESCRIPTION
- [x] Raw function pointer
  - [x] Passing arguments via r1 - r5
- [x] Raw dyn trait function pointer
  - [x] Passing arguments unshifted
- [x] Correct return of optional error
- [x] Fix stack pointer alignment on entry to entire JIT compiled code
- [x] Linux
- [x] macOS