### PR TITLE
Unify VM and JIT address translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ therefore must use specific syscall numbers.
 
 ```rust,ignore
 // for struct EbpfVm
-pub fn execute_program(&self,
-                 mem: &'a mut [u8]) -> Result<(u64), Error>
+pub fn execute_program(&mut self) -> Result<(u64), Error>
 ```
 
 Interprets the loaded program. The function takes a reference to the packet
@@ -171,8 +170,7 @@ is called. The generated assembly function is internally stored in the VM.
 
 ```rust,ignore
 // for struct EbpfVm
-pub unsafe fn execute_program_jit(&self, 
-                                  mem: &'a mut [u8]) -> Result<(u64), Error>
+pub unsafe fn execute_program_jit(&self) -> Result<(u64), Error>
 ```
 
 Calls the JIT-compiled program. The arguments to provide are the same as for
@@ -205,10 +203,10 @@ fn main() {
     // Instantiate a struct EbpfVmNoData. This is an eBPF VM for programs that
     // takes no packet data in argument.
     // The eBPF program is passed to the constructor.
-    let vm = rbpf::EbpfVm::new(prog).unwrap();
+    let vm = rbpf::EbpfVm::new(prog, &[]. &[]).unwrap();
 
     // Execute (interpret) the program.
-    assert_eq!(vm.execute_program(&[], &[]. &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 }
 ```
 

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -41,7 +41,7 @@ fn main() {
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog1, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
     // Execute prog1.
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 
     // We know prog1 will always return 3. There is an exception: when it uses
     // syscalls, the latter may have non-deterministic values, and all calls may not return the same
@@ -66,7 +66,7 @@ fn main() {
 
     #[cfg(windows)]
     {
-        time = vm.execute_program(&[], &[], &[]).unwrap();
+        time = vm.execute_program(&[], &[]).unwrap();
     }
 
     let days = time / 10u64.pow(9) / 60 / 60 / 24;

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -61,7 +61,7 @@ fn main() {
     {
         vm.jit_compile().unwrap();
 
-        time = unsafe { vm.execute_program_jit(&mut []).unwrap() };
+        time = unsafe { vm.execute_program_jit().unwrap() };
     }
 
     #[cfg(windows)]

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -39,9 +39,9 @@ fn main() {
 
     // Create a VM: this one takes no data. Load prog1 in it.
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog1, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
     // Execute prog1.
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 
     // We know prog1 will always return 3. There is an exception: when it uses
     // syscalls, the latter may have non-deterministic values, and all calls may not return the same
@@ -51,7 +51,7 @@ fn main() {
     // reimplement uptime in eBPF, in Rust. Because why not.
 
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog2, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
     vm.register_syscall(syscalls::BPF_KTIME_GETNS_IDX, syscalls::bpf_time_getns)
         .unwrap();
 
@@ -66,7 +66,7 @@ fn main() {
 
     #[cfg(windows)]
     {
-        time = vm.execute_program(&[], &[]).unwrap();
+        time = vm.execute_program().unwrap();
     }
 
     let days = time / 10u64.pow(9) / 60 / 60 / 24;

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -54,9 +54,9 @@ impl CallFrames {
             let start = i * size;
             let end = start + size;
             // Seperate each stack frame's virtual address so that stack over/under-run is caught explicitly
-            let addr_vm = MM_STACK_START + (i * 2 * size) as u64;
+            let vm_addr = MM_STACK_START + (i * 2 * size) as u64;
             frames.frames[i].stack =
-                MemoryRegion::new_from_slice(&frames.stack[start..end], addr_vm, true);
+                MemoryRegion::new_from_slice(&frames.stack[start..end], vm_addr, true);
         }
         frames
     }
@@ -72,7 +72,7 @@ impl CallFrames {
 
     /// Get the address of a frame's top of stack
     pub fn get_stack_top(&self) -> u64 {
-        self.frames[self.frame].stack.addr_vm + self.frames[self.frame].stack.len
+        self.frames[self.frame].stack.vm_addr + self.frames[self.frame].stack.len
     }
 
     /// Get current call frame index, 0 is the root frame
@@ -139,11 +139,11 @@ mod tests {
 
             let top = frames.push::<UserError>(&registers[0..4], i).unwrap();
             let new_ptrs = frames.get_stacks();
-            assert_eq!(top, new_ptrs[i + 1].addr_vm + new_ptrs[i + 1].len);
-            assert_ne!(top, ptrs[i].addr_vm + ptrs[i].len - 1);
+            assert_eq!(top, new_ptrs[i + 1].vm_addr + new_ptrs[i + 1].len);
+            assert_ne!(top, ptrs[i].vm_addr + ptrs[i].len - 1);
             assert!(
-                !(ptrs[i].addr_vm <= new_ptrs[i + 1].addr_vm
-                    && new_ptrs[i + 1].addr_vm < ptrs[i].addr_vm + ptrs[i].len)
+                !(ptrs[i].vm_addr <= new_ptrs[i + 1].vm_addr
+                    && new_ptrs[i + 1].vm_addr < ptrs[i].vm_addr + ptrs[i].len)
             );
         }
         let i = DEPTH - 1;
@@ -156,7 +156,7 @@ mod tests {
         for i in (0..DEPTH - 1).rev() {
             let (saved_reg, stack_ptr, return_ptr) = frames.pop::<UserError>().unwrap();
             assert_eq!(saved_reg, [i as u64, i as u64, i as u64, i as u64]);
-            assert_eq!(ptrs[i].addr_vm + ptrs[i].len, stack_ptr);
+            assert_eq!(ptrs[i].vm_addr + ptrs[i].len, stack_ptr);
             assert_eq!(i, return_ptr);
         }
 

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -43,11 +43,7 @@ impl CallFrames {
             max_frame: 0,
             frames: vec![
                 CallFrame {
-                    stack: MemoryRegion {
-                        addr_host: 0,
-                        addr_vm: 0,
-                        len: 0,
-                    },
+                    stack: MemoryRegion::default(),
                     saved_reg: [0u64; SCRATCH_REGS],
                     return_ptr: 0
                 };
@@ -60,7 +56,7 @@ impl CallFrames {
             // Seperate each stack frame's virtual address so that stack over/under-run is caught explicitly
             let addr_vm = MM_STACK_START + (i * 2 * size) as u64;
             frames.frames[i].stack =
-                MemoryRegion::new_from_slice(&frames.stack[start..end], addr_vm);
+                MemoryRegion::new_from_slice(&frames.stack[start..end], addr_vm, true);
         }
         frames
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
-use crate::{elf::ELFError, jit::JITError};
+use crate::{elf::ELFError, jit::JITError, memory_region::AccessType};
 use std::error::Error;
 use thiserror::Error as ThisError;
 
@@ -72,8 +72,8 @@ pub enum EbpfError<E: UserDefinedError> {
     #[error("invalid virtual address {0:x?}")]
     InvalidVirtualAddress(u64),
     /// Access violation
-    #[error("out of bounds memory {0} (insn #{1}), addr {2:#x}/{3:?} \n{4}")]
-    AccessViolation(String, usize, u64, usize, String),
+    #[error("out of bounds memory {0:?} (insn #{1}), addr {2:#x}/{3:?} \n{4}")]
+    AccessViolation(AccessType, usize, u64, usize, String),
     /// Invalid instruction
     #[error("Invalid instruction at {0}")]
     InvalidInstruction(usize),

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ pub enum EbpfError<E: UserDefinedError> {
     InvalidVirtualAddress(u64),
     /// Access violation
     #[error("out of bounds memory {0:?} (insn #{1}), addr {2:#x}/{3:?} \n{4}")]
-    AccessViolation(AccessType, usize, u64, usize, String),
+    AccessViolation(AccessType, usize, u64, u64, String),
     /// Invalid instruction
     #[error("Invalid instruction at {0}")]
     InvalidInstruction(usize),

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,8 +72,8 @@ pub enum EbpfError<E: UserDefinedError> {
     #[error("invalid virtual address {0:x?}")]
     InvalidVirtualAddress(u64),
     /// Access violation
-    #[error("out of bounds memory {0:?} (insn #{1}), addr {2:#x}/{3:?} \n{4}")]
-    AccessViolation(AccessType, usize, u64, u64, String),
+    #[error("out of bounds memory {1:?} (insn #{0}), addr {2:#x}/{3:?} \n{4}")]
+    AccessViolation(usize, AccessType, u64, u64, String),
     /// Invalid instruction
     #[error("Invalid instruction at {0}")]
     InvalidInstruction(usize),

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -199,7 +199,7 @@ pub fn memfrob<E: UserDefinedError> (
 ) -> Result<u64, EbpfError<E>>
 {
 
-        let host_addr = memory_mapping.translate_addr(AccessType::Store, addr, len as usize)?;
+        let host_addr = memory_mapping.map(AccessType::Store, addr, len as usize)?;
         for i in 0..len {
             unsafe {
                 let mut p = (host_addr + i) as *mut u8;
@@ -291,8 +291,8 @@ pub fn strcmp<E: UserDefinedError> (
         if arg1 == 0 || arg2 == 0 {
             return Ok(u64::MAX);
         }
-        let mut a = memory_mapping.translate_addr(AccessType::Load, arg1, 1)?;
-        let mut b = memory_mapping.translate_addr(AccessType::Load, arg2, 1)?;
+        let mut a = memory_mapping.map(AccessType::Load, arg1, 1)?;
+        let mut b = memory_mapping.map(AccessType::Load, arg2, 1)?;
         unsafe {
             let mut a_val = *(a as *const u8);
             let mut b_val = *(b as *const u8);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -190,7 +190,7 @@ pub fn gather_bytes<E: UserDefinedError> (
 /// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub fn memfrob<E: UserDefinedError> (
-    addr: u64,
+    vm_addr: u64,
     len: u64,
     _arg3: u64,
     _arg4: u64,
@@ -199,7 +199,7 @@ pub fn memfrob<E: UserDefinedError> (
 ) -> Result<u64, EbpfError<E>>
 {
 
-        let host_addr = memory_mapping.map(AccessType::Store, addr, len as usize)?;
+        let host_addr = memory_mapping.map(AccessType::Store, vm_addr, len as usize)?;
         for i in 0..len {
             unsafe {
                 let mut p = (host_addr + i) as *mut u8;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -199,7 +199,7 @@ pub fn memfrob<E: UserDefinedError> (
 ) -> Result<u64, EbpfError<E>>
 {
 
-        let host_addr = memory_mapping.translate_addr(addr, len as usize, AccessType::Store, 0)?;
+        let host_addr = memory_mapping.translate_addr(AccessType::Store, addr, len as usize)?;
         for i in 0..len {
             unsafe {
                 let mut p = (host_addr + i) as *mut u8;
@@ -291,8 +291,8 @@ pub fn strcmp<E: UserDefinedError> (
         if arg1 == 0 || arg2 == 0 {
             return Ok(u64::MAX);
         }
-        let mut a = memory_mapping.translate_addr(arg1, 1, AccessType::Load, 0)?;
-        let mut b = memory_mapping.translate_addr(arg2, 1, AccessType::Load, 0)?;
+        let mut a = memory_mapping.translate_addr(AccessType::Load, arg1, 1)?;
+        let mut b = memory_mapping.translate_addr(AccessType::Load, arg2, 1)?;
         unsafe {
             let mut a_val = *(a as *const u8);
             let mut b_val = *(b as *const u8);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -60,7 +60,7 @@ pub fn bpf_time_getns<E: UserDefinedError> (
     _arg5: u64,
     _ro_regions: &[MemoryRegion],
     _rw_regions: &[MemoryRegion],
-) -> Result<u64, EbpfError<E>> 
+) -> Result<u64, EbpfError<E>>
 {
     Ok(time::precise_time_ns())
 }
@@ -188,16 +188,15 @@ pub fn gather_bytes<E: UserDefinedError> (
 /// ```
 pub fn memfrob<E: UserDefinedError> (
     addr: u64,
-    len: u64, 
+    len: u64,
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
-    _ro_regions: &[MemoryRegion],
-    rw_regions: &[MemoryRegion]
+    memory_mapping: &[MemoryRegion]
 ) -> Result<u64, EbpfError<E>>
 {
 
-        let host_addr = translate_addr(addr, len as usize, "Store", 0, rw_regions)?;
+        let host_addr = translate_addr(addr, len as usize, true, 0, memory_mapping)?;
         for i in 0..len {
             unsafe {
                 let mut p = (host_addr + i) as *mut u8;
@@ -282,16 +281,15 @@ pub fn strcmp<E: UserDefinedError> (
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
-    ro_regions: &[MemoryRegion],
-    _rw_regions: &[MemoryRegion]
+    memory_mapping: &[MemoryRegion]
 ) -> Result<u64, EbpfError<E>>
 {
         // C-like strcmp, maybe shorter than converting the bytes to string and comparing?
         if arg1 == 0 || arg2 == 0 {
             return Ok(u64::MAX);
         }
-        let mut a = translate_addr(arg1, 1, "Load", 0, ro_regions)?;
-        let mut b = translate_addr(arg2, 1, "Load", 0, ro_regions)?;
+        let mut a = translate_addr(arg1, 1, false, 0, memory_mapping)?;
+        let mut b = translate_addr(arg2, 1, false, 0, memory_mapping)?;
         unsafe {
             let mut a_val = *(a as *const u8);
             let mut b_val = *(b as *const u8);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -22,7 +22,10 @@
 
 use std::u64;
 use time;
-use crate::{ebpf::{EbpfError, UserDefinedError}, memory_region::{MemoryRegion, translate_addr}};
+use crate::{
+    ebpf::{EbpfError, UserDefinedError},
+    memory_region::{MemoryRegion, MemoryMapping}
+};
 
 // Syscalls associated to kernel syscalls
 // See also linux/include/uapi/linux/bpf.h in Linux kernel sources.
@@ -196,7 +199,7 @@ pub fn memfrob<E: UserDefinedError> (
 ) -> Result<u64, EbpfError<E>>
 {
 
-        let host_addr = translate_addr(addr, len as usize, true, 0, memory_mapping)?;
+        let host_addr = memory_mapping.translate_addr(addr, len as usize, AccessType::Store, 0)?;
         for i in 0..len {
             unsafe {
                 let mut p = (host_addr + i) as *mut u8;
@@ -288,8 +291,8 @@ pub fn strcmp<E: UserDefinedError> (
         if arg1 == 0 || arg2 == 0 {
             return Ok(u64::MAX);
         }
-        let mut a = translate_addr(arg1, 1, false, 0, memory_mapping)?;
-        let mut b = translate_addr(arg2, 1, false, 0, memory_mapping)?;
+        let mut a = memory_mapping.translate_addr(arg1, 1, AccessType::Load, 0)?;
+        let mut b = memory_mapping.translate_addr(arg2, 1, AccessType::Load, 0)?;
         unsafe {
             let mut a_val = *(a as *const u8);
             let mut b_val = *(b as *const u8);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -644,7 +644,7 @@ impl<'a> JitMemory<'a> {
 
         // Initialize registers
         for (i, reg) in REGISTER_MAP.iter().enumerate() {
-            if i != 1 {
+            if i != 1 && i != 10 {
                 emit_load_imm(self, *reg, 0);
             }
         }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -635,11 +635,13 @@ impl<'a> JitMemory<'a> {
         }
 
         // Save pointer to memory_mapping
-        emit_mov(self, ARGUMENT_REGISTERS[1], R10);
+        emit_mov(self, ARGUMENT_REGISTERS[2], R10);
 
         // Initialize registers
         for (i, reg) in REGISTER_MAP.iter().enumerate() {
-            emit_load_imm(self, *reg, if i == 1 { ebpf::MM_INPUT_START as i64 } else { 0 });
+            if i != 1 {
+                emit_load_imm(self, *reg, 0);
+            }
         }
 
         // Allocate stack space

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -4,7 +4,7 @@ use crate::error::{EbpfError, UserDefinedError};
 use std::fmt;
 
 /// Memory region for bounds checking and address translation
-#[derive(Clone, PartialEq, Eq, Ord, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct MemoryRegion {
     /// start host address
     pub host_addr: u64,
@@ -53,7 +53,12 @@ impl fmt::Debug for MemoryRegion {
 }
 impl std::cmp::PartialOrd for MemoryRegion {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.vm_addr.cmp(&other.vm_addr))
+        Some(self.cmp(&other))
+    }
+}
+impl std::cmp::Ord for MemoryRegion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.vm_addr.cmp(&other.vm_addr)
     }
 }
 

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -110,7 +110,7 @@ pub fn translate_addr<E: UserDefinedError>(
                     len,
                     access_type,
                     pc,
-                    regions
+                    regions,
                 ));
             }
             index - 1
@@ -126,6 +126,6 @@ pub fn translate_addr<E: UserDefinedError>(
         len,
         access_type,
         pc,
-        regions
+        regions,
     ))
 }

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -16,7 +16,7 @@ pub struct MemoryRegion {
     /// Length in bytes
     pub len: u64,
     /// Is also writable (otherwise it is readonly)
-    pub writable: bool
+    pub writable: bool,
 }
 impl MemoryRegion {
     /// Creates a new MemoryRegion structure from a slice
@@ -61,7 +61,7 @@ pub enum AccessType {
     /// Read
     Load,
     /// Write
-    Store
+    Store,
 }
 
 /// Helper for translate_addr to generate errors
@@ -105,7 +105,13 @@ pub fn translate_addr<E: UserDefinedError>(
         Ok(index) => index,
         Err(index) => {
             if index == 0 {
-                return Err(generate_access_violation(vm_addr, len, access_type, pc, regions));
+                return Err(generate_access_violation(
+                    vm_addr,
+                    len,
+                    access_type,
+                    pc,
+                    regions
+                ));
             }
             index - 1
         }
@@ -115,5 +121,11 @@ pub fn translate_addr<E: UserDefinedError>(
             return Ok(host_addr);
         }
     }
-    Err(generate_access_violation(vm_addr, len, access_type, pc, regions))
+    Err(generate_access_violation(
+        vm_addr,
+        len,
+        access_type,
+        pc,
+        regions
+    ))
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -186,14 +186,14 @@ pub fn gather_bytes<E: UserDefinedError>(
 /// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub fn memfrob<E: UserDefinedError>(
-    addr: u64,
+    vm_addr: u64,
     len: u64,
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
-    let host_addr = memory_mapping.map(AccessType::Store, addr, len)?;
+    let host_addr = memory_mapping.map(AccessType::Store, vm_addr, len)?;
     for i in 0..len {
         unsafe {
             let p = (host_addr + i) as *mut u8;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -23,7 +23,7 @@ extern crate libc;
 
 use crate::{
     error::{EbpfError, UserDefinedError},
-    memory_region::{translate_addr, MemoryRegion, AccessType},
+    memory_region::{translate_addr, AccessType, MemoryRegion},
 };
 use std::u64;
 use time;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -193,7 +193,7 @@ pub fn memfrob<E: UserDefinedError>(
     _arg5: u64,
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
-    let host_addr = memory_mapping.translate_addr(addr, len, AccessType::Store, 0)?;
+    let host_addr = memory_mapping.translate_addr(AccessType::Store, addr, len)?;
     for i in 0..len {
         unsafe {
             let p = (host_addr + i) as *mut u8;
@@ -282,8 +282,8 @@ pub fn strcmp<E: UserDefinedError>(
     if arg1 == 0 || arg2 == 0 {
         return Ok(u64::MAX);
     }
-    let mut a = memory_mapping.translate_addr(arg1, 1, AccessType::Load, 0)?;
-    let mut b = memory_mapping.translate_addr(arg2, 1, AccessType::Load, 0)?;
+    let mut a = memory_mapping.translate_addr(AccessType::Load, arg1, 1)?;
+    let mut b = memory_mapping.translate_addr(AccessType::Load, arg2, 1)?;
     unsafe {
         let mut a_val = *(a as *const u8);
         let mut b_val = *(b as *const u8);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -746,19 +746,19 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
         Ok(())
     }
 
-    /// Execute the previously JIT-compiled program, with the given packet data
-    /// in a manner very similar to `execute_program(&[], &[])`.
+    /// Execute the previously JIT-compiled program, with the given packet data in a manner
+    /// very similar to `execute_program(&[], &[])`.
+    /// TODO: This in fact requires execute_program to be run beforehand,
+    /// so that the memory_mapping is defined.
     ///
     /// # Safety
     ///
-    /// **WARNING:** JIT-compiled assembly code is not safe, in particular there is no runtime
-    /// check for memory access; so if the eBPF program attempts erroneous accesses, this may end
-    /// very bad (program may segfault). It may be wise to check that the program works with the
-    /// interpreter before running the JIT-compiled version of it.
+    /// **WARNING:** JIT-compiled assembly code is not safe. It may be wise to check that
+    /// the program works with the interpreter before running the JIT-compiled version of it.
     ///
     /// For this reason the function should be called from within an `unsafe` bloc.
     ///
-    pub unsafe fn execute_program_jit(&self, _mem: &mut [u8]) -> Result<u64, EbpfError<E>> {
+    pub unsafe fn execute_program_jit(&self) -> Result<u64, EbpfError<E>> {
         match self.jit {
             Some(jit) => jit(&self.memory_mapping),
             None => Err(EbpfError::JITNotCompiled),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -16,7 +16,7 @@ use crate::{
     elf::EBpfElf,
     error::{EbpfError, UserDefinedError},
     jit,
-    memory_region::{translate_addr, MemoryRegion, AccessType},
+    memory_region::{translate_addr, AccessType, MemoryRegion},
 };
 use log::{debug, log_enabled, trace};
 use std::{collections::HashMap, u32};
@@ -42,15 +42,7 @@ pub type SyscallFunction<E> =
 pub trait SyscallObject<E: UserDefinedError> {
     /// Call the syscall function
     #[allow(clippy::too_many_arguments)]
-    fn call(
-        &mut self,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        &[MemoryRegion],
-    ) -> Result<u64, EbpfError<E>>;
+    fn call(&mut self, u64, u64, u64, u64, u64, &[MemoryRegion]) -> Result<u64, EbpfError<E>>;
 }
 
 /// Contains the syscall
@@ -286,11 +278,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
         mem: &[u8],
         granted_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<E>> {
-        self.execute_program_metered(
-            mem,
-            granted_regions,
-            DefaultInstructionMeter {},
-        )
+        self.execute_program_metered(mem, granted_regions, DefaultInstructionMeter {})
     }
 
     /// Execute the program loaded, with the given packet data and instruction meter.
@@ -300,11 +288,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
         granted_regions: &[MemoryRegion],
         mut instruction_meter: I,
     ) -> Result<u64, EbpfError<E>> {
-        let result = self.execute_program_inner(
-            mem,
-            granted_regions,
-            &mut instruction_meter,
-        );
+        let result = self.execute_program_inner(mem, granted_regions, &mut instruction_meter);
         instruction_meter.consume(self.last_insn_count);
         result
     }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -136,7 +136,7 @@ fn bpf_syscall_string(
     _arg5: u64,
     memory_mapping: &MemoryMapping,
 ) -> ExecResult {
-    let host_addr = memory_mapping.translate_addr(AccessType::Load, vm_addr, len)?;
+    let host_addr = memory_mapping.map(AccessType::Load, vm_addr, len)?;
     let c_buf: *const c_char = host_addr as *const c_char;
     unsafe {
         for i in 0..len {

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -253,43 +253,34 @@ fn test_vm_jit_ldabsdw() {
 }
 
 #[test]
-fn test_vm_err_ldabsb_oob() {
-    let prog = assemble(
+fn test_vm_jit_err_ldabsb_oob() {
+    test_vm_and_jit!(
         "
         ldabsb 0x33
         exit",
-    )
-    .unwrap();
-    let mem = [
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, //
-        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
-    ];
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert!(matches!(
-        vm.execute_program(&mem, &[]).unwrap_err(),
-        EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29
-    ));
-    // TODO Memory check not implemented for JIT yet.
-    // test_vm_and_jit!(prog, mem, {|res: ExecResult| { matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29) }});
+        [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, //
+            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
+        ],
+        [],
+        {
+            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29)
+        }
+    );
 }
 
 #[test]
-fn test_vm_err_ldabsb_nomem() {
-    let prog = assemble(
+fn test_vm_jit_err_ldabsb_nomem() {
+    test_vm_and_jit!(
         "
         ldabsb 0x33
         exit",
-    )
-    .unwrap();
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert!(matches!(
-        vm.execute_program(&[], &[]).unwrap_err(),
-        EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29
-    ));
-    // TODO Memory check not implemented for JIT yet.
-    // test_vm_and_jit!(prog, [], {|res: ExecResult| { matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29) }});
+        [],
+        [],
+        {
+            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29)
+        }
+    );
 }
 
 #[test]
@@ -357,45 +348,36 @@ fn test_vm_jit_ldinddw() {
 }
 
 #[test]
-fn test_vm_err_ldindb_oob() {
-    let prog = assemble(
+fn test_vm_jit_err_ldindb_oob() {
+    test_vm_and_jit!(
         "
         mov64 r1, 0x5
         ldindb r1, 0x33
         exit",
-    )
-    .unwrap();
-    let mem = [
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, //
-        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
-    ];
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert!(matches!(
-        vm.execute_program(&mem, &[]).unwrap_err(),
-        EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30
-    ));
-    // TODO Memory check not implemented for JIT yet.
-    // test_vm_and_jit!(prog, mem, {|res: ExecResult| { matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30) }});
+        [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, //
+            0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
+        ],
+        [],
+        {
+            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30)
+        }
+    );
 }
 
 #[test]
-fn test_vm_err_ldindb_nomem() {
-    let prog = assemble(
+fn test_vm_jit_err_ldindb_nomem() {
+    test_vm_and_jit!(
         "
-        mov64 r1, 0x3
-        ldindb r1, 0x3
+        mov64 r1, 0x5
+        ldindb r1, 0x33
         exit",
-    )
-    .unwrap();
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert!(matches!(
-        vm.execute_program(&[], &[]).unwrap_err(),
-        EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30
-    ));
-    // TODO Memory check not implemented for JIT yet.
-    // test_vm_and_jit!(prog, [], {|res: ExecResult| { matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30) }});
+        [],
+        [],
+        {
+            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30)
+        }
+    );
 }
 
 /// Error definitions

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -160,11 +160,11 @@ fn bpf_syscall_u64(
     arg3: u64,
     arg4: u64,
     arg5: u64,
-    _memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping,
 ) -> ExecResult {
     println!(
-        "dump_64: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
-        arg1, arg2, arg3, arg4, arg5
+        "dump_64: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:?}",
+        arg1, arg2, arg3, arg4, arg5, memory_mapping as *const _
     );
     Ok(0)
 }
@@ -180,11 +180,11 @@ impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping,
     ) -> ExecResult {
         println!(
-            "SyscallWithContext: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
-            arg1, arg2, arg3, arg4, arg5
+            "SyscallWithContext: {:?}, {:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:?}",
+            self as *const _, arg1, arg2, arg3, arg4, arg5, memory_mapping as *const _
         );
         assert_eq!(*self.context, 42);
         *self.context = 84;
@@ -264,7 +264,12 @@ fn test_vm_jit_err_ldabsb_oob() {
         ],
         [],
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29)
+            |res: ExecResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::AccessViolation(pc, access_type, _, _, _)
+                    if access_type == AccessType::Load && pc == 29
+                )
+            }
         }
     );
 }
@@ -278,7 +283,12 @@ fn test_vm_jit_err_ldabsb_nomem() {
         [],
         [],
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 29)
+            |res: ExecResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::AccessViolation(pc, access_type, _, _, _)
+                    if access_type == AccessType::Load && pc == 29
+                )
+            }
         }
     );
 }
@@ -360,7 +370,12 @@ fn test_vm_jit_err_ldindb_oob() {
         ],
         [],
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30)
+            |res: ExecResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::AccessViolation(pc, access_type, _, _, _)
+                    if access_type == AccessType::Load && pc == 30
+                )
+            }
         }
     );
 }
@@ -375,7 +390,12 @@ fn test_vm_jit_err_ldindb_nomem() {
         [],
         [],
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::AccessViolation(pc, access_type, _, _, _) if access_type == AccessType::Load && pc == 30)
+            |res: ExecResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::AccessViolation(pc, access_type, _, _, _)
+                    if access_type == AccessType::Load && pc == 30
+                )
+            }
         }
     );
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -111,7 +111,7 @@ fn bpf_syscall_string(
     _arg5: u64,
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<UserError>> {
-    let host_addr = memory_mapping.translate_addr(vm_addr, len, AccessType::Load, 0)?;
+    let host_addr = memory_mapping.translate_addr(AccessType::Load, vm_addr, len)?;
     let c_buf: *const c_char = host_addr as *const c_char;
     unsafe {
         for i in 0..len {
@@ -264,7 +264,7 @@ fn test_vm_jit_ldabsdw() {
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(Load, 29")]
+#[should_panic(expected = "AccessViolation(29, Load")]
 fn test_vm_err_ldabsb_oob() {
     let prog = assemble(
         "
@@ -284,7 +284,7 @@ fn test_vm_err_ldabsb_oob() {
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(Load, 29")]
+#[should_panic(expected = "AccessViolation(29, Load")]
 fn test_vm_err_ldabsb_nomem() {
     let prog = assemble(
         "
@@ -403,7 +403,7 @@ fn test_vm_jit_ldinddw() {
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(Load, 30")]
+#[should_panic(expected = "AccessViolation(30, Load")]
 fn test_vm_err_ldindb_oob() {
     let prog = assemble(
         "
@@ -424,7 +424,7 @@ fn test_vm_err_ldindb_oob() {
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(Load, 30")]
+#[should_panic(expected = "AccessViolation(30, Load")]
 fn test_vm_err_ldindb_nomem() {
     let prog = assemble(
         "
@@ -728,7 +728,7 @@ fn test_syscall_parameter_on_stack() {
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(Load, 29")]
+#[should_panic(expected = "AccessViolation(0, Load")]
 fn test_null_string() {
     let mut prog = assemble(
         "

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -29,7 +29,7 @@ use solana_rbpf::{
     ebpf::{self},
     error::{EbpfError, UserDefinedError},
     fuzz::fuzz,
-    memory_region::{translate_addr, AccessType, MemoryRegion},
+    memory_region::{AccessType, MemoryMapping},
     user_error::UserError,
     verifier::check,
     vm::{EbpfVm, InstructionMeter, SyscallObject},
@@ -109,9 +109,9 @@ fn bpf_syscall_string(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
-    memory_mapping: &Vec<MemoryRegion>,
+    memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<UserError>> {
-    let host_addr = translate_addr(vm_addr, len, AccessType::Load, 0, memory_mapping)?;
+    let host_addr = memory_mapping.translate_addr(vm_addr, len, AccessType::Load, 0)?;
     let c_buf: *const c_char = host_addr as *const c_char;
     unsafe {
         for i in 0..len {
@@ -132,7 +132,7 @@ fn bpf_syscall_u64(
     arg3: u64,
     arg4: u64,
     arg5: u64,
-    _memory_mapping: &Vec<MemoryRegion>,
+    _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<UserError>> {
     println!(
         "dump_64: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
@@ -152,7 +152,7 @@ impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &Vec<MemoryRegion>,
+        _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<UserError>> {
         println!(
             "SyscallWithContext: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
@@ -493,7 +493,7 @@ fn bpf_trace_printf<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
-    _memory_mapping: &Vec<MemoryRegion>,
+    _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     Ok(0)
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -109,9 +109,9 @@ fn bpf_syscall_string(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
-    memory_mapping: &[MemoryRegion],
+    memory_mapping: &Vec<MemoryRegion>,
 ) -> Result<u64, EbpfError<UserError>> {
-    let host_addr = translate_addr(vm_addr, len as usize, AccessType::Load, 0, memory_mapping)?;
+    let host_addr = translate_addr(vm_addr, len, AccessType::Load, 0, memory_mapping)?;
     let c_buf: *const c_char = host_addr as *const c_char;
     unsafe {
         for i in 0..len {
@@ -132,7 +132,7 @@ fn bpf_syscall_u64(
     arg3: u64,
     arg4: u64,
     arg5: u64,
-    _memory_mapping: &[MemoryRegion],
+    _memory_mapping: &Vec<MemoryRegion>,
 ) -> Result<u64, EbpfError<UserError>> {
     println!(
         "dump_64: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
@@ -152,7 +152,7 @@ impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &[MemoryRegion],
+        _memory_mapping: &Vec<MemoryRegion>,
     ) -> Result<u64, EbpfError<UserError>> {
         println!(
             "SyscallWithContext: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
@@ -493,7 +493,7 @@ fn bpf_trace_printf<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
-    _memory_mapping: &[MemoryRegion],
+    _memory_mapping: &Vec<MemoryRegion>,
 ) -> Result<u64, EbpfError<E>> {
     Ok(0)
 }

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -38,7 +38,7 @@ fn test_vm_add() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_vm_alu64_arith() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x2a);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x2a);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn test_vm_alu64_bit() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn test_vm_alu_arith() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x2a);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x2a);
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn test_vm_alu_bit() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -179,7 +179,7 @@ fn test_vm_arsh32_high_shift() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x4);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4);
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn test_vm_arsh() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffff8000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffff8000);
 }
 
 #[test]
@@ -211,10 +211,7 @@ fn test_vm_arsh64() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(&[], &[], &[]).unwrap(),
-        0xfffffffffffffff8
-    );
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffffffffff8);
 }
 
 #[test]
@@ -230,7 +227,7 @@ fn test_vm_arsh_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffff8000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffff8000);
 }
 
 #[test]
@@ -245,7 +242,7 @@ fn test_vm_be16() {
     let mem = &mut [0x11, 0x22];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122);
 }
 
 #[test]
@@ -260,7 +257,7 @@ fn test_vm_be16_high() {
     let mem = &mut [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122);
 }
 
 #[test]
@@ -275,7 +272,7 @@ fn test_vm_be32() {
     let mem = &mut [0x11, 0x22, 0x33, 0x44];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11223344);
 }
 
 #[test]
@@ -290,7 +287,7 @@ fn test_vm_be32_high() {
     let mem = &mut [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11223344);
 }
 
 #[test]
@@ -305,10 +302,7 @@ fn test_vm_be64() {
     let mem = &mut [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0x1122334455667788
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -327,7 +321,7 @@ fn test_vm_call() {
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
     vm.register_syscall(0, syscalls::gather_bytes).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0102030405);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0102030405);
 }
 
 #[test]
@@ -349,10 +343,7 @@ fn test_vm_call_memfrob() {
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
     vm.register_syscall(1, syscalls::memfrob).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0x102292e2f2c0708
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x102292e2f2c0708);
 }
 
 // TODO: syscalls::trash_registers needs asm!().
@@ -375,7 +366,7 @@ fn test_vm_call_memfrob() {
 //     ];
 //     let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
 //     vm.register_syscall(2, syscalls::trash_registers, None);
-//     assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x4321);
+//     assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4321);
 // }
 
 #[test]
@@ -390,7 +381,7 @@ fn test_vm_div32_high_divisor() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -404,7 +395,7 @@ fn test_vm_div32_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -419,7 +410,7 @@ fn test_vm_div32_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 #[test]
@@ -434,7 +425,7 @@ fn test_vm_div64_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x300000000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x300000000);
 }
 
 #[test]
@@ -450,7 +441,7 @@ fn test_vm_div64_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x300000000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x300000000);
 }
 
 #[test]
@@ -465,7 +456,7 @@ fn test_vm_early_exit() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x3);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
 }
 
 // uBPF limits the number of user functions at 64. We don't.
@@ -489,7 +480,7 @@ fn test_vm_err_call_unreg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[], &[]).unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -505,7 +496,7 @@ fn test_vm_err_div64_by_zero_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[], &[]).unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -521,7 +512,7 @@ fn test_vm_err_div_by_zero_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[], &[]).unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -537,7 +528,7 @@ fn test_vm_err_mod64_by_zero_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[], &[]).unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -553,14 +544,14 @@ fn test_vm_err_mod_by_zero_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[], &[]).unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 // With the introduction of call frames there may be stack regions
 // above or below the current stack, to test out of bounds we have to
 // try significantly further away
 #[test]
-#[should_panic(expected = "AccessViolation(\"store\", 29")]
+#[should_panic(expected = "AccessViolation(Store, 29")]
 fn test_vm_err_stack_out_of_bound() {
     let prog = assemble(
         "
@@ -570,7 +561,7 @@ fn test_vm_err_stack_out_of_bound() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[], &[]).unwrap();
+    vm.execute_program(&[], &[]).unwrap();
 }
 
 #[test]
@@ -583,7 +574,7 @@ fn test_vm_exit() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -598,7 +589,7 @@ fn test_vm_ja() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -617,7 +608,7 @@ fn test_vm_jeq_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -637,7 +628,7 @@ fn test_vm_jeq_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -656,7 +647,7 @@ fn test_vm_jge_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -676,7 +667,7 @@ fn test_vm_jle_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -698,7 +689,7 @@ fn test_vm_jle_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -717,7 +708,7 @@ fn test_vm_jgt_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -738,7 +729,7 @@ fn test_vm_jgt_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -757,7 +748,7 @@ fn test_vm_jlt_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -778,7 +769,7 @@ fn test_vm_jlt_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -796,7 +787,7 @@ fn test_vm_jit_bounce() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -816,7 +807,7 @@ fn test_vm_jne_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -835,7 +826,7 @@ fn test_vm_jset_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -855,7 +846,7 @@ fn test_vm_jset_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -875,7 +866,7 @@ fn test_vm_jsge_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -897,7 +888,7 @@ fn test_vm_jsge_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -917,7 +908,7 @@ fn test_vm_jsle_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -940,7 +931,7 @@ fn test_vm_jsle_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -959,7 +950,7 @@ fn test_vm_jsgt_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -979,7 +970,7 @@ fn test_vm_jsgt_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -998,7 +989,7 @@ fn test_vm_jslt_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1019,7 +1010,7 @@ fn test_vm_jslt_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1031,10 +1022,7 @@ fn test_vm_lddw() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(&[], &[], &[]).unwrap(),
-        0x1122334455667788
-    );
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -1047,7 +1035,7 @@ fn test_vm_lddw2() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x80000000);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x80000000);
 }
 
 #[test]
@@ -1093,7 +1081,7 @@ fn test_vm_ldxb_all() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x9876543210);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x9876543210);
 }
 
 #[test]
@@ -1107,7 +1095,7 @@ fn test_vm_ldxb() {
     let mem = &mut [0xaa, 0xbb, 0x11, 0xcc, 0xdd];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -1124,14 +1112,11 @@ fn test_vm_ldxdw() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0x8877665544332211
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x8877665544332211);
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(\"load\", 29")]
+#[should_panic(expected = "AccessViolation(Load, 29")]
 fn test_vm_ldxdw_oob() {
     let prog = assemble(
         "
@@ -1145,10 +1130,7 @@ fn test_vm_ldxdw_oob() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0x8877665544332211
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -1205,7 +1187,7 @@ fn test_vm_ldxh_all() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x9876543210);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x9876543210);
 }
 
 #[test]
@@ -1252,7 +1234,7 @@ fn test_vm_ldxh_all2() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x3ff);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x3ff);
 }
 
 #[test]
@@ -1268,7 +1250,7 @@ fn test_vm_ldxh() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2211);
 }
 
 #[test]
