### PR TITLE
EbpfError::DivideByZero in JIT

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -20,10 +20,9 @@ use elf::goblin::{
     error::Error as GoblinError,
 };
 use std::{collections::HashMap, mem, ops::Range, str};
-use thiserror::Error;
 
 /// Error definitions
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum ELFError {
     /// Failed to parse ELF file
     #[error("Failed to parse ELF file: {0}")]
@@ -139,7 +138,7 @@ enum BPFRelocationType {
     /// the post-load 64-bit physical address referenced by the imm field and writing
     /// that physical address back into the imm fields of the ldxdw instruction.
     R_BPF_64_RELATIVE = 8,
-    /// Relocation of a call instruction.  
+    /// Relocation of a call instruction.
     /// The existing imm field contains either an offset of the instruction to jump to
     /// (think local function call) or a special value of "-1".  If -1 the symbol must
     /// be looked up in the symbol table.  The relocation entry contains the symbol

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,14 +18,12 @@
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
 use crate::{elf::ELFError, jit::JITError};
-use std::error::Error;
-use thiserror::Error as ThisError;
 
 /// User defined errors must implement this trait
-pub trait UserDefinedError: 'static + Error {}
+pub trait UserDefinedError: 'static + std::error::Error {}
 
 /// Error definitions
-#[derive(Debug, PartialEq, ThisError)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum EbpfError<E: UserDefinedError> {
     /// User defined error
     #[error("{0}")]

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -24,9 +24,8 @@ use crate::{
     vm::Syscall,
     call_frames::CALL_FRAME_SIZE,
     ebpf::{self},
-    error::UserDefinedError,
+    error::{UserDefinedError, EbpfError},
 };
-use thiserror::Error;
 
 /// A virtual method table for SyscallObject
 pub struct SyscallObjectVtable {
@@ -52,7 +51,7 @@ pub struct SyscallTraitObject {
 extern crate libc;
 
 /// Error definitions
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum JITError {
     /// Failed to parse ELF file
     #[error("Unknown eBPF opcode {0:#2x} (insn #{1:?})")]
@@ -457,7 +456,7 @@ fn muldivmod(jit: &mut JitMemory, pc: u16, opc: u8, src: u8, dst: u8, imm: i32) 
         }
 
         // jz div_by_zero
-        //emit_jcc(jit, 0x84, TARGET_PC_DIV_BY_ZERO);
+        emit_jcc(jit, 0x84, TARGET_PC_DIV_BY_ZERO);
     }
 
     if dst != RAX {
@@ -893,8 +892,16 @@ impl<'a> JitMemory<'a> {
 
         // Division by zero handler
         set_anchor(self, TARGET_PC_DIV_BY_ZERO);
-        emit_mov(self, RCX, RDI); // muldivmod stored pc in RCX
-        // TODO: Store error
+        // Store that an error occured
+        emit_load_imm(self, map_register(0), 1);
+        emit_store(self, OperandSize::S64, map_register(0), RDI, 0);
+        // Store which error occured
+        let err = Result::<u64, EbpfError<E>>::Err(EbpfError::DivideByZero(0));
+        let err_kind = unsafe { *(&err as *const _ as *const u64).offset(1) };
+        emit_load_imm(self, map_register(0), err_kind as i64);
+        emit_store(self, OperandSize::S64, map_register(0), RDI, 8);
+        // muldivmod stored pc in RCX
+        emit_store(self, OperandSize::S64, RCX, RDI, 16);
         emit_jmp(self, TARGET_PC_EPILOGUE);
         Ok(())
     }

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -1,10 +1,9 @@
 //! This module defines an example user error definition
 
 use crate::{error::UserDefinedError, verifier::VerifierError};
-use thiserror::Error;
 
 /// User defined error
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum UserError {
     /// Verifier error
     #[error("VerifierError")]

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -25,11 +25,10 @@ use crate::{
     ebpf::{self},
     error::UserDefinedError,
 };
-use thiserror::Error;
 use user_error::UserError;
 
 /// Error definitions
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum VerifierError {
     /// ProgramLengthNotMultiple
     #[error("program length must be a multiple of {} octets", ebpf::INSN_SIZE)]


### PR DESCRIPTION
Implements EbpfError::DivideByZero in JIT and adds a test for it.