### PR TITLE
JIT Consuming Instruction Meter in Syscalls

### DIFF
--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -8,7 +8,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     syscalls,
     user_error::UserError,
-    vm::{DefaultInstructionMeter, EbpfVm, Syscall},
+    vm::{DefaultInstructionMeter, EbpfVm, Executable, Syscall},
 };
 
 // The main objectives of this example is to show:
@@ -42,8 +42,9 @@ fn main() {
     ];
 
     // Create a VM: this one takes no data. Load prog1 in it.
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog1, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    let executable = Executable::<UserError>::from_text_bytes(prog1, None).unwrap();
+    let mut vm =
+        EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
     // Execute prog1.
     assert_eq!(
         vm.execute_program_interpreted(&mut DefaultInstructionMeter {})
@@ -58,8 +59,9 @@ fn main() {
     // In the following example we use a syscall to get the elapsed time since boot time: we
     // reimplement uptime in eBPF, in Rust. Because why not.
 
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(prog2, None).unwrap();
-    let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+    let executable = Executable::<UserError>::from_text_bytes(prog2, None).unwrap();
+    let mut vm =
+        EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
     vm.register_syscall(
         syscalls::BPF_KTIME_GETNS_IDX,
         Syscall::Function(syscalls::bpf_time_getns),

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,8 +55,8 @@ pub enum EbpfError<E: UserDefinedError> {
     #[error("unresolved symbol at instruction #{0}")]
     UnresolvedSymbol(usize),
     /// Exceeded max instructions allowed
-    #[error("exceeded maximum number of instructions allowed ({1}) at instruction #{0}")]
-    ExceededMaxInstructions(usize, u64),
+    #[error("exceeded maximum number of instructions allowed at instruction #{0}")]
+    ExceededMaxInstructions(usize),
     /// JIT does not support read only data
     #[error("JIT does not support read only data")]
     ReadOnlyDataUnsupported,

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,8 +55,8 @@ pub enum EbpfError<E: UserDefinedError> {
     #[error("unresolved symbol at instruction #{0}")]
     UnresolvedSymbol(usize),
     /// Exceeded max instructions allowed
-    #[error("exceeded maximum number of instructions allowed at instruction #{0}")]
-    ExceededMaxInstructions(usize),
+    #[error("exceeded maximum number of instructions allowed ({1}) at instruction #{0}")]
+    ExceededMaxInstructions(usize, u64),
     /// JIT does not support read only data
     #[error("JIT does not support read only data")]
     ReadOnlyDataUnsupported,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1240,7 +1240,7 @@ impl<'a> JitCompiler<'a> {
         // Handler for EbpfError::ExceededMaxInstructions
         set_anchor(self, TARGET_PC_CALL_EXCEEDED_MAX_INSTRUCTIONS);
         emit_mov(self, ARGUMENT_REGISTERS[0], R11);
-        set_exception_kind::<E>(self, EbpfError::ExceededMaxInstructions(0));
+        set_exception_kind::<E>(self, EbpfError::ExceededMaxInstructions(0, 0));
         emit_jmp(self, TARGET_PC_EXCEPTION_AT);
 
         // Handler for EbpfError::CallDepthExceeded

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -779,7 +779,6 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 &result,
                 reg1,
                 &*(compiled_prog_and_arg.argument.as_ptr() as *const JitProgramArgument),
-                remaining_insn_count,
                 instruction_meter,
             ) as i64) as u64;
         if self.total_insn_count > remaining_insn_count {

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -50,7 +50,9 @@ macro_rules! test_interpreter_and_jit {
             match vm.jit_compile() {
                 Err(err) => assert!(check_closure(Err(err))),
                 Ok(()) => {
-                    assert!(check_closure(unsafe { vm.execute_program_jit(&mut TestInstructionMeter { remaining: $expected_instruction_count }) }));
+                    let res = unsafe { vm.execute_program_jit(&mut TestInstructionMeter { remaining: $expected_instruction_count }) };
+                    println!("res={:?}", res);
+                    assert!(check_closure(res));
                     let instruction_count_jit = vm.get_total_instruction_count();
                     assert_eq!(instruction_count_interpreter, instruction_count_jit);
                 },
@@ -2593,8 +2595,8 @@ fn test_err_instruction_count_syscall_capped() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ExceededMaxInstructions(pc, instruction_count)
-                    if pc == 32 && instruction_count == 3
+                    EbpfError::ExceededMaxInstructions(pc)
+                    if pc == 32
                 )
             }
         },
@@ -2651,8 +2653,8 @@ fn test_err_non_terminate_capped() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ExceededMaxInstructions(pc, instruction_count)
-                    if pc == 35 && instruction_count == 6
+                    EbpfError::ExceededMaxInstructions(pc)
+                    if pc == 35
                 )
             }
         },
@@ -2681,8 +2683,8 @@ fn test_err_non_terminating_capped() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ExceededMaxInstructions(pc, instruction_count)
-                    if pc == 37 && instruction_count == 1000
+                    EbpfError::ExceededMaxInstructions(pc)
+                    if pc == 37
                 )
             }
         },

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2595,8 +2595,8 @@ fn test_err_instruction_count_syscall_capped() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ExceededMaxInstructions(pc)
-                    if pc == 32
+                    EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
+                    if pc == 32 && initial_insn_count == 3
                 )
             }
         },