@@ -1284,7 +1266,7 @@ fn test_vm_ldxh_same_reg() {
     let mem = &mut [0xff, 0xff];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1234);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1234);
 }
 
 #[test]
@@ -1333,7 +1315,7 @@ fn test_vm_ldxw_all() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x030f0f);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x030f0f);
 }
 
 #[test]
@@ -1349,7 +1331,7 @@ fn test_vm_ldxw() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1364,7 +1346,7 @@ fn test_vm_le16() {
     let mem = &mut [0x22, 0x11];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1122);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122);
 }
 
 #[test]
@@ -1381,7 +1363,7 @@ fn test_vm_le32() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11223344);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11223344);
 }
 
 #[test]
@@ -1398,10 +1380,7 @@ fn test_vm_le64() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0x1122334455667788
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -1416,7 +1395,7 @@ fn test_vm_lsh_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x10);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x10);
 }
 
 #[test]
@@ -1432,7 +1411,7 @@ fn test_vm_mod() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x5);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x5);
 }
 
 #[test]
@@ -1446,7 +1425,7 @@ fn test_vm_mod32() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1466,7 +1445,7 @@ fn test_vm_mod64() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x30ba5a04);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x30ba5a04);
 }
 
 #[test]
@@ -1480,7 +1459,7 @@ fn test_vm_mov() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1493,7 +1472,7 @@ fn test_vm_mov32_imm_large() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffffffff);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffffffff);
 }
 
 #[test]
