### PR TITLE
JIT BPF Stack Guard

### DIFF
--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -1,7 +1,7 @@
 //! Call frame handler
 
 use crate::{
-    ebpf::{MM_STACK_START, SCRATCH_REGS},
+    ebpf::{ELF_INSN_DUMP_OFFSET, MM_STACK_START, SCRATCH_REGS},
     error::{EbpfError, UserDefinedError},
     memory_region::MemoryRegion,
 };
@@ -93,7 +93,10 @@ impl CallFrames {
         return_ptr: usize,
     ) -> Result<u64, EbpfError<E>> {
         if self.frame + 1 >= self.frames.len() {
-            return Err(EbpfError::CallDepthExceeded(self.frames.len()));
+            return Err(EbpfError::CallDepthExceeded(
+                return_ptr + ELF_INSN_DUMP_OFFSET - 1,
+                self.frames.len(),
+            ));
         }
         self.frames[self.frame].saved_reg[..].copy_from_slice(saved_reg);
         self.frames[self.frame].return_ptr = return_ptr;

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,8 +38,8 @@ pub enum EbpfError<E: UserDefinedError> {
     #[error("no program or ELF set")]
     NothingToExecute,
     /// Exceeded max BPF to BPF call depth
-    #[error("exceeded max BPF to BPF call depth of {0}")]
-    CallDepthExceeded(usize),
+    #[error("exceeded max BPF to BPF call depth of {1} at instruction #{0}")]
+    CallDepthExceeded(usize, usize),
     /// Attempt to exit from root call frame
     #[error("attempted to exit root call frame")]
     ExitRootCallFrame,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -23,7 +23,7 @@ use std::ops::{Index, IndexMut};
 
 use crate::{
     vm::{Executable, Syscall},
-    call_frames::CALL_FRAME_SIZE,
+    call_frames::{CALL_FRAME_SIZE, MAX_CALL_DEPTH},
     ebpf::{self, INSN_SIZE, FIRST_SCRATCH_REG, SCRATCH_REGS, STACK_REG, MM_STACK_START, MM_PROGRAM_START},
     error::{UserDefinedError, EbpfError},
     memory_region::{AccessType, MemoryMapping},
@@ -81,9 +81,10 @@ pub enum JITError {
 const TARGET_OFFSET: isize = ebpf::PROG_MAX_INSNS as isize;
 const TARGET_PC_EXIT: isize = TARGET_OFFSET + 1;
 const TARGET_PC_EPILOGUE: isize = TARGET_OFFSET + 2;
-const TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT: isize = TARGET_OFFSET + 3;
-const TARGET_PC_DIV_BY_ZERO: isize = TARGET_OFFSET + 4;
-const TARGET_PC_EXCEPTION_AT: isize = TARGET_OFFSET + 5;
+const TARGET_PC_CALL_DEPTH_EXCEEDED: isize = TARGET_OFFSET + 3;
+const TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT: isize = TARGET_OFFSET + 4;
+const TARGET_PC_DIV_BY_ZERO: isize = TARGET_OFFSET + 5;
+const TARGET_PC_EXCEPTION_AT: isize = TARGET_OFFSET + 6;
 
 #[derive(Copy, Clone)]
 enum OperandSize {
@@ -471,10 +472,10 @@ fn emit_bpf_call(jit: &mut JitMemory, dst: Value, number_of_instructions: usize,
             // Force alignment of RAX
             emit_alu64_imm32(jit, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i32 - 1)); // RAX &= !(INSN_SIZE - 1);
             // Upper bound check
-            // if(RAX > MM_PROGRAM_START + (number_of_instructions - 1) * INSN_SIZE) throw CALL_OUTSIDE_TEXT_SEGMENT;
-            emit_load_imm(jit, REGISTER_MAP[STACK_REG], MM_PROGRAM_START as i64 + ((number_of_instructions - 1) * INSN_SIZE) as i64);
+            // if(RAX >= MM_PROGRAM_START + number_of_instructions * INSN_SIZE) throw CALL_OUTSIDE_TEXT_SEGMENT;
+            emit_load_imm(jit, REGISTER_MAP[STACK_REG], MM_PROGRAM_START as i64 + (number_of_instructions * INSN_SIZE) as i64);
             emit_cmp(jit, REGISTER_MAP[STACK_REG], REGISTER_MAP[0]);
-            emit_jcc(jit, 0x87, TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT);
+            emit_jcc(jit, 0x83, TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT);
             // Lower bound check
             // if(RAX < MM_PROGRAM_START) throw CALL_OUTSIDE_TEXT_SEGMENT;
             emit_load_imm(jit, REGISTER_MAP[STACK_REG], MM_PROGRAM_START as i64);
@@ -495,6 +496,13 @@ fn emit_bpf_call(jit: &mut JitMemory, dst: Value, number_of_instructions: usize,
     emit_alu64_imm32(jit, 0x81, 4, REGISTER_MAP[STACK_REG], !(CALL_FRAME_SIZE as i32 * 2 - 1)); // stack_ptr &= !(CALL_FRAME_SIZE * 2 - 1);
     emit_alu64_imm32(jit, 0x81, 0, REGISTER_MAP[STACK_REG], CALL_FRAME_SIZE as i32 * 3); // stack_ptr += CALL_FRAME_SIZE * 3;
     emit_store(jit, OperandSize::S64, REGISTER_MAP[STACK_REG], RBP, -8 * CALLEE_SAVED_REGISTERS.len() as i32); // store stack_ptr
+
+    // if(stack_ptr >= MM_STACK_START + MAX_CALL_DEPTH * CALL_FRAME_SIZE * 2) throw EbpfError::CallDepthExeeded;
+    emit_mov(jit, REGISTER_MAP[0], R11);
+    emit_load_imm(jit, REGISTER_MAP[0], MM_STACK_START as i64 + (MAX_CALL_DEPTH * CALL_FRAME_SIZE * 2) as i64);
+    emit_cmp(jit, REGISTER_MAP[0], REGISTER_MAP[STACK_REG]);
+    emit_mov(jit, R11, REGISTER_MAP[0]);
+    emit_jcc(jit, 0x83, TARGET_PC_CALL_DEPTH_EXCEEDED);
 
     match dst {
         Value::Register(_reg) => {
@@ -720,6 +728,10 @@ impl<'a> JitMemory<'a> {
         // Initialize and save BPF stack pointer
         emit_load_imm(self, REGISTER_MAP[STACK_REG], MM_STACK_START as i64 + CALL_FRAME_SIZE as i64);
         emit_push(self, REGISTER_MAP[STACK_REG]);
+
+        // Padding on the stack to reach 16 byte alignment
+        emit_load_imm(self, R11, 0);
+        emit_push(self, R11);
 
         // Initialize other registers
         for reg in REGISTER_MAP.iter() {
@@ -1132,6 +1144,18 @@ impl<'a> JitMemory<'a> {
         }
 
         emit1(self, 0xc3); // ret
+
+        // Handler for EbpfError::CallDepthExceeded
+        set_anchor(self, TARGET_PC_CALL_DEPTH_EXCEEDED);
+        let err = Result::<u64, EbpfError<E>>::Err(EbpfError::CallDepthExceeded(0));
+        let err_kind = unsafe { *(&err as *const _ as *const u64).offset(1) };
+        emit_load_imm(self, REGISTER_MAP[0], err_kind as i64);
+        emit_store(self, OperandSize::S64, REGISTER_MAP[0], RDI, 8); // err_kind = EbpfError::CallOutsideTextSegment
+        emit_load_imm(self, REGISTER_MAP[0], MAX_CALL_DEPTH as i64);
+        emit_store(self, OperandSize::S64, REGISTER_MAP[0], RDI, 16); // depth = MAX_CALL_DEPTH
+        emit_load_imm(self, REGISTER_MAP[0], 1);
+        emit_store(self, OperandSize::S64, REGISTER_MAP[0], RDI, 0); // is_err = true
+        emit_jmp(self, TARGET_PC_EPILOGUE);
 
         // Handler for EbpfError::CallOutsideTextSegment
         set_anchor(self, TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -468,7 +468,6 @@ fn emit_bpf_call(jit: &mut JitMemory, dst: Value, number_of_instructions: usize,
         Value::Register(reg) => {
             // Move vm target_address into RAX
             emit_mov(jit, reg, REGISTER_MAP[0]);
-            emit_push(jit, REGISTER_MAP[STACK_REG]);
             // Force alignment of RAX
             emit_alu64_imm32(jit, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i32 - 1)); // RAX &= !(INSN_SIZE - 1);
             // Upper bound check
@@ -486,7 +485,6 @@ fn emit_bpf_call(jit: &mut JitMemory, dst: Value, number_of_instructions: usize,
             // Load host target_address from JitProgramArgument.instruction_addresses
             emit_mov(jit, R10, REGISTER_MAP[STACK_REG]);
             emit_alu64(jit, 0x01, REGISTER_MAP[STACK_REG], REGISTER_MAP[0]); // RAX += &JitProgramArgument as *const _;
-            emit_pop(jit, REGISTER_MAP[STACK_REG]);
             emit_load(jit, OperandSize::S64, REGISTER_MAP[0], REGISTER_MAP[0], std::mem::size_of::<MemoryMapping>() as i32); // RAX = JitProgramArgument.instruction_addresses[RAX / 8];
         },
         Value::Constant(_target_pc) => {},

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -30,7 +30,7 @@ use crate::{
     user_error::UserError,
 };
 
-/// eBPF Jit-compiled program.
+/// Argument for executing a eBPF JIT-compiled program
 pub struct JitProgramArgument {
     /// The MemoryMapping to be used to run the compiled code
     pub memory_mapping: MemoryMapping,
@@ -38,7 +38,7 @@ pub struct JitProgramArgument {
     pub instruction_addresses: [*const u8; 1],
 }
 
-/// eBPF Jit-compiled program.
+/// eBPF JIT-compiled program
 pub struct JitProgram<E: UserDefinedError> {
     /// Call this with JitProgramArgument to execute the compiled code
     pub main: unsafe fn(u64, &JitProgramArgument) -> Result<u64, EbpfError<E>>,
@@ -461,35 +461,45 @@ fn emit_bpf_call(jit: &mut JitMemory, dst: Value, number_of_instructions: usize,
     }
     emit_push(jit, REGISTER_MAP[STACK_REG]);
 
-    emit_alu64_imm32(jit, 0x81, 4, REGISTER_MAP[STACK_REG], !(CALL_FRAME_SIZE as i32 * 2 - 1)); // stack_ptr &= !(CALL_FRAME_SIZE * 2 - 1);
-    emit_alu64_imm32(jit, 0x81, 0, REGISTER_MAP[STACK_REG], CALL_FRAME_SIZE as i32 * 3); // stack_ptr += CALL_FRAME_SIZE * 3;
+    // Store PC in case the bounds check fails
+    emit_load_imm(jit, R11, pc as i64 + ebpf::ELF_INSN_DUMP_OFFSET as i64);
 
     match dst {
         Value::Register(reg) => {
             // Move vm target_address into RAX
-            emit_mov(jit, reg, RAX);
-            emit_push(jit, RBX);
-            // Store PC in case the bounds check fails
-            emit_load_imm(jit, R11, pc as i64 + ebpf::ELF_INSN_DUMP_OFFSET as i64);
+            emit_mov(jit, reg, REGISTER_MAP[0]);
+            emit_push(jit, REGISTER_MAP[STACK_REG]);
             // Force alignment of RAX
-            emit_alu64_imm32(jit, 0x81, 4, RAX, !7); // RAX &= !(8 - 1);
+            emit_alu64_imm32(jit, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i32 - 1)); // RAX &= !(INSN_SIZE - 1);
             // Upper bound check
             // if(RAX > MM_PROGRAM_START + (number_of_instructions - 1) * INSN_SIZE) throw CALL_OUTSIDE_TEXT_SEGMENT;
-            emit_load_imm(jit, RBX, MM_PROGRAM_START as i64 + ((number_of_instructions - 1) * INSN_SIZE) as i64);
-            emit_cmp(jit, RBX, RAX);
+            emit_load_imm(jit, REGISTER_MAP[STACK_REG], MM_PROGRAM_START as i64 + ((number_of_instructions - 1) * INSN_SIZE) as i64);
+            emit_cmp(jit, REGISTER_MAP[STACK_REG], REGISTER_MAP[0]);
             emit_jcc(jit, 0x87, TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT);
             // Lower bound check
             // if(RAX < MM_PROGRAM_START) throw CALL_OUTSIDE_TEXT_SEGMENT;
-            emit_load_imm(jit, RBX, MM_PROGRAM_START as i64);
-            emit_cmp(jit, RBX, RAX);
+            emit_load_imm(jit, REGISTER_MAP[STACK_REG], MM_PROGRAM_START as i64);
+            emit_cmp(jit, REGISTER_MAP[STACK_REG], REGISTER_MAP[0]);
             emit_jcc(jit, 0x82, TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT);
             // Calculate offset relative to instruction_addresses
-            emit_alu64(jit, 0x29, RBX, RAX); // RAX -= MM_PROGRAM_START;
+            emit_alu64(jit, 0x29, REGISTER_MAP[STACK_REG], REGISTER_MAP[0]); // RAX -= MM_PROGRAM_START;
             // Load host target_address from JitProgramArgument.instruction_addresses
-            emit_mov(jit, R10, RBX);
-            emit_alu64(jit, 0x01, RBX, RAX); // RAX += &JitProgramArgument as *const _;
-            emit_pop(jit, RBX);
-            emit_load(jit, OperandSize::S64, RAX, RAX, std::mem::size_of::<MemoryMapping>() as i32); // RAX = JitProgramArgument.instruction_addresses[RAX / 8];
+            emit_mov(jit, R10, REGISTER_MAP[STACK_REG]);
+            emit_alu64(jit, 0x01, REGISTER_MAP[STACK_REG], REGISTER_MAP[0]); // RAX += &JitProgramArgument as *const _;
+            emit_pop(jit, REGISTER_MAP[STACK_REG]);
+            emit_load(jit, OperandSize::S64, REGISTER_MAP[0], REGISTER_MAP[0], std::mem::size_of::<MemoryMapping>() as i32); // RAX = JitProgramArgument.instruction_addresses[RAX / 8];
+        },
+        Value::Constant(_target_pc) => {},
+        _ => panic!()
+    }
+
+    emit_load(jit, OperandSize::S64, RBP, REGISTER_MAP[STACK_REG], -8 * CALLEE_SAVED_REGISTERS.len() as i32); // load stack_ptr
+    emit_alu64_imm32(jit, 0x81, 4, REGISTER_MAP[STACK_REG], !(CALL_FRAME_SIZE as i32 * 2 - 1)); // stack_ptr &= !(CALL_FRAME_SIZE * 2 - 1);
+    emit_alu64_imm32(jit, 0x81, 0, REGISTER_MAP[STACK_REG], CALL_FRAME_SIZE as i32 * 3); // stack_ptr += CALL_FRAME_SIZE * 3;
+    emit_store(jit, OperandSize::S64, REGISTER_MAP[STACK_REG], RBP, -8 * CALLEE_SAVED_REGISTERS.len() as i32); // store stack_ptr
+
+    match dst {
+        Value::Register(_reg) => {
             // callq *%rax
             emit1(jit, 0xff);
             emit1(jit, 0xd0);
@@ -706,9 +716,14 @@ impl<'a> JitMemory<'a> {
             }
         }
 
-        // Initialize registers
-        emit_mov(self, ARGUMENT_REGISTERS[2], R10); // JitProgramArgument
+        // Save JitProgramArgument
+        emit_mov(self, ARGUMENT_REGISTERS[2], R10);
+
+        // Initialize and save BPF stack pointer
         emit_load_imm(self, REGISTER_MAP[STACK_REG], MM_STACK_START as i64 + CALL_FRAME_SIZE as i64);
+        emit_push(self, REGISTER_MAP[STACK_REG]);
+
+        // Initialize other registers
         for reg in REGISTER_MAP.iter() {
             if *reg != REGISTER_MAP[1] && *reg != REGISTER_MAP[STACK_REG] {
                 emit_load_imm(self, *reg, 0);
@@ -1074,8 +1089,10 @@ impl<'a> JitMemory<'a> {
                     emit_bpf_call(self, Value::Register(REGISTER_MAP[insn.imm as usize]), prog.len() / ebpf::INSN_SIZE, insn_ptr);
                 },
                 ebpf::EXIT      => {
+                    emit_load(self, OperandSize::S64, RBP, REGISTER_MAP[STACK_REG], -8 * CALLEE_SAVED_REGISTERS.len() as i32); // load stack_ptr
                     emit_alu64_imm32(self, 0x81, 4, REGISTER_MAP[STACK_REG], !(CALL_FRAME_SIZE as i32 * 2 - 1)); // stack_ptr &= !(CALL_FRAME_SIZE * 2 - 1);
                     emit_alu64_imm32(self, 0x81, 5, REGISTER_MAP[STACK_REG], CALL_FRAME_SIZE as i32 * 2); // stack_ptr -= CALL_FRAME_SIZE * 2;
+                    emit_store(self, OperandSize::S64, REGISTER_MAP[STACK_REG], RBP, -8 * CALLEE_SAVED_REGISTERS.len() as i32); // store stack_ptr
 
                     // if(stack_ptr < MM_STACK_START) goto exit;
                     emit_mov(self, REGISTER_MAP[0], R11);

--- a/tests/ubpf_unified.rs
+++ b/tests/ubpf_unified.rs
@@ -2166,8 +2166,8 @@ fn test_vm_jit_err_bpf_to_bpf_too_deep() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::CallDepthExceeded(depth)
-                    if depth == MAX_CALL_DEPTH
+                    EbpfError::CallDepthExceeded(pc, depth)
+                    if pc == 55 && depth == MAX_CALL_DEPTH
                 )
             }
         }
@@ -2189,8 +2189,8 @@ fn test_vm_jit_err_reg_stack_depth() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::CallDepthExceeded(depth)
-                    if depth == MAX_CALL_DEPTH
+                    EbpfError::CallDepthExceeded(pc, depth)
+                    if pc == 31 && depth == MAX_CALL_DEPTH
                 )
             }
         }

--- a/tests/ubpf_unified.rs
+++ b/tests/ubpf_unified.rs
@@ -15,6 +15,7 @@ use common::{PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH};
 use libc::c_char;
 use solana_rbpf::{
     assembler::assemble,
+    call_frames::MAX_CALL_DEPTH,
     ebpf::hash_symbol_name,
     elf::ELFError,
     error::EbpfError,
@@ -2134,6 +2135,62 @@ fn test_vm_jit_err_oob_callx_high() {
                 matches!(res.unwrap_err(),
                     EbpfError::CallOutsideTextSegment(pc, target_pc)
                     if pc == 31 && target_pc == 0xffffffff00000000
+                )
+            }
+        }
+    );
+}
+
+#[test]
+fn test_vm_jit_bpf_to_bpf_depth() {
+    for i in 0..MAX_CALL_DEPTH {
+        test_vm_and_jit_elf!(
+            "tests/elfs/multiple_file.so",
+            [i as u8],
+            (
+                hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+            ),
+            { |res: ExecResult| { res.unwrap() == 0 } }
+        );
+    }
+}
+
+#[test]
+fn test_vm_jit_err_bpf_to_bpf_too_deep() {
+    test_vm_and_jit_elf!(
+        "tests/elfs/multiple_file.so",
+        [MAX_CALL_DEPTH as u8],
+        (
+            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+        ),
+        {
+            |res: ExecResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::CallDepthExceeded(depth)
+                    if depth == MAX_CALL_DEPTH
+                )
+            }
+        }
+    );
+}
+
+#[test]
+fn test_vm_jit_err_reg_stack_depth() {
+    test_vm_and_jit_asm!(
+        "
+        mov64 r0, 0x1
+        lsh64 r0, 0x20
+        callx 0x0
+        exit",
+        [],
+        (
+            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+        ),
+        {
+            |res: ExecResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::CallDepthExceeded(depth)
+                    if depth == MAX_CALL_DEPTH
                 )
             }
         }


### PR DESCRIPTION
* Protect against manipulation of the BPF stack pointer. Stores it on the JITs stack frame as a local variable, and resets the BPF stack pointer on every `call` and `exit` (return).

* Trigger exception on stack overflow.