@@ -2653,8 +2653,8 @@ fn test_err_non_terminate_capped() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ExceededMaxInstructions(pc)
-                    if pc == 35
+                    EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
+                    if pc == 35 && initial_insn_count == 6
                 )
             }
         },
@@ -2683,8 +2683,8 @@ fn test_err_non_terminating_capped() {
         {
             |res: ExecResult| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ExceededMaxInstructions(pc)
-                    if pc == 37
+                    EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
+                    if pc == 37 && initial_insn_count == 1000
                 )
             }
         },

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -25,7 +25,7 @@ use solana_rbpf::{
     syscalls,
     user_error::UserError,
     verifier::check,
-    vm::{DefaultInstructionMeter, EbpfVm, Syscall},
+    vm::{DefaultInstructionMeter, EbpfVm, Executable, Syscall},
 };
 use std::{fs::File, io::Read};
 
@@ -37,7 +37,7 @@ macro_rules! test_interpreter_and_jit {
         let check_closure = $check;
         let instruction_count_interpreter = {
             let mem = $mem;
-            let mut vm = EbpfVm::<UserError>::new($executable.as_ref(), &mem, &[]).unwrap();
+            let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new($executable.as_ref(), &mem, &[]).unwrap();
             test_interpreter_and_jit!(vm, $($location => $syscall),*);
             assert!(check_closure(vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: $expected_instruction_count })));
             vm.get_total_instruction_count()
@@ -45,7 +45,7 @@ macro_rules! test_interpreter_and_jit {
         #[cfg(not(windows))]
         {
             let mem = $mem;
-            let mut vm = EbpfVm::<UserError>::new($executable.as_ref(), &mem, &[]).unwrap();
+            let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new($executable.as_ref(), &mem, &[]).unwrap();
             test_interpreter_and_jit!(vm, $($location => $syscall),*);
             match vm.jit_compile() {
                 Err(err) => assert!(check_closure(Err(err))),
@@ -63,7 +63,7 @@ macro_rules! test_interpreter_and_jit {
 macro_rules! test_interpreter_and_jit_asm {
     ( $source:tt, $mem:tt, ($($location:expr => $syscall:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
         let program = assemble($source).unwrap();
-        let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&program, None).unwrap();
+        let executable = Executable::<UserError>::from_text_bytes(&program, None).unwrap();
         test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
     };
 }
@@ -73,7 +73,7 @@ macro_rules! test_interpreter_and_jit_elf {
         let mut file = File::open($source).unwrap();
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        let executable = EbpfVm::<UserError>::create_executable_from_elf(&elf, None).unwrap();
+        let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
         test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
     };
 }
@@ -2546,7 +2546,7 @@ fn test_custom_entrypoint() {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     elf[24] = 80; // Move entrypoint to later in the text section
-    let executable = EbpfVm::<UserError>::create_executable_from_elf(&elf, None).unwrap();
+    let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
     test_interpreter_and_jit!(
         executable,
         [],
@@ -2989,9 +2989,10 @@ fn test_large_program() {
         // Test jumping to pc larger then i16
         write_insn(&mut prog, ebpf::PROG_MAX_INSNS - 2, "ja 0x0");
 
-        let executable =
-            EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
-        let mut vm = EbpfVm::<UserError>::new(executable.as_ref(), &[], &[]).unwrap();
+        let executable = Executable::<UserError>::from_text_bytes(&prog, None).unwrap();
+        let mut vm =
+            EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])
+                .unwrap();
         assert_eq!(
             0,
             vm.execute_program_interpreted(&mut DefaultInstructionMeter {})
@@ -3005,15 +3006,13 @@ fn test_large_program() {
         // test program that is too large
         prog.extend_from_slice(&assemble("exit").unwrap());
 
-        assert!(
-            EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, Some(check)).is_err()
-        );
+        assert!(Executable::<UserError>::from_text_bytes(&prog, Some(check)).is_err());
     }
     // reset program
     prog.truncate(ebpf::PROG_MAX_INSNS * ebpf::INSN_SIZE);
 
     // verify program still works
-    let executable = EbpfVm::<UserError>::create_executable_from_text_bytes(&prog, None).unwrap();
+    let executable = Executable::<UserError>::from_text_bytes(&prog, None).unwrap();
     test_interpreter_and_jit!(
         executable,
         [],


### PR DESCRIPTION
 Adds support for syscalls consuming the instruction meter in JIT while the program is running.