@@ -1507,7 +1486,7 @@ fn test_vm_mov_large() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xffffffff);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffffffff);
 }
 
 #[test]
@@ -1521,7 +1500,7 @@ fn test_vm_mul32_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xc);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xc);
 }
 
 #[test]
@@ -1536,7 +1515,7 @@ fn test_vm_mul32_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xc);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xc);
 }
 
 #[test]
@@ -1551,7 +1530,7 @@ fn test_vm_mul32_reg_overflow() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x4);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4);
 }
 
 #[test]
@@ -1565,7 +1544,7 @@ fn test_vm_mul64_imm() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x100000004);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x100000004);
 }
 
 #[test]
@@ -1580,7 +1559,7 @@ fn test_vm_mul64_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x100000004);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x100000004);
 }
 
 #[test]
@@ -1601,7 +1580,7 @@ fn test_vm_mul_loop() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x75db9c97);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x75db9c97);
 }
 
 #[test]
@@ -1615,10 +1594,7 @@ fn test_vm_neg64() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(&[], &[], &[]).unwrap(),
-        0xfffffffffffffffe
-    );
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffffffffffe);
 }
 
 #[test]
@@ -1632,7 +1608,7 @@ fn test_vm_neg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xfffffffe);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffe);
 }
 
 #[test]
