### PR TITLE
JIT Instruction Meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ therefore must use specific syscall numbers.
 
 ```rust,ignore
 // for struct EbpfVm
-pub fn execute_program(&mut self) -> Result<(u64), Error>
+pub fn execute_program_interpreted<I: InstructionMeter>(
+    &mut self,
+    instruction_meter: &mut I) -> Result<(u64), Error>
 ```
 
 Interprets the loaded program. The function takes a reference to the packet
@@ -170,14 +172,16 @@ is called. The generated assembly function is internally stored in the VM.
 
 ```rust,ignore
 // for struct EbpfVm
-pub unsafe fn execute_program_jit(&self) -> Result<(u64), Error>
+pub unsafe fn execute_program_jit<I: InstructionMeter>(
+    &self,
+    instruction_meter: &mut I) -> Result<(u64), Error>
 ```
 
 Calls the JIT-compiled program. The arguments to provide are the same as for
-`execute_program()`, again depending on the kind of VM that is used. The result of
-the JIT-compiled program should be the same as with the interpreter, but it
-should run faster. Note that if errors occur during the program execution, the
-JIT-compiled version does not handle it as well as the interpreter, and the
+`execute_program_interpreted()`, again depending on the kind of VM that is used.
+The result of the JIT-compiled program should be the same as with the interpreter,
+but it should run faster. Note that if errors occur during the program execution,
+the JIT-compiled version does not handle it as well as the interpreter, and the
 program may crash. For this reason, the functions are marked as `unsafe`.
 
 ## Example uses