@@ -1659,7 +1635,7 @@ fn test_vm_prime() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1674,7 +1650,7 @@ fn test_vm_rhs32() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x00ffffff);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x00ffffff);
 }
 
 #[test]
@@ -1689,7 +1665,7 @@ fn test_vm_rsh_reg() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -1709,7 +1685,7 @@ fn test_vm_stack1() {
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0xcd);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xcd);
 }
 
 #[test]
@@ -1738,7 +1714,7 @@ fn test_vm_stack2() {
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
     vm.register_syscall(0, syscalls::gather_bytes).unwrap();
     vm.register_syscall(1, syscalls::memfrob).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x01020304);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x01020304);
 }
 
 #[test]
@@ -1753,7 +1729,7 @@ fn test_vm_stb() {
     let mem = &mut [0xaa, 0xbb, 0xff, 0xcc, 0xdd];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -1771,7 +1747,7 @@ fn test_vm_stdw() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1788,7 +1764,7 @@ fn test_vm_sth() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2211);
 }
 
 #[test]
@@ -1828,7 +1804,7 @@ fn test_vm_string_stack() {
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
     vm.register_syscall(4, syscalls::strcmp).unwrap();
-    assert_eq!(vm.execute_program(&[], &[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -1845,7 +1821,7 @@ fn test_vm_stw() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1863,7 +1839,7 @@ fn test_vm_stxb() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x11);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11);
 }
 
 #[test]
@@ -1896,10 +1872,7 @@ fn test_vm_stxb_all() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0xf0f2f3f4f5f6f7f8
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0xf0f2f3f4f5f6f7f8);
 }
 
 #[test]
@@ -1919,7 +1892,7 @@ fn test_vm_stxb_all2() {
     let mem = &mut [0xff, 0xff];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0xf1f9);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0xf1f9);
 }
 
 #[test]
@@ -1955,7 +1928,7 @@ fn test_vm_stxb_chain() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2a);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2a);
 }
 
 #[test]
@@ -1976,10 +1949,7 @@ fn test_vm_stxdw() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem, &[], &[]).unwrap(),
-        0x8877665544332211
-    );
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -1997,7 +1967,7 @@ fn test_vm_stxh() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x2211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2211);
 }
 
 #[test]
@@ -2015,7 +1985,7 @@ fn test_vm_stxw() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x44332211);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
 }
 
 #[test]
@@ -2052,7 +2022,7 @@ fn test_vm_subnet() {
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1);
 }
 
 const PROG_TCP_PORT_80: [u8; 152] = [
@@ -2097,7 +2067,7 @@ fn test_vm_tcp_port80_match() {
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x1);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -2120,7 +2090,7 @@ fn test_vm_tcp_port80_nomatch() {
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -2143,7 +2113,7 @@ fn test_vm_tcp_port80_nomatch_ethertype() {
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -2166,7 +2136,7 @@ fn test_vm_tcp_port80_nomatch_proto() {
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x0);
 }
 
 #[test]
@@ -2175,10 +2145,7 @@ fn test_vm_tcp_sack_match() {
     let prog = assemble(TCP_SACK_ASM).unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem.as_mut_slice(), &[], &[]).unwrap(),
-        0x1
-    );
+    assert_eq!(vm.execute_program(mem.as_mut_slice(), &[]).unwrap(), 0x1);
 }
 
 #[test]