@@ -206,7 +210,9 @@ fn main() {
     let vm = rbpf::EbpfVm::new(prog, &[]. &[]).unwrap();
 
     // Execute (interpret) the program.
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(vm.execute_program_interpreted(
+        &mut rbpf::EbpfVm::DefaultInstructionMeter {}
+    ).unwrap(), 0x3);
 }
 ```
 

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -71,7 +71,6 @@ fn main() {
     #[cfg(not(windows))]
     {
         vm.jit_compile().unwrap();
-
         time = unsafe {
             vm.execute_program_jit(&mut DefaultInstructionMeter {})
                 .unwrap()
@@ -80,7 +79,9 @@ fn main() {
 
     #[cfg(windows)]
     {
-        time = vm.execute_program().unwrap();
+        time = vm
+            .execute_program_interpreted(&mut DefaultInstructionMeter {})
+            .unwrap();
     }
 
     let days = time / 10u64.pow(9) / 60 / 60 / 24;

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -8,7 +8,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     syscalls,
     user_error::UserError,
-    vm::{EbpfVm, Syscall},
+    vm::{DefaultInstructionMeter, EbpfVm, Syscall},
 };
 
 // The main objectives of this example is to show:
@@ -45,7 +45,11 @@ fn main() {
     let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog1, None).unwrap();
     let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
     // Execute prog1.
-    assert_eq!(vm.execute_program().unwrap(), 0x3);
+    assert_eq!(
+        vm.execute_program_interpreted(&mut DefaultInstructionMeter {})
+            .unwrap(),
+        0x3
+    );
 
     // We know prog1 will always return 3. There is an exception: when it uses
     // syscalls, the latter may have non-deterministic values, and all calls may not return the same
@@ -68,7 +72,10 @@ fn main() {
     {
         vm.jit_compile().unwrap();
 
-        time = unsafe { vm.execute_program_jit().unwrap() };
+        time = unsafe {
+            vm.execute_program_jit(&mut DefaultInstructionMeter {})
+                .unwrap()
+        };
     }
 
     #[cfg(windows)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,8 +55,8 @@ pub enum EbpfError<E: UserDefinedError> {
     #[error("unresolved symbol at instruction #{0}")]
     UnresolvedSymbol(usize),
     /// Exceeded max instructions allowed
-    #[error("exceeded maximum number of instructions allowed ({0})")]
-    ExceededMaxInstructions(u64),
+    #[error("exceeded maximum number of instructions allowed ({1}) at instruction #{0}")]
+    ExceededMaxInstructions(usize, u64),
     /// JIT does not support read only data
     #[error("JIT does not support read only data")]
     ReadOnlyDataUnsupported,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -652,11 +652,7 @@ fn muldivmod(jit: &mut JitMemory, pc: u16, opc: u8, src: u8, dst: u8, imm: i32) 
 }
 
 fn profile_instruction_count(jit: &mut JitMemory, instruction_count: usize) {
-    emit_mov(jit, REGISTER_MAP[0], R11);
-    emit_load(jit, OperandSize::S64, RBP, REGISTER_MAP[0], -8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32); // load instruction_meter
-    emit_alu64_imm32(jit, 0x81, 0, REGISTER_MAP[0], instruction_count as i32); // instruction_meter += instruction_count;
-    emit_store(jit, OperandSize::S64, REGISTER_MAP[0], RBP, -8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32); // store instruction_meter
-    emit_mov(jit, R11, REGISTER_MAP[0]);
+    emit_alu(jit, 1, 0x81, 0, RBP, instruction_count as i32, Some(-8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32)); // instruction_meter += instruction_count;
     // TODO: Throw if depleted
 }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -513,12 +513,12 @@ fn emit_bpf_call(jit: &mut JitMemory, dst: Value, number_of_instructions: usize)
             emit_alu(jit, OperationWidth::Bit64, 0x29, REGISTER_MAP[STACK_REG], REGISTER_MAP[0], 0, None); // RAX -= MM_PROGRAM_START;
             // Calculate the target_pc to update the instruction_meter
             let shift_amount = INSN_SIZE.trailing_zeros();
-            assert!(INSN_SIZE == 1<<shift_amount);
+            assert_eq!(INSN_SIZE, 1<<shift_amount);
             emit_mov(jit, REGISTER_MAP[0], REGISTER_MAP[STACK_REG]);
             emit_alu(jit, OperationWidth::Bit64, 0xc1, 5, REGISTER_MAP[STACK_REG], shift_amount as i32, None);
             emit_push(jit, REGISTER_MAP[STACK_REG]);
             // Load host target_address from JitProgramArgument.instruction_addresses
-            assert!(INSN_SIZE == 8); // Because the instruction size is also the slot size we do not need to shift the offset
+            assert_eq!(INSN_SIZE, 8); // Because the instruction size is also the slot size we do not need to shift the offset
             emit_mov(jit, REGISTER_MAP[0], REGISTER_MAP[STACK_REG]);
             emit_mov(jit, R10, REGISTER_MAP[STACK_REG]);
             emit_alu(jit, OperationWidth::Bit64, 0x01, REGISTER_MAP[STACK_REG], REGISTER_MAP[0], 0, None); // RAX += &JitProgramArgument as *const _;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -832,6 +832,7 @@ impl<'a> JitMemory<'a> {
                 },
 
                 ebpf::LD_DW_IMM  => {
+                    profile_instruction_count(self, Value::Constant(self.pc as i64 + 2));
                     self.pc += 1;
                     let second_part = ebpf::get_insn(prog, self.pc).imm as u64;
                     let imm = (insn.imm as u32) as u64 | second_part.wrapping_shl(32);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -448,8 +448,8 @@ fn emit_profile_instruction_count(jit: &mut JitCompiler, target_pc: Option<usize
 #[inline]
 fn emit_validate_and_profile_instruction_count(jit: &mut JitCompiler, target_pc: Option<usize>) {
     if jit.enable_instruction_meter {
-        emit_cmp_imm32(jit, RBP, jit.pc as i32 + 1, Some(-8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32));
-        emit_load_imm(jit, R11, jit.pc as i64);
+        emit_load(jit, OperandSize::S64, RBP, R11, -8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32);
+        emit_cmp_imm32(jit, R11, jit.pc as i32 + 1, None);
         emit_jcc(jit, 0x82, TARGET_PC_CALL_EXCEEDED_MAX_INSTRUCTIONS);
         emit_profile_instruction_count(jit, target_pc);
     }
@@ -748,7 +748,7 @@ struct JitCompiler<'a> {
 
 impl<'a> JitCompiler<'a> {
     // num_pages is unused on windows
-    fn new(_num_pages: usize, enable_instruction_meter: bool) -> JitCompiler<'a> {
+    fn new(_num_pages: usize, _enable_instruction_meter: bool) -> JitCompiler<'a> {
         #[cfg(windows)]
         {
             panic!("JIT not supported on windows");
@@ -772,7 +772,7 @@ impl<'a> JitCompiler<'a> {
             pc_locs: vec![],
             jumps: vec![],
             special_targets: HashMap::new(),
-            enable_instruction_meter,
+            enable_instruction_meter: _enable_instruction_meter,
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -757,7 +757,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
         let compiled_prog = self
             .compiled_prog
             .as_ref()
-            .ok_or_else(|| EbpfError::JITNotCompiled)?;
+            .ok_or(EbpfError::JITNotCompiled)?;
         let mut jit_arg: Vec<*const u8> =
             vec![std::ptr::null(); 2 + compiled_prog.instruction_addresses.len()];
         libc::memcpy(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -762,7 +762,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
                     std::mem::size_of::<MemoryMapping>(),
                 );
                 jit_arg[2..].copy_from_slice(&compiled_prog.instruction_addresses[..]);
-                (compiled_prog.main)(reg1, &*(jit_arg.as_ptr() as *const JitProgramArgument))
+                (compiled_prog.main)(reg1, &*(jit_arg.as_ptr() as *const JitProgramArgument), 0x1000)
             }
             None => Err(EbpfError::JITNotCompiled),
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -675,7 +675,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
                 _ => return Err(EbpfError::UnsupportedInstruction(pc + ebpf::ELF_INSN_DUMP_OFFSET)),
             }
             if self.last_insn_count >= remaining_insn_count {
-                return Err(EbpfError::ExceededMaxInstructions(self.total_insn_count));
+                return Err(EbpfError::ExceededMaxInstructions(pc + ebpf::ELF_INSN_DUMP_OFFSET, self.total_insn_count));
             }
         }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -762,7 +762,11 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
                     std::mem::size_of::<MemoryMapping>(),
                 );
                 jit_arg[2..].copy_from_slice(&compiled_prog.instruction_addresses[..]);
-                (compiled_prog.main)(reg1, &*(jit_arg.as_ptr() as *const JitProgramArgument), 0x1000)
+                (compiled_prog.main)(
+                    reg1,
+                    &*(jit_arg.as_ptr() as *const JitProgramArgument),
+                    0x1000,
+                )
             }
             None => Err(EbpfError::JITNotCompiled),
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -732,7 +732,7 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
     }
 
     /// Execute the previously JIT-compiled program, with the given packet data in a manner
-    /// very similar to `execute_program()`.
+    /// very similar to `execute_program_interpreted()`.
     ///
     /// # Safety
     ///

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -727,7 +727,12 @@ impl<'a, E: UserDefinedError> EbpfVm<'a, E> {
     /// vm.jit_compile();
     /// ```
     pub fn jit_compile(&mut self) -> Result<(), EbpfError<E>> {
-        self.compiled_prog = Some(jit::compile(self.prog, self.executable, &self.syscalls)?);
+        self.compiled_prog = Some(jit::compile(
+            self.prog,
+            self.executable,
+            &self.syscalls,
+            true,
+        )?);
         Ok(())
     }
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -215,7 +215,7 @@ impl InstructionMeter for TestInstructionMeter {
 }
 
 #[test]
-#[should_panic(expected = "ExceededMaxInstructions(1000)")]
+#[should_panic(expected = "ExceededMaxInstructions(36, 1000)")]
 fn test_non_terminating() {
     let prog = assemble(
         "
@@ -323,7 +323,7 @@ fn test_get_total_instruction_count_with_syscall() {
 }
 
 #[test]
-#[should_panic(expected = "ExceededMaxInstructions(3)")]
+#[should_panic(expected = "ExceededMaxInstructions(31, 3)")]
 fn test_get_total_instruction_count_with_syscall_capped() {
     let prog = assemble(
         "


### PR DESCRIPTION
The instruction meter is only validated and updated on branching instructions.

- [x] Branches
  - [x] Unconditional Branches / Jumps
  - [x] Conditional Branches
  - [x] Exceptions
  - [x] Call
  - [x] Return / Exit
- [x] Special treatment of `LD_DW_IMM`, which takes two slots but counts as one instruction only
- [x] `InstructionMeter` object
- [x] Unification of interpreter and JIT interfaces: `execute_program_interpreted` and `execute_program_jit`
- [x] Comparison of final instruction meter in unified tests