@@ -2187,8 +2154,5 @@ fn test_vm_tcp_sack_nomatch() {
     let prog = assemble(TCP_SACK_ASM).unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(
-        vm.execute_program(mem.as_mut_slice(), &[], &[]).unwrap(),
-        0x0
-    );
+    assert_eq!(vm.execute_program(mem.as_mut_slice(), &[]).unwrap(), 0x0);
 }

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -551,7 +551,7 @@ fn test_vm_err_mod_by_zero_reg() {
 // above or below the current stack, to test out of bounds we have to
 // try significantly further away
 #[test]
-#[should_panic(expected = "AccessViolation(Store, 29")]
+#[should_panic(expected = "AccessViolation(29, Store")]
 fn test_vm_err_stack_out_of_bound() {
     let prog = assemble(
         "
@@ -1116,7 +1116,7 @@ fn test_vm_ldxdw() {
 }
 
 #[test]
-#[should_panic(expected = "AccessViolation(Load, 29")]
+#[should_panic(expected = "AccessViolation(29, Load")]
 fn test_vm_ldxdw_oob() {
     let prog = assemble(
         "

--- a/tests/ubpf_vm.rs
+++ b/tests/ubpf_vm.rs
@@ -37,8 +37,8 @@ fn test_vm_add() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 }
 
 #[test]
@@ -67,8 +67,8 @@ fn test_vm_alu64_arith() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x2a);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x2a);
 }
 
 #[test]
@@ -101,8 +101,8 @@ fn test_vm_alu64_bit() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x11);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11);
 }
 
 #[test]
@@ -131,8 +131,8 @@ fn test_vm_alu_arith() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x2a);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x2a);
 }
 
 #[test]
@@ -163,8 +163,8 @@ fn test_vm_alu_bit() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x11);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11);
 }
 
 #[test]
@@ -178,8 +178,8 @@ fn test_vm_arsh32_high_shift() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x4);
 }
 
 #[test]
@@ -193,8 +193,8 @@ fn test_vm_arsh() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffff8000);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xffff8000);
 }
 
 #[test]
@@ -210,8 +210,8 @@ fn test_vm_arsh64() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffffffffff8);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xfffffffffffffff8);
 }
 
 #[test]
@@ -226,8 +226,8 @@ fn test_vm_arsh_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffff8000);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xffff8000);
 }
 
 #[test]
@@ -241,8 +241,8 @@ fn test_vm_be16() {
     .unwrap();
     let mem = &mut [0x11, 0x22];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1122);
 }
 
 #[test]
@@ -256,8 +256,8 @@ fn test_vm_be16_high() {
     .unwrap();
     let mem = &mut [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1122);
 }
 
 #[test]
@@ -271,8 +271,8 @@ fn test_vm_be32() {
     .unwrap();
     let mem = &mut [0x11, 0x22, 0x33, 0x44];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11223344);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11223344);
 }
 
 #[test]
@@ -286,8 +286,8 @@ fn test_vm_be32_high() {
     .unwrap();
     let mem = &mut [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11223344);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11223344);
 }
 
 #[test]
@@ -301,8 +301,8 @@ fn test_vm_be64() {
     .unwrap();
     let mem = &mut [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122334455667788);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -319,9 +319,9 @@ fn test_vm_call() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
     vm.register_syscall(0, syscalls::gather_bytes).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0102030405);
+    assert_eq!(vm.execute_program().unwrap(), 0x0102030405);
 }
 
 #[test]
@@ -341,9 +341,9 @@ fn test_vm_call_memfrob() {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
     vm.register_syscall(1, syscalls::memfrob).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x102292e2f2c0708);
+    assert_eq!(vm.execute_program().unwrap(), 0x102292e2f2c0708);
 }
 
 // TODO: syscalls::trash_registers needs asm!().
@@ -364,9 +364,9 @@ fn test_vm_call_memfrob() {
 //         0x4f, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
 //         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
 //     ];
-//     let mut vm = EbpfVm::<UserError>::new(Some(prog)).unwrap();
+//     let mut vm = EbpfVm::<UserError>::new(Some(prog), &[], &[]).unwrap();
 //     vm.register_syscall(2, syscalls::trash_registers, None);
-//     assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4321);
+//     assert_eq!(vm.execute_program().unwrap(), 0x4321);
 // }
 
 #[test]
@@ -380,8 +380,8 @@ fn test_vm_div32_high_divisor() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 }
 
 #[test]
@@ -394,8 +394,8 @@ fn test_vm_div32_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 }
 
 #[test]
@@ -409,8 +409,8 @@ fn test_vm_div32_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 }
 
 #[test]
@@ -424,8 +424,8 @@ fn test_vm_div64_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x300000000);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x300000000);
 }
 
 #[test]
@@ -440,8 +440,8 @@ fn test_vm_div64_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x300000000);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x300000000);
 }
 
 #[test]
@@ -455,8 +455,8 @@ fn test_vm_early_exit() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x3);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x3);
 }
 
 // uBPF limits the number of user functions at 64. We don't.
@@ -479,8 +479,8 @@ fn test_vm_err_call_unreg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[]).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.execute_program().unwrap();
 }
 
 #[test]
@@ -495,8 +495,8 @@ fn test_vm_err_div64_by_zero_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[]).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.execute_program().unwrap();
 }
 
 #[test]
@@ -511,8 +511,8 @@ fn test_vm_err_div_by_zero_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[]).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.execute_program().unwrap();
 }
 
 #[test]
@@ -527,8 +527,8 @@ fn test_vm_err_mod64_by_zero_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[]).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.execute_program().unwrap();
 }
 
 #[test]
@@ -543,8 +543,8 @@ fn test_vm_err_mod_by_zero_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[]).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.execute_program().unwrap();
 }
 
 // With the introduction of call frames there may be stack regions
@@ -560,8 +560,8 @@ fn test_vm_err_stack_out_of_bound() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    vm.execute_program(&[], &[]).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.execute_program().unwrap();
 }
 
 #[test]
@@ -573,8 +573,8 @@ fn test_vm_exit() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }
 
 #[test]
@@ -588,8 +588,8 @@ fn test_vm_ja() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -607,8 +607,8 @@ fn test_vm_jeq_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -627,8 +627,8 @@ fn test_vm_jeq_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -646,8 +646,8 @@ fn test_vm_jge_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -666,8 +666,8 @@ fn test_vm_jle_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -688,8 +688,8 @@ fn test_vm_jle_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -707,8 +707,8 @@ fn test_vm_jgt_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -728,8 +728,8 @@ fn test_vm_jgt_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -747,8 +747,8 @@ fn test_vm_jlt_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -768,8 +768,8 @@ fn test_vm_jlt_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -786,8 +786,8 @@ fn test_vm_jit_bounce() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -806,8 +806,8 @@ fn test_vm_jne_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -825,8 +825,8 @@ fn test_vm_jset_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -845,8 +845,8 @@ fn test_vm_jset_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -865,8 +865,8 @@ fn test_vm_jsge_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -887,8 +887,8 @@ fn test_vm_jsge_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -907,8 +907,8 @@ fn test_vm_jsle_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -930,8 +930,8 @@ fn test_vm_jsle_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -949,8 +949,8 @@ fn test_vm_jsgt_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -969,8 +969,8 @@ fn test_vm_jsgt_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -988,8 +988,8 @@ fn test_vm_jslt_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -1009,8 +1009,8 @@ fn test_vm_jslt_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -1021,8 +1021,8 @@ fn test_vm_lddw() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1122334455667788);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -1034,8 +1034,8 @@ fn test_vm_lddw2() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x80000000);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x80000000);
 }
 
 #[test]
@@ -1080,8 +1080,8 @@ fn test_vm_ldxb_all() {
         0x08, 0x09, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x9876543210);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x9876543210);
 }
 
 #[test]
@@ -1094,8 +1094,8 @@ fn test_vm_ldxb() {
     .unwrap();
     let mem = &mut [0xaa, 0xbb, 0x11, 0xcc, 0xdd];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11);
 }
 
 #[test]
@@ -1111,8 +1111,8 @@ fn test_vm_ldxdw() {
         0x77, 0x88, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x8877665544332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -1129,8 +1129,8 @@ fn test_vm_ldxdw_oob() {
         0x77, 0x88, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x8877665544332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -1186,8 +1186,8 @@ fn test_vm_ldxh_all() {
         0x00, 0x08, 0x00, 0x09, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x9876543210);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x9876543210);
 }
 
 #[test]
@@ -1233,8 +1233,8 @@ fn test_vm_ldxh_all2() {
         0x01, 0x00, 0x02, 0x00, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x3ff);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x3ff);
 }
 
 #[test]
@@ -1249,8 +1249,8 @@ fn test_vm_ldxh() {
         0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x2211);
 }
 
 #[test]
@@ -1265,8 +1265,8 @@ fn test_vm_ldxh_same_reg() {
     .unwrap();
     let mem = &mut [0xff, 0xff];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1234);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1234);
 }
 
 #[test]
@@ -1314,8 +1314,8 @@ fn test_vm_ldxw_all() {
         0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x030f0f);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x030f0f);
 }
 
 #[test]
@@ -1330,8 +1330,8 @@ fn test_vm_ldxw() {
         0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1345,8 +1345,8 @@ fn test_vm_le16() {
     .unwrap();
     let mem = &mut [0x22, 0x11];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1122);
 }
 
 #[test]
@@ -1362,8 +1362,8 @@ fn test_vm_le32() {
         0x44, 0x33, 0x22, 0x11, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11223344);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11223344);
 }
 
 #[test]
@@ -1379,8 +1379,8 @@ fn test_vm_le64() {
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1122334455667788);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1122334455667788);
 }
 
 #[test]
@@ -1394,8 +1394,8 @@ fn test_vm_lsh_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x10);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x10);
 }
 
 #[test]
@@ -1410,8 +1410,8 @@ fn test_vm_mod() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x5);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x5);
 }
 
 #[test]
@@ -1424,8 +1424,8 @@ fn test_vm_mod32() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }
 
 #[test]
@@ -1444,8 +1444,8 @@ fn test_vm_mod64() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x30ba5a04);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x30ba5a04);
 }
 
 #[test]
@@ -1458,8 +1458,8 @@ fn test_vm_mov() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -1471,8 +1471,8 @@ fn test_vm_mov32_imm_large() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffffffff);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xffffffff);
 }
 
 #[test]
@@ -1485,8 +1485,8 @@ fn test_vm_mov_large() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xffffffff);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xffffffff);
 }
 
 #[test]
@@ -1499,8 +1499,8 @@ fn test_vm_mul32_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xc);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xc);
 }
 
 #[test]
@@ -1514,8 +1514,8 @@ fn test_vm_mul32_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xc);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xc);
 }
 
 #[test]
@@ -1529,8 +1529,8 @@ fn test_vm_mul32_reg_overflow() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x4);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x4);
 }
 
 #[test]
@@ -1543,8 +1543,8 @@ fn test_vm_mul64_imm() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x100000004);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x100000004);
 }
 
 #[test]
@@ -1558,8 +1558,8 @@ fn test_vm_mul64_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x100000004);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x100000004);
 }
 
 #[test]
@@ -1579,8 +1579,8 @@ fn test_vm_mul_loop() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x75db9c97);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x75db9c97);
 }
 
 #[test]
@@ -1593,8 +1593,8 @@ fn test_vm_neg64() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffffffffffe);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xfffffffffffffffe);
 }
 
 #[test]
@@ -1607,8 +1607,8 @@ fn test_vm_neg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xfffffffe);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xfffffffe);
 }
 
 #[test]
@@ -1634,8 +1634,8 @@ fn test_vm_prime() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -1649,8 +1649,8 @@ fn test_vm_rhs32() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x00ffffff);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x00ffffff);
 }
 
 #[test]
@@ -1664,8 +1664,8 @@ fn test_vm_rsh_reg() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -1684,8 +1684,8 @@ fn test_vm_stack1() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0xcd);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xcd);
 }
 
 #[test]
@@ -1711,10 +1711,10 @@ fn test_vm_stack2() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
     vm.register_syscall(0, syscalls::gather_bytes).unwrap();
     vm.register_syscall(1, syscalls::memfrob).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x01020304);
+    assert_eq!(vm.execute_program().unwrap(), 0x01020304);
 }
 
 #[test]
@@ -1728,8 +1728,8 @@ fn test_vm_stb() {
     .unwrap();
     let mem = &mut [0xaa, 0xbb, 0xff, 0xcc, 0xdd];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11);
 }
 
 #[test]
@@ -1746,8 +1746,8 @@ fn test_vm_stdw() {
         0xff, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1763,8 +1763,8 @@ fn test_vm_sth() {
         0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x2211);
 }
 
 #[test]
@@ -1802,9 +1802,9 @@ fn test_vm_string_stack() {
     )
     .unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
     vm.register_syscall(4, syscalls::strcmp).unwrap();
-    assert_eq!(vm.execute_program(&[], &[]).unwrap(), 0x0);
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }
 
 #[test]
@@ -1820,8 +1820,8 @@ fn test_vm_stw() {
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x44332211);
 }
 
 #[test]
@@ -1838,8 +1838,8 @@ fn test_vm_stxb() {
         0xaa, 0xbb, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x11);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x11);
 }
 
 #[test]
@@ -1871,8 +1871,8 @@ fn test_vm_stxb_all() {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0xf0f2f3f4f5f6f7f8);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xf0f2f3f4f5f6f7f8);
 }
 
 #[test]
@@ -1891,8 +1891,8 @@ fn test_vm_stxb_all2() {
     .unwrap();
     let mem = &mut [0xff, 0xff];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0xf1f9);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0xf1f9);
 }
 
 #[test]
@@ -1927,8 +1927,8 @@ fn test_vm_stxb_chain() {
         0x00, 0x00, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2a);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x2a);
 }
 
 #[test]
@@ -1948,8 +1948,8 @@ fn test_vm_stxdw() {
         0xff, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x8877665544332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x8877665544332211);
 }
 
 #[test]
@@ -1966,8 +1966,8 @@ fn test_vm_stxh() {
         0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x2211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x2211);
 }
 
 #[test]
@@ -1984,8 +1984,8 @@ fn test_vm_stxw() {
         0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x44332211);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x44332211);
 }
 
 #[test]
@@ -2021,8 +2021,8 @@ fn test_vm_subnet() {
         0x03, 0x00, //
     ];
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 const PROG_TCP_PORT_80: [u8; 152] = [
@@ -2066,8 +2066,8 @@ fn test_vm_tcp_port80_match() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -2089,8 +2089,8 @@ fn test_vm_tcp_port80_nomatch() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x0);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }
 
 #[test]
@@ -2112,8 +2112,8 @@ fn test_vm_tcp_port80_nomatch_ethertype() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x0);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }
 
 #[test]
@@ -2135,8 +2135,8 @@ fn test_vm_tcp_port80_nomatch_proto() {
     ];
     let prog = &PROG_TCP_PORT_80;
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem, &[]).unwrap(), 0x0);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem, &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }
 
 #[test]
@@ -2144,8 +2144,8 @@ fn test_vm_tcp_sack_match() {
     let mut mem = TCP_SACK_MATCH.to_vec();
     let prog = assemble(TCP_SACK_ASM).unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem.as_mut_slice(), &[]).unwrap(), 0x1);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem.as_mut_slice(), &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x1);
 }
 
 #[test]
@@ -2153,6 +2153,6 @@ fn test_vm_tcp_sack_nomatch() {
     let mut mem = TCP_SACK_NOMATCH.to_vec();
     let prog = assemble(TCP_SACK_ASM).unwrap();
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref()).unwrap();
-    assert_eq!(vm.execute_program(mem.as_mut_slice(), &[]).unwrap(), 0x0);
+    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), mem.as_mut_slice(), &[]).unwrap();
+    assert_eq!(vm.execute_program().unwrap(), 0x0);
 }


### PR DESCRIPTION
Combines all regions into one `memory_mapping` which can be transported through the interpreter and JIT likewise,
so both can use `translate_addr` in memory_region.rs

- [x] Unify regions into `memory_mapping` struct
- [x] Use `memory_mapping` in JIT instead of linear `mem`
- [x] Reduce registers needed to call `MemoryMapping::translate_addr` by setting pc after an error occurred
- [x] Enable unified `EbpfError::AccessViolation` tests
- [x] Pass `memory_mapping` to syscalls in JIT
- [x] Initialize registers in JIT
- [x] Separate initialization of `memory_mapping` in `vm` so it can also be used by JIT