### PR TITLE
Refactoring for JIT compilation cache

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -59,7 +59,7 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
         .unwrap();
         let mut syscall_registry = SyscallRegistry::default();
         syscall_registry
-            .register_syscall::<UserError, _>(hash_symbol_name(b"log_64"), BpfSyscallU64::call)
+            .register_syscall_by_name::<UserError, _>(b"log_64", BpfSyscallU64::call)
             .unwrap();
         executable.set_syscall_registry(syscall_registry);
     });

--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -31,7 +31,7 @@ fn bench_load_elf(bencher: &mut Bencher) {
 }
 
 #[bench]
-fn bench_load_elf_and_init_vm_without_syscall(bencher: &mut Bencher) {
+fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/noro.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
@@ -42,13 +42,11 @@ fn bench_load_elf_and_init_vm_without_syscall(bencher: &mut Bencher) {
             Config::default(),
         )
         .unwrap();
-        let _vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])
-            .unwrap();
     });
 }
 
 #[bench]
-fn bench_load_elf_and_init_vm_with_syscall(bencher: &mut Bencher) {
+fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/noro.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
@@ -64,8 +62,5 @@ fn bench_load_elf_and_init_vm_with_syscall(bencher: &mut Bencher) {
             .register_syscall::<UserError, _>(hash_symbol_name(b"log_64"), BpfSyscallU64::call)
             .unwrap();
         executable.set_syscall_registry(syscall_registry);
-        let mut _vm =
-            EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])
-                .unwrap();
     });
 }

--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -13,7 +13,7 @@ extern crate test_utils;
 use solana_rbpf::{
     ebpf::hash_symbol_name,
     user_error::UserError,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, Syscall},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -60,10 +60,7 @@ fn bench_load_elf_and_init_vm_with_syscall(bencher: &mut Bencher) {
         )
         .unwrap();
         executable
-            .register_syscall(
-                hash_symbol_name(b"log_64"),
-                Syscall::Function(bpf_syscall_u64),
-            )
+            .register_syscall(hash_symbol_name(b"log_64"), bpf_syscall_u64)
             .unwrap();
         let mut _vm =
             EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])

--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -24,7 +24,10 @@ fn bench_load_elf(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/noro.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    bencher.iter(|| Executable::<UserError>::from_elf(&elf, None).unwrap());
+    bencher.iter(|| {
+        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
+            .unwrap()
+    });
 }
 
 #[bench]
@@ -33,14 +36,14 @@ fn bench_load_elf_and_init_vm_without_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
-        let _vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(
-            executable.as_ref(),
+        let executable = Executable::<UserError, DefaultInstructionMeter>::from_elf(
+            &elf,
+            None,
             Config::default(),
-            &[],
-            &[],
         )
         .unwrap();
+        let _vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])
+            .unwrap();
     });
 }
 
@@ -50,18 +53,20 @@ fn bench_load_elf_and_init_vm_with_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
-        let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(
-            executable.as_ref(),
+        let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_elf(
+            &elf,
+            None,
             Config::default(),
-            &[],
-            &[],
         )
         .unwrap();
-        vm.register_syscall(
-            hash_symbol_name(b"log_64"),
-            Syscall::Function(bpf_syscall_u64),
-        )
-        .unwrap();
+        executable
+            .register_syscall(
+                hash_symbol_name(b"log_64"),
+                Syscall::Function(bpf_syscall_u64),
+            )
+            .unwrap();
+        let mut _vm =
+            EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])
+                .unwrap();
     });
 }

--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -13,11 +13,11 @@ extern crate test_utils;
 use solana_rbpf::{
     ebpf::hash_symbol_name,
     user_error::UserError,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
-use test_utils::bpf_syscall_u64;
+use test_utils::BpfSyscallU64;
 
 #[bench]
 fn bench_load_elf(bencher: &mut Bencher) {
@@ -60,7 +60,10 @@ fn bench_load_elf_and_init_vm_with_syscall(bencher: &mut Bencher) {
         )
         .unwrap();
         executable
-            .register_syscall(hash_symbol_name(b"log_64"), bpf_syscall_u64)
+            .register_syscall(
+                hash_symbol_name(b"log_64"),
+                BpfSyscallU64::call::<UserError>,
+            )
             .unwrap();
         let mut _vm =
             EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -21,15 +21,11 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
+    let executable =
+        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
+            .unwrap();
     bencher.iter(|| {
-        EbpfVm::<UserError, DefaultInstructionMeter>::new(
-            executable.as_ref(),
-            Config::default(),
-            &[],
-            &[],
-        )
-        .unwrap()
+        EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap()
     });
 }
 
@@ -39,15 +35,8 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
-    bencher.iter(|| {
-        let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(
-            executable.as_ref(),
-            Config::default(),
-            &[],
-            &[],
-        )
-        .unwrap();
-        vm.jit_compile().unwrap()
-    });
+    let mut executable =
+        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
+            .unwrap();
+    bencher.iter(|| executable.jit_compile().unwrap());
 }

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -21,14 +21,11 @@ fn bench_init_interpreter_execution(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
-    let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(
-        executable.as_ref(),
-        Config::default(),
-        &[],
-        &[],
-    )
-    .unwrap();
+    let executable =
+        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
+            .unwrap();
+    let mut vm =
+        EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
     bencher.iter(|| {
         vm.execute_program_interpreted(&mut DefaultInstructionMeter {})
             .unwrap()
@@ -41,14 +38,11 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<UserError>::from_elf(&elf, None).unwrap();
-    let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(
-        executable.as_ref(),
-        Config::default(),
-        &[],
-        &[],
-    )
-    .unwrap();
-    vm.jit_compile().unwrap();
+    let mut executable =
+        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
+            .unwrap();
+    executable.jit_compile().unwrap();
+    let mut vm =
+        EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
     bencher.iter(|| unsafe { vm.execute_program_jit(&mut DefaultInstructionMeter {}) }.unwrap());
 }

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -44,5 +44,8 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     executable.jit_compile().unwrap();
     let mut vm =
         EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
-    bencher.iter(|| unsafe { vm.execute_program_jit(&mut DefaultInstructionMeter {}) }.unwrap());
+    bencher.iter(|| {
+        vm.execute_program_jit(&mut DefaultInstructionMeter {})
+            .unwrap()
+    });
 }

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -84,7 +84,7 @@ fn main() {
     }
     let mut vm =
         EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
-    vm.bind_syscall_context_object(&mut syscalls::BpfTimeGetNs {})
+    vm.bind_syscall_context_object(Box::new(syscalls::BpfTimeGetNs {}))
         .unwrap();
 
     let time;

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -8,7 +8,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     syscalls,
     user_error::UserError,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject},
 };
 
 // The main objectives of this example is to show:
@@ -71,7 +71,7 @@ fn main() {
     )
     .unwrap();
     executable
-        .register_syscall(syscalls::BPF_KTIME_GETNS_IDX, syscalls::bpf_time_getns)
+        .register_syscall(syscalls::BPF_KTIME_GETNS_IDX, syscalls::BpfTimeGetNs::call)
         .unwrap();
     #[cfg(not(windows))]
     {

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -8,7 +8,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     syscalls,
     user_error::UserError,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject, SyscallRegistry},
 };
 
 // The main objectives of this example is to show:
@@ -70,9 +70,14 @@ fn main() {
         Config::default(),
     )
     .unwrap();
-    executable
-        .register_syscall(syscalls::BPF_KTIME_GETNS_IDX, syscalls::BpfTimeGetNs::call)
+    let mut syscall_registry = SyscallRegistry::default();
+    syscall_registry
+        .register_syscall::<UserError, _>(
+            syscalls::BPF_KTIME_GETNS_IDX,
+            syscalls::BpfTimeGetNs::call,
+        )
         .unwrap();
+    executable.set_syscall_registry(syscall_registry);
     #[cfg(not(windows))]
     {
         executable.jit_compile().unwrap();

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -84,6 +84,8 @@ fn main() {
     }
     let mut vm =
         EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[]).unwrap();
+    vm.bind_syscall_context_object(&mut syscalls::BpfTimeGetNs {})
+        .unwrap();
 
     let time;
     #[cfg(not(windows))]

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -72,7 +72,7 @@ fn main() {
     .unwrap();
     let mut syscall_registry = SyscallRegistry::default();
     syscall_registry
-        .register_syscall::<UserError, _>(
+        .register_syscall_by_hash::<UserError, _>(
             syscalls::BPF_KTIME_GETNS_IDX,
             syscalls::BpfTimeGetNs::call,
         )

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -8,7 +8,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     syscalls,
     user_error::UserError,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, Syscall},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable},
 };
 
 // The main objectives of this example is to show:
@@ -71,10 +71,7 @@ fn main() {
     )
     .unwrap();
     executable
-        .register_syscall(
-            syscalls::BPF_KTIME_GETNS_IDX,
-            Syscall::Function(syscalls::bpf_time_getns),
-        )
+        .register_syscall(syscalls::BPF_KTIME_GETNS_IDX, syscalls::bpf_time_getns)
         .unwrap();
     #[cfg(not(windows))]
     {
@@ -86,10 +83,9 @@ fn main() {
     let time;
     #[cfg(not(windows))]
     {
-        time = unsafe {
-            vm.execute_program_jit(&mut DefaultInstructionMeter {})
-                .unwrap()
-        };
+        time = vm
+            .execute_program_jit(&mut DefaultInstructionMeter {})
+            .unwrap();
     }
 
     #[cfg(windows)]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -11,7 +11,8 @@ extern crate scroll;
 
 use crate::{
     error::{EbpfError, UserDefinedError},
-    vm::Executable,
+    jit::{compile, JitProgram},
+    vm::{Config, Executable, InstructionMeter, Syscall},
 };
 use byteorder::{ByteOrder, LittleEndian};
 use ebpf;
@@ -19,7 +20,7 @@ use elf::goblin::{
     elf::{header::*, reloc::*, section_header::*, Elf},
     error::Error as GoblinError,
 };
-use std::{collections::HashMap, mem, ops::Range, str};
+use std::{collections::HashMap, fmt::Debug, mem, ops::Range, str};
 
 /// Error definitions
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -168,8 +169,9 @@ struct SectionInfo {
 }
 
 /// Elf loader/relocator
-#[derive(Debug, PartialEq)]
-pub struct EBpfElf {
+pub struct EBpfElf<E: UserDefinedError, I: InstructionMeter> {
+    /// Configuration settings
+    config: Config,
     /// Loaded and executable elf
     elf_bytes: Vec<u8>,
     /// Entrypoint instruction offset
@@ -180,8 +182,41 @@ pub struct EBpfElf {
     ro_section_infos: Vec<SectionInfo>,
     /// Call resolution map
     calls: HashMap<u32, usize>,
+    /// Syscall resolution map
+    syscalls: HashMap<u32, Syscall<E>>,
+    /// Compiled program and argument
+    compiled_program: Option<JitProgram<E, I>>,
 }
-impl<E: UserDefinedError> Executable<E> for EBpfElf {
+
+impl<E: UserDefinedError, I: InstructionMeter> PartialEq for EBpfElf<E, I> {
+    fn eq(&self, other: &EBpfElf<E, I>) -> bool {
+        self.config == other.config
+            && self.elf_bytes == other.elf_bytes
+            && self.entrypoint == other.entrypoint
+            && self.text_section_info == other.text_section_info
+            && self.ro_section_infos == other.ro_section_infos
+            && self.calls == other.calls
+    }
+}
+
+impl<E: UserDefinedError, I: InstructionMeter> Debug for EBpfElf<E, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EBpfElf")
+            .field("config", &self.config)
+            .field("elf_bytes", &self.elf_bytes)
+            .field("text_section_info", &self.text_section_info)
+            .field("ro_section_infos", &self.ro_section_infos)
+            .field("calls", &self.calls)
+            .finish()
+    }
+}
+
+impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> for EBpfElf<E, I> {
+    /// Get the configuration settings
+    fn get_config(&self) -> &Config {
+        &self.config
+    }
+
     /// Get the .text section virtual address and bytes
     fn get_text_bytes(&self) -> Result<(u64, &[u8]), EbpfError<E>> {
         Ok((
@@ -218,6 +253,28 @@ impl<E: UserDefinedError> Executable<E> for EBpfElf {
         self.calls.get(&hash)
     }
 
+    /// Get a symbol's function pointer (and context object if any)
+    fn lookup_syscall(&self, hash: u32) -> Option<&Syscall<E>> {
+        self.syscalls.get(&hash)
+    }
+
+    /// Get the JIT compiled program
+    fn get_compiled_program(&self) -> Option<&JitProgram<E, I>> {
+        self.compiled_program.as_ref()
+    }
+
+    /// Register a syscall (function or an object which provides additional context)
+    fn register_syscall(&mut self, key: u32, syscall: Syscall<E>) -> Result<(), EbpfError<E>> {
+        self.syscalls.insert(key, syscall);
+        Ok(())
+    }
+
+    /// JIT compile the executable
+    fn jit_compile(&mut self) -> Result<(), EbpfError<E>> {
+        self.compiled_program = Some(compile::<E, I>(self, true)?);
+        Ok(())
+    }
+
     /// Report information on a symbol that failed to be resolved
     fn report_unresolved_symbol(&self, insn_offset: usize) -> Result<(), EbpfError<E>> {
         let file_offset =
@@ -251,10 +308,12 @@ impl<E: UserDefinedError> Executable<E> for EBpfElf {
         .into())
     }
 }
-impl EBpfElf {
+
+impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
     /// Create from raw text section bytes (list of instructions)
-    pub fn new_from_text_bytes(text_bytes: &[u8]) -> Self {
+    pub fn new_from_text_bytes(config: Config, text_bytes: &[u8]) -> Self {
         Self {
+            config,
             elf_bytes: text_bytes.to_vec(),
             entrypoint: 0,
             text_section_info: SectionInfo {
@@ -266,10 +325,13 @@ impl EBpfElf {
             },
             ro_section_infos: vec![],
             calls: HashMap::default(),
+            syscalls: HashMap::default(),
+            compiled_program: None,
         }
     }
+
     /// Fully loads an ELF, including validation and relocation
-    pub fn load(bytes: &[u8]) -> Result<Self, ELFError> {
+    pub fn load(config: Config, bytes: &[u8]) -> Result<Self, ELFError> {
         let elf = Elf::parse(bytes)?;
         let mut elf_bytes = bytes.to_vec();
         Self::validate(&elf, &elf_bytes)?;
@@ -313,11 +375,14 @@ impl EBpfElf {
             .collect();
 
         Ok(Self {
+            config,
             elf_bytes,
             entrypoint,
             text_section_info,
             ro_section_infos,
             calls,
+            syscalls: HashMap::default(),
+            compiled_program: None,
         })
     }
 
@@ -561,10 +626,11 @@ impl EBpfElf {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{ebpf, fuzz::fuzz, user_error::UserError};
+    use crate::{ebpf, fuzz::fuzz, user_error::UserError, vm::DefaultInstructionMeter};
     use elf::scroll::Pwrite;
     use rand::{distributions::Uniform, Rng};
     use std::{collections::HashMap, fs::File, io::Read};
+    type ElfExecutable = EBpfElf<UserError, DefaultInstructionMeter>;
 
     #[test]
     fn test_validate() {
@@ -575,27 +641,27 @@ mod test {
         let mut parsed_elf = Elf::parse(&bytes).unwrap();
         let elf_bytes = bytes.to_vec();
 
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect("validation failed");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect("validation failed");
         parsed_elf.header.e_ident[EI_CLASS] = ELFCLASS32;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect_err("allowed bad class");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect_err("allowed bad class");
         parsed_elf.header.e_ident[EI_CLASS] = ELFCLASS64;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect("validation failed");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect("validation failed");
         parsed_elf.header.e_ident[EI_DATA] = ELFDATA2MSB;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect_err("allowed big endian");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect_err("allowed big endian");
         parsed_elf.header.e_ident[EI_DATA] = ELFDATA2LSB;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect("validation failed");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect("validation failed");
         parsed_elf.header.e_ident[EI_OSABI] = 1;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect_err("allowed wrong abi");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect_err("allowed wrong abi");
         parsed_elf.header.e_ident[EI_OSABI] = ELFOSABI_NONE;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect("validation failed");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect("validation failed");
         parsed_elf.header.e_machine = EM_QDSP6;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect_err("allowed wrong machine");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect_err("allowed wrong machine");
         parsed_elf.header.e_machine = EM_BPF;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect("validation failed");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect("validation failed");
         parsed_elf.header.e_type = ET_REL;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect_err("allowed wrong type");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect_err("allowed wrong type");
         parsed_elf.header.e_type = ET_DYN;
-        EBpfElf::validate(&parsed_elf, &elf_bytes).expect("validation failed");
+        ElfExecutable::validate(&parsed_elf, &elf_bytes).expect("validation failed");
     }
 
     #[test]
@@ -604,7 +670,7 @@ mod test {
         let mut elf_bytes = Vec::new();
         file.read_to_end(&mut elf_bytes)
             .expect("failed to read elf file");
-        EBpfElf::load(&elf_bytes).expect("validation failed");
+        ElfExecutable::load(Config::default(), &elf_bytes).expect("validation failed");
     }
 
     #[test]
@@ -613,10 +679,10 @@ mod test {
         let mut elf_bytes = Vec::new();
         file.read_to_end(&mut elf_bytes)
             .expect("failed to read elf file");
-        let elf = EBpfElf::load(&elf_bytes).expect("validation failed");
+        let elf = ElfExecutable::load(Config::default(), &elf_bytes).expect("validation failed");
         let mut parsed_elf = Elf::parse(&elf_bytes).unwrap();
         let initial_e_entry = parsed_elf.header.e_entry;
-        let executable: &dyn Executable<UserError> = &elf;
+        let executable: &dyn Executable<UserError, DefaultInstructionMeter> = &elf;
         assert_eq!(
             0,
             executable
@@ -627,8 +693,8 @@ mod test {
         parsed_elf.header.e_entry += 8;
         let mut elf_bytes = elf_bytes.clone();
         elf_bytes.pwrite(parsed_elf.header, 0).unwrap();
-        let elf = EBpfElf::load(&elf_bytes).expect("validation failed");
-        let executable: &dyn Executable<UserError> = &elf;
+        let elf = ElfExecutable::load(Config::default(), &elf_bytes).expect("validation failed");
+        let executable: &dyn Executable<UserError, DefaultInstructionMeter> = &elf;
         assert_eq!(
             1,
             executable
@@ -641,7 +707,7 @@ mod test {
         elf_bytes.pwrite(parsed_elf.header, 0).unwrap();
         assert_eq!(
             Err(ELFError::EntrypointOutOfBounds),
-            EBpfElf::load(&elf_bytes)
+            ElfExecutable::load(Config::default(), &elf_bytes)
         );
 
         parsed_elf.header.e_entry = std::u64::MAX;
@@ -649,19 +715,22 @@ mod test {
         elf_bytes.pwrite(parsed_elf.header, 0).unwrap();
         assert_eq!(
             Err(ELFError::EntrypointOutOfBounds),
-            EBpfElf::load(&elf_bytes)
+            ElfExecutable::load(Config::default(), &elf_bytes)
         );
 
         parsed_elf.header.e_entry = initial_e_entry + ebpf::INSN_SIZE as u64 + 1;
         let mut elf_bytes = elf_bytes;
         elf_bytes.pwrite(parsed_elf.header, 0).unwrap();
-        assert_eq!(Err(ELFError::InvalidEntrypoint), EBpfElf::load(&elf_bytes));
+        assert_eq!(
+            Err(ELFError::InvalidEntrypoint),
+            ElfExecutable::load(Config::default(), &elf_bytes)
+        );
 
         parsed_elf.header.e_entry = initial_e_entry;
         let mut elf_bytes = elf_bytes;
         elf_bytes.pwrite(parsed_elf.header, 0).unwrap();
-        let elf = EBpfElf::load(&elf_bytes).expect("validation failed");
-        let executable: &dyn Executable<UserError> = &elf;
+        let elf = ElfExecutable::load(Config::default(), &elf_bytes).expect("validation failed");
+        let executable: &dyn Executable<UserError, DefaultInstructionMeter> = &elf;
         assert_eq!(
             0,
             executable
@@ -683,7 +752,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x85, 0x10, 0x00, 0x00, 0xfe, 0xff, 0xff, 0xff];
 
-        EBpfElf::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[5, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -698,7 +767,7 @@ mod test {
         // // call +6
         let mut calls: HashMap<u32, usize> = HashMap::new();
         prog.splice(44.., vec![0xfa, 0xff, 0xff, 0xff]);
-        EBpfElf::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[5, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -724,7 +793,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
-        EBpfElf::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[0, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -739,7 +808,7 @@ mod test {
         // call +4
         let mut calls: HashMap<u32, usize> = HashMap::new();
         prog.splice(4..8, vec![0x04, 0x00, 0x00, 0x00]);
-        EBpfElf::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[0, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -768,7 +837,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
-        EBpfElf::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -797,7 +866,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x85, 0x10, 0x00, 0x00, 0xf9, 0xff, 0xff, 0xff];
 
-        EBpfElf::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[5]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -819,7 +888,7 @@ mod test {
         println!("random bytes");
         for _ in 0..1_000 {
             let elf_bytes: Vec<u8> = (0..100).map(|_| rng.sample(&range)).collect();
-            let _ = EBpfElf::load(&elf_bytes);
+            let _ = ElfExecutable::load(Config::default(), &elf_bytes);
         }
 
         // Take a real elf and mangle it
@@ -839,7 +908,7 @@ mod test {
             0..parsed_elf.header.e_ehsize as usize,
             0..255,
             |bytes: &mut [u8]| {
-                let _ = EBpfElf::load(bytes);
+                let _ = ElfExecutable::load(Config::default(), bytes);
             },
         );
 
@@ -852,7 +921,7 @@ mod test {
             parsed_elf.header.e_shoff as usize..elf_bytes.len(),
             0..255,
             |bytes: &mut [u8]| {
-                let _ = EBpfElf::load(bytes);
+                let _ = ElfExecutable::load(Config::default(), bytes);
             },
         );
 
@@ -865,7 +934,7 @@ mod test {
             0..elf_bytes.len(),
             0..255,
             |bytes: &mut [u8]| {
-                let _ = EBpfElf::load(bytes);
+                let _ = ElfExecutable::load(Config::default(), bytes);
             },
         );
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,12 @@ pub enum EbpfError<E: UserDefinedError> {
     /// ELF error
     #[error("ELF error: {0}")]
     ELFError(#[from] ELFError),
+    /// Syscall was already registered before
+    #[error("syscall was already registered before")]
+    SycallAlreadyRegistered,
+    /// Syscall already has a bound context object
+    #[error("syscall already has a bound context object")]
+    SycallAlreadyBound,
     /// No program or ELF set
     #[error("no program or ELF set")]
     NothingToExecute,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1304,6 +1304,10 @@ impl<'a> JitCompiler<'a> {
                              std::mem::size_of::<i32>());
             }
         }
+
+        for offset in self.pc_locs.iter_mut() {
+            *offset = unsafe { (self.contents.as_ptr() as *const u8).add(*offset as usize) } as u64;
+        }
     }
 } // struct JitCompiler
 
@@ -1348,9 +1352,6 @@ pub fn compile<E: UserDefinedError, I: InstructionMeter>(
     jit.compile::<E, I>(executable)?;
     jit.resolve_jumps();
     jit.set_permissions();
-    for offset in jit.pc_locs.iter_mut() {
-        *offset = unsafe { (jit.contents.as_ptr() as *const u8).add(*offset as usize) } as u64;
-    }
 
     Ok(JitProgram {
         main: unsafe { mem::transmute(jit.contents.as_ptr()) },

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1134,7 +1134,7 @@ impl<'a> JitCompiler<'a> {
                     // For JIT, syscalls MUST be registered at compile time. They can be
                     // updated later, but not created after compiling (we need the address of the
                     // syscall function in the JIT-compiled program).
-                    if let Some(syscall) = executable.lookup_syscall(insn.imm as u32) {
+                    if let Some(syscall) = executable.get_syscall_registry().lookup_syscall(insn.imm as u32) {
                         if self.enable_instruction_meter {
                             emit_validate_and_profile_instruction_count(self, Some(0));
                             emit_load(self, OperandSize::S64, RBP, R11, -8 * (CALLEE_SAVED_REGISTERS.len() + 2) as i32);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1147,16 +1147,17 @@ impl<'a> JitCompiler<'a> {
                             ], None);
                         }
 
-                        emit_load(self, OperandSize::S64, R10, R11, (2 + syscall.context_object_slot as i32) * 8);
+                        emit_load(self, OperandSize::S64, R10, RAX, (2 + syscall.context_object_slot as i32) * 8);
+                        emit_load(self, OperandSize::S64, RBP, R11, -8 * (CALLEE_SAVED_REGISTERS.len() as i32 + 1));
                         emit_rust_call(self, syscall.function as *const u8, &[
-                            Argument { index: 0, value: Value::Stack(1) }, // Pointer to optional typed return value
+                            Argument { index: 0, value: Value::Register(RAX) }, // "&mut self" in the "call" method of the SyscallObject
                             Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[1]) },
                             Argument { index: 2, value: Value::Register(ARGUMENT_REGISTERS[2]) },
                             Argument { index: 3, value: Value::Register(ARGUMENT_REGISTERS[3]) },
                             Argument { index: 4, value: Value::Register(ARGUMENT_REGISTERS[4]) },
                             Argument { index: 5, value: Value::Register(ARGUMENT_REGISTERS[5]) },
-                            Argument { index: 6, value: Value::Register(R11) }, // "&mut self" in the "call" method of the SyscallObject
-                            Argument { index: 7, value: Value::Register(R10) }, // JitProgramArgument::memory_mapping
+                            Argument { index: 6, value: Value::Register(R10) }, // JitProgramArgument::memory_mapping
+                            Argument { index: 7, value: Value::Register(R11) }, // Pointer to optional typed return value
                         ], None);
 
                         // Throw error if the result indicates one

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -49,7 +49,7 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// use solana_rbpf::vm::SyscallObject;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let t = BpfTimeGetNs::call::<UserError>(0, 0, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let t = BpfTimeGetNs::call::<UserError>(0, 0, 0, 0, 0, &mut BpfTimeGetNs {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// let d =  t / 10u64.pow(9)  / 60   / 60  / 24;
 /// let h = (t / 10u64.pow(9)  / 60   / 60) % 24;
 /// let m = (t / 10u64.pow(9)  / 60 ) % 60;
@@ -58,14 +58,14 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// println!("Uptime: {:#x} == {} days {}:{}:{}, {} ns", t, d, h, m, s, ns);
 /// ```
 pub struct BpfTimeGetNs {}
-impl<'a> SyscallObject for BpfTimeGetNs {
+impl SyscallObject for BpfTimeGetNs {
     fn call<E: UserDefinedError>(
         _arg1: u64,
         _arg2: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         Ok(time::precise_time_ns())
@@ -93,7 +93,7 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// use solana_rbpf::vm::SyscallObject;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let res = BpfTracePrintf::call::<UserError>(0, 0, 1, 15, 32, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let res = BpfTracePrintf::call::<UserError>(0, 0, 1, 15, 32, &mut BpfTracePrintf {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert_eq!(res as usize, "BpfTracePrintf: 0x1, 0xf, 0x20\n".len());
 /// ```
 ///
@@ -118,14 +118,14 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// This would equally print the three numbers in `/sys/kernel/debug/tracing` file each time the
 /// program is run.
 pub struct BpfTracePrintf {}
-impl<'a> SyscallObject for BpfTracePrintf {
+impl SyscallObject for BpfTracePrintf {
     fn call<E: UserDefinedError>(
         _arg1: u64,
         _arg2: u64,
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         println!("BpfTracePrintf: {:#x}, {:#x}, {:#x}", arg3, arg4, arg5);
@@ -157,18 +157,18 @@ impl<'a> SyscallObject for BpfTracePrintf {
 /// use solana_rbpf::vm::SyscallObject;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let gathered = BpfGatherBytes::call::<UserError>(0x11, 0x22, 0x33, 0x44, 0x55, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let gathered = BpfGatherBytes::call::<UserError>(0x11, 0x22, 0x33, 0x44, 0x55, &mut BpfGatherBytes {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert_eq!(gathered, 0x1122334455);
 /// ```
 pub struct BpfGatherBytes {}
-impl<'a> SyscallObject for BpfGatherBytes {
+impl SyscallObject for BpfGatherBytes {
     fn call<E: UserDefinedError>(
         arg1: u64,
         arg2: u64,
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         Ok(arg1.wrapping_shl(32)
@@ -195,20 +195,20 @@ impl<'a> SyscallObject for BpfGatherBytes {
 /// let val_va = 0x1000;
 /// let memory_mapping = [MemoryRegion::new_from_slice(&val, val_va, true)];
 ///
-/// BpfMemFrob::call::<UserError>(val_va, 8, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
+/// BpfMemFrob::call::<UserError>(val_va, 8, 0, 0, 0, &mut BpfMemFrob {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
 /// assert_eq!(val, vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
-/// BpfMemFrob::call::<UserError>(val_va, 8, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
+/// BpfMemFrob::call::<UserError>(val_va, 8, 0, 0, 0, &mut BpfMemFrob {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
 /// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub struct BpfMemFrob {}
-impl<'a> SyscallObject for BpfMemFrob {
+impl SyscallObject for BpfMemFrob {
     fn call<E: UserDefinedError>(
         vm_addr: u64,
         len: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         let host_addr = memory_mapping.map(AccessType::Store, vm_addr, len)?;
@@ -255,18 +255,18 @@ impl<'a> SyscallObject for BpfMemFrob {
 /// use solana_rbpf::vm::SyscallObject;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let x = BpfSqrtI::call::<UserError>(9, 0, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let x = BpfSqrtI::call::<UserError>(9, 0, 0, 0, 0, &mut BpfSqrtI {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert_eq!(x, 3);
 /// ```
 pub struct BpfSqrtI {}
-impl<'a> SyscallObject for BpfSqrtI {
+impl SyscallObject for BpfSqrtI {
     fn call<E: UserDefinedError>(
         arg1: u64,
         _arg2: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         Ok((arg1 as f64).sqrt() as u64)
@@ -288,19 +288,19 @@ impl<'a> SyscallObject for BpfSqrtI {
 /// let va_foo = 0x1000;
 /// let va_bar = 0x2000;
 /// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, false)];
-/// assert!(BpfStrCmp::call::<UserError>(va_foo, va_foo, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() == 0);
+/// assert!(BpfStrCmp::call::<UserError>(va_foo, va_foo, 0, 0, 0, &mut BpfStrCmp {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() == 0);
 /// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, false)];
-/// assert!(BpfStrCmp::call::<UserError>(va_foo, va_bar, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() != 0);
+/// assert!(BpfStrCmp::call::<UserError>(va_foo, va_bar, 0, 0, 0, &mut BpfStrCmp {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() != 0);
 /// ```
 pub struct BpfStrCmp {}
-impl<'a> SyscallObject for BpfStrCmp {
+impl SyscallObject for BpfStrCmp {
     fn call<E: UserDefinedError>(
         arg1: u64,
         arg2: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         // C-like strcmp, maybe shorter than converting the bytes to string and comparing?
@@ -352,18 +352,18 @@ impl<'a> SyscallObject for BpfStrCmp {
 /// }
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let n = BpfRand::call::<UserError>(3, 6, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let n = BpfRand::call::<UserError>(3, 6, 0, 0, 0, &mut BpfRand {}, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert!(3 <= n && n <= 6);
 /// ```
 pub struct BpfRand {}
-impl<'a> SyscallObject for BpfRand {
+impl SyscallObject for BpfRand {
     fn call<E: UserDefinedError>(
         min: u64,
         max: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         let mut n = unsafe { (libc::rand() as u64).wrapping_shl(32) + libc::rand() as u64 };

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -47,7 +47,7 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// use solana_rbpf::user_error::UserError;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let t = bpf_time_getns::<UserError>(0, 0, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let t = bpf_time_getns::<UserError>(0, 0, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// let d =  t / 10u64.pow(9)  / 60   / 60  / 24;
 /// let h = (t / 10u64.pow(9)  / 60   / 60) % 24;
 /// let m = (t / 10u64.pow(9)  / 60 ) % 60;
@@ -62,6 +62,7 @@ pub fn bpf_time_getns<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
+    _self: *mut u8,
     _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     Ok(time::precise_time_ns())
@@ -87,7 +88,7 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// use solana_rbpf::user_error::UserError;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let res = bpf_trace_printf::<UserError>(0, 0, 1, 15, 32, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let res = bpf_trace_printf::<UserError>(0, 0, 1, 15, 32, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert_eq!(res as usize, "bpf_trace_printf: 0x1, 0xf, 0x20\n".len());
 /// ```
 ///
@@ -118,6 +119,7 @@ pub fn bpf_trace_printf<E: UserDefinedError>(
     arg3: u64,
     arg4: u64,
     arg5: u64,
+    _self: *mut u8,
     _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     println!("bpf_trace_printf: {:#x}, {:#x}, {:#x}", arg3, arg4, arg5);
@@ -147,7 +149,7 @@ pub fn bpf_trace_printf<E: UserDefinedError>(
 /// use solana_rbpf::user_error::UserError;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let gathered = gather_bytes::<UserError>(0x11, 0x22, 0x33, 0x44, 0x55, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let gathered = gather_bytes::<UserError>(0x11, 0x22, 0x33, 0x44, 0x55, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert_eq!(gathered, 0x1122334455);
 /// ```
 pub fn gather_bytes<E: UserDefinedError>(
@@ -156,6 +158,7 @@ pub fn gather_bytes<E: UserDefinedError>(
     arg3: u64,
     arg4: u64,
     arg5: u64,
+    _self: *mut u8,
     _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     Ok(arg1.wrapping_shl(32)
@@ -180,9 +183,9 @@ pub fn gather_bytes<E: UserDefinedError>(
 /// let val_va = 0x1000;
 /// let memory_mapping = [MemoryRegion::new_from_slice(&val, val_va, true)];
 ///
-/// memfrob::<UserError>(val_va, 8, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
+/// memfrob::<UserError>(val_va, 8, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
 /// assert_eq!(val, vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
-/// memfrob::<UserError>(val_va, 8, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
+/// memfrob::<UserError>(val_va, 8, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec()));
 /// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub fn memfrob<E: UserDefinedError>(
@@ -191,6 +194,7 @@ pub fn memfrob<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
+    _self: *mut u8,
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     let host_addr = memory_mapping.map(AccessType::Store, vm_addr, len)?;
@@ -235,7 +239,7 @@ pub fn memfrob<E: UserDefinedError>(
 /// use solana_rbpf::user_error::UserError;
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let x = sqrti::<UserError>(9, 0, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let x = sqrti::<UserError>(9, 0, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert_eq!(x, 3);
 /// ```
 #[allow(dead_code)]
@@ -245,6 +249,7 @@ pub fn sqrti<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
+    _self: *mut u8,
     _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     Ok((arg1 as f64).sqrt() as u64)
@@ -264,10 +269,10 @@ pub fn sqrti<E: UserDefinedError>(
 /// let va_foo = 0x1000;
 /// let va_bar = 0x2000;
 /// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, false)];
-/// assert!(strcmp::<UserError>(va_foo, va_foo, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() == 0);
+/// assert!(strcmp::<UserError>(va_foo, va_foo, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() == 0);
 /// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, false),
 ///                MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, false)];
-/// assert!(strcmp::<UserError>(va_foo, va_bar, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() != 0);
+/// assert!(strcmp::<UserError>(va_foo, va_bar, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap() != 0);
 /// ```
 #[allow(dead_code)]
 pub fn strcmp<E: UserDefinedError>(
@@ -276,6 +281,7 @@ pub fn strcmp<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
+    _self: *mut u8,
     memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     // C-like strcmp, maybe shorter than converting the bytes to string and comparing?
@@ -325,7 +331,7 @@ pub fn strcmp<E: UserDefinedError>(
 /// }
 ///
 /// let memory_mapping = [MemoryRegion::default()];
-/// let n = rand::<UserError>(3, 6, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
+/// let n = rand::<UserError>(3, 6, 0, 0, 0, std::ptr::null_mut(), &MemoryMapping::new_from_regions(memory_mapping.to_vec())).unwrap();
 /// assert!(3 <= n && n <= 6);
 /// ```
 #[allow(dead_code)]
@@ -335,6 +341,7 @@ pub fn rand<E: UserDefinedError>(
     _arg3: u64,
     _arg4: u64,
     _arg5: u64,
+    _self: *mut u8,
     _memory_mapping: &MemoryMapping,
 ) -> Result<u64, EbpfError<E>> {
     let mut n = unsafe { (libc::rand() as u64).wrapping_shl(32) + libc::rand() as u64 };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -438,10 +438,10 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     }
 
     /// Lookup a syscall context object by its function pointer. Used for testing and validation.
-    pub fn get_syscall_context_object(&self, syscall_function: u64) -> Option<*mut u8> {
+    pub fn get_syscall_context_object(&self, syscall_function: usize) -> Option<*mut u8> {
         self.executable
             .get_syscall_registry()
-            .lookup_context_object_slot(syscall_function)
+            .lookup_context_object_slot(syscall_function as u64)
             .map(|slot| self.syscall_context_objects[2 + slot])
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -63,10 +63,18 @@ pub type SyscallFunction<E> =
     fn(u64, u64, u64, u64, u64, *mut u8, &MemoryMapping) -> ProgramResult<E>;
 
 /// Syscall with context
-pub trait SyscallObject<E: UserDefinedError> {
+pub trait SyscallObject {
     /// Call the syscall function
     #[allow(clippy::too_many_arguments)]
-    fn call(u64, u64, u64, u64, u64, *mut u8, &MemoryMapping) -> ProgramResult<E>;
+    fn call<E: UserDefinedError>(
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        *mut u8,
+        &MemoryMapping,
+    ) -> ProgramResult<E>;
 }
 
 /// Syscall function and binding slot for a context object

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -40,11 +40,13 @@ pub type ProgramResult<E> = Result<u64, EbpfError<E>>;
 macro_rules! question_mark {
     ( $value:expr, $result:ident ) => {{
         let value = $value;
-        if value.is_err() {
-            *$result = value;
-            return;
+        match value {
+            Err(err) => {
+                *$result = Err(err.into());
+                return;
+            }
+            Ok(value) => value,
         }
-        value.unwrap()
     }};
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -294,7 +294,7 @@ pub struct EbpfVm<'a, E: UserDefinedError, I: InstructionMeter> {
     program_vm_addr: u64,
     memory_mapping: MemoryMapping,
     syscall_context_objects: Vec<*mut u8>,
-    syscall_context_object_pool: Vec<Box<dyn SyscallObject<E>>>,
+    syscall_context_object_pool: Vec<Box<dyn SyscallObject<E> + 'a>>,
     frames: CallFrames,
     last_insn_count: u64,
     total_insn_count: u64,
@@ -415,7 +415,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// ```
     pub fn bind_syscall_context_object(
         &mut self,
-        syscall_context_object: Box<dyn SyscallObject<E>>,
+        syscall_context_object: Box<dyn SyscallObject<E> + 'a>,
     ) -> Result<(), EbpfError<E>> {
         let fat_ptr_ptr =
             unsafe { std::mem::transmute::<_, *const SyscallTraitObject>(&syscall_context_object) };

--- a/test_utils/Cargo.lock
+++ b/test_utils/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.31"
+version = "0.2.0"
 dependencies = [
  "byteorder",
  "combine",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "solana_rbpf",

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -38,14 +38,14 @@ impl InstructionMeter for TestInstructionMeter {
 pub type ExecResult = Result<u64, EbpfError<UserError>>;
 
 pub struct BpfTracePrintf {}
-impl<'a> SyscallObject for BpfTracePrintf {
+impl SyscallObject for BpfTracePrintf {
     fn call<E: UserDefinedError>(
         _arg1: u64,
         _arg2: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         _memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         Ok(0)
@@ -53,14 +53,14 @@ impl<'a> SyscallObject for BpfTracePrintf {
 }
 
 pub struct BpfSyscallString {}
-impl<'a> SyscallObject for BpfSyscallString {
+impl SyscallObject for BpfSyscallString {
     fn call<E: UserDefinedError>(
         vm_addr: u64,
         len: u64,
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         let host_addr = memory_mapping.map(AccessType::Load, vm_addr, len)?;
@@ -80,14 +80,14 @@ impl<'a> SyscallObject for BpfSyscallString {
 }
 
 pub struct BpfSyscallU64 {}
-impl<'a> SyscallObject for BpfSyscallU64 {
+impl SyscallObject for BpfSyscallU64 {
     fn call<E: UserDefinedError>(
         arg1: u64,
         arg2: u64,
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         println!(
@@ -101,14 +101,14 @@ impl<'a> SyscallObject for BpfSyscallU64 {
 pub struct SyscallWithContext {
     pub context: u64,
 }
-impl<'a> SyscallObject for SyscallWithContext {
+impl SyscallObject for SyscallWithContext {
     fn call<E: UserDefinedError>(
         arg1: u64,
         arg2: u64,
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _self: *mut u8,
+        _self: &mut Self,
         memory_mapping: &MemoryMapping,
     ) -> Result<u64, EbpfError<E>> {
         println!(

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -86,12 +86,12 @@ pub fn bpf_syscall_u64(
     Ok(0)
 }
 
-pub struct SyscallWithContext<'a> {
-    pub context: &'a mut u64,
+pub struct SyscallWithContext {
+    pub context: *const u64,
 }
-impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
+impl<'a> SyscallObject<UserError> for SyscallWithContext {
     fn call(
-        &mut self,
+        &self,
         arg1: u64,
         arg2: u64,
         arg3: u64,
@@ -103,8 +103,8 @@ impl<'a> SyscallObject<UserError> for SyscallWithContext<'a> {
             "SyscallWithContext: {:?}, {:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:?}",
             self as *const _, arg1, arg2, arg3, arg4, arg5, memory_mapping as *const _
         );
-        assert_eq!(*self.context, 42);
-        *self.context = 84;
+        assert_eq!(unsafe { *self.context }, 42);
+        // *self.context = 84;
         Ok(0)
     }
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -141,6 +141,10 @@ fn test_fuzz_execute() {
                     &[],
                 )
                 .unwrap();
+                vm.bind_syscall_context_object(&mut BpfSyscallString {})
+                    .unwrap();
+                vm.bind_syscall_context_object(&mut BpfSyscallU64 {})
+                    .unwrap();
                 let _ = vm.execute_program_interpreted(&mut DefaultInstructionMeter {});
             }
         },

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -134,9 +134,9 @@ fn test_fuzz_execute() {
                     &[],
                 )
                 .unwrap();
-                vm.bind_syscall_context_object(&mut BpfSyscallString {})
+                vm.bind_syscall_context_object(Box::new(BpfSyscallString {}))
                     .unwrap();
-                vm.bind_syscall_context_object(&mut BpfSyscallU64 {})
+                vm.bind_syscall_context_object(Box::new(BpfSyscallU64 {}))
                     .unwrap();
                 let _ = vm.execute_program_interpreted(&mut DefaultInstructionMeter {});
             }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -22,7 +22,6 @@ extern crate solana_rbpf;
 extern crate test_utils;
 
 use solana_rbpf::{
-    ebpf::hash_symbol_name,
     fuzz::fuzz,
     user_error::UserError,
     verifier::check,
@@ -123,16 +122,10 @@ fn test_fuzz_execute() {
             ) {
                 let mut syscall_registry = SyscallRegistry::default();
                 syscall_registry
-                    .register_syscall::<UserError, _>(
-                        hash_symbol_name(b"log"),
-                        BpfSyscallString::call,
-                    )
+                    .register_syscall_by_name::<UserError, _>(b"log", BpfSyscallString::call)
                     .unwrap();
                 syscall_registry
-                    .register_syscall::<UserError, _>(
-                        hash_symbol_name(b"log_64"),
-                        BpfSyscallU64::call,
-                    )
+                    .register_syscall_by_name::<UserError, _>(b"log_64", BpfSyscallU64::call)
                     .unwrap();
                 executable.set_syscall_registry(syscall_registry);
                 let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -26,10 +26,10 @@ use solana_rbpf::{
     fuzz::fuzz,
     user_error::UserError,
     verifier::check,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject},
 };
 use std::{fs::File, io::Read};
-use test_utils::{bpf_syscall_string, bpf_syscall_u64};
+use test_utils::{BpfSyscallString, BpfSyscallU64};
 
 // The following two examples have been compiled from C with the following command:
 //
@@ -122,10 +122,10 @@ fn test_fuzz_execute() {
                 Config::default(),
             ) {
                 executable
-                    .register_syscall(hash_symbol_name(b"log"), bpf_syscall_string)
+                    .register_syscall(hash_symbol_name(b"log"), BpfSyscallString::call)
                     .unwrap();
                 executable
-                    .register_syscall(hash_symbol_name(b"log_64"), bpf_syscall_u64)
+                    .register_syscall(hash_symbol_name(b"log_64"), BpfSyscallU64::call)
                     .unwrap();
                 let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(
                     executable.as_ref(),

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2554,7 +2554,7 @@ fn test_syscall_with_context() {
             0 => SyscallWithContext::call; SyscallWithContext { context: 42 },
         ),
         { |vm: &EbpfVm<UserError, TestInstructionMeter>, res: Result| {
-            let syscall_context_object = unsafe { &*(vm.get_syscall_context_object(SyscallWithContext::call as u64).unwrap() as *const SyscallWithContext) };
+            let syscall_context_object = unsafe { &*(vm.get_syscall_context_object(SyscallWithContext::call as usize).unwrap() as *const SyscallWithContext) };
             assert_eq!(syscall_context_object.context, 84);
             res.unwrap() == 0
         }},

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -60,8 +60,11 @@ macro_rules! test_interpreter_and_jit {
 macro_rules! test_interpreter_and_jit_asm {
     ( $source:tt, $mem:tt, ($($location:expr => $syscall:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
         let program = assemble($source).unwrap();
-        let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(&program, None, Config::default()).unwrap();
-        test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
+        #[allow(unused_mut)]
+        {
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(&program, None, Config::default()).unwrap();
+            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
+        }
     };
 }
 
@@ -70,8 +73,11 @@ macro_rules! test_interpreter_and_jit_elf {
         let mut file = File::open($source).unwrap();
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, Config::default()).unwrap();
-        test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
+        #[allow(unused_mut)]
+        {
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, Config::default()).unwrap();
+            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
+        }
     };
 }
 
@@ -3078,17 +3084,20 @@ fn test_large_program() {
     prog.truncate(ebpf::PROG_MAX_INSNS * ebpf::INSN_SIZE);
 
     // verify program still works
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
-        &prog,
-        None,
-        Config::default(),
-    )
-    .unwrap();
-    test_interpreter_and_jit!(
-        executable,
-        [],
-        (),
-        { |res: ExecResult| res.unwrap() == 0x0 },
-        ebpf::PROG_MAX_INSNS as u64
-    );
+    #[allow(unused_mut)]
+    {
+        let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+            &prog,
+            None,
+            Config::default(),
+        )
+        .unwrap();
+        test_interpreter_and_jit!(
+            executable,
+            [],
+            (),
+            { |res: ExecResult| res.unwrap() == 0x0 },
+            ebpf::PROG_MAX_INSNS as u64
+        );
+    }
 }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -29,7 +29,7 @@ use test_utils::{
 
 macro_rules! test_interpreter_and_jit {
     (1, $syscall_registry:expr, $($location:expr => $syscall_function:expr; $syscall_context_object:expr),*) => {
-        $($syscall_registry.register_syscall::<UserError, _>($location, $syscall_function).unwrap();)*
+        $($syscall_registry.register_syscall_by_hash::<UserError, _>($location, $syscall_function).unwrap();)*
     };
     (2, $vm:expr, $($location:expr => $syscall_function:expr; $syscall_context_object:expr),*) => {
         $($vm.bind_syscall_context_object($syscall_context_object).unwrap();)*

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -19,7 +19,7 @@ use solana_rbpf::{
     syscalls,
     user_error::UserError,
     verifier::check,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, Syscall},
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject},
 };
 use std::{fs::File, io::Read};
 use test_utils::{
@@ -28,15 +28,19 @@ use test_utils::{
 };
 
 macro_rules! test_interpreter_and_jit {
-    ($executable:expr, $($location:expr => $syscall:expr),*) => {
-        $($executable.register_syscall($location, $syscall).unwrap();)*
+    (1, $executable:expr, $($location:expr => $syscall_function:expr; $syscall_context_object:expr),*) => {
+        $($executable.register_syscall($location, $syscall_function).unwrap();)*
     };
-    ( $executable:expr, $mem:tt, ($($location:expr => $syscall:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
+    (2, $vm:expr, $($location:expr => $syscall_function:expr; $syscall_context_object:expr),*) => {
+        $($vm.bind_syscall_context_object($location, $syscall_context_object);)*
+    };
+    ( $executable:expr, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
         let check_closure = $check;
-        test_interpreter_and_jit!($executable, $($location => $syscall),*);
+        test_interpreter_and_jit!(1, $executable, $($location => $syscall_function; $syscall_context_object),*);
         let instruction_count_interpreter = {
             let mem = $mem;
             let mut vm = EbpfVm::new($executable.as_ref(), &mem, &[]).unwrap();
+            test_interpreter_and_jit!(2, vm, $($location => $syscall_function; $syscall_context_object),*);
             assert!(check_closure(vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: $expected_instruction_count })));
             vm.get_total_instruction_count()
         };
@@ -47,7 +51,8 @@ macro_rules! test_interpreter_and_jit {
                 Ok(()) => {
                     let mem = $mem;
                     let mut vm = EbpfVm::new($executable.as_ref(), &mem, &[]).unwrap();
-                    assert!(check_closure(unsafe { vm.execute_program_jit(&mut TestInstructionMeter { remaining: $expected_instruction_count }) }));
+                    test_interpreter_and_jit!(2, vm, $($location => $syscall_function; $syscall_context_object),*);
+                    assert!(check_closure(vm.execute_program_jit(&mut TestInstructionMeter { remaining: $expected_instruction_count })));
                     let instruction_count_jit = vm.get_total_instruction_count();
                     assert_eq!(instruction_count_interpreter, instruction_count_jit);
                 },
@@ -58,25 +63,25 @@ macro_rules! test_interpreter_and_jit {
 }
 
 macro_rules! test_interpreter_and_jit_asm {
-    ( $source:tt, $mem:tt, ($($location:expr => $syscall:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
+    ( $source:tt, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
         let program = assemble($source).unwrap();
         #[allow(unused_mut)]
         {
             let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(&program, None, Config::default()).unwrap();
-            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
+            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
         }
     };
 }
 
 macro_rules! test_interpreter_and_jit_elf {
-    ( $source:tt, $mem:tt, ($($location:expr => $syscall:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
+    ( $source:tt, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr ) => {
         let mut file = File::open($source).unwrap();
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
         #[allow(unused_mut)]
         {
             let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, Config::default()).unwrap();
-            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall),*), $check, $expected_instruction_count);
+            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
         }
     };
 }
@@ -2144,8 +2149,8 @@ fn test_stack2() {
         exit",
         [],
         (
-            0 => Syscall::Function(syscalls::gather_bytes),
-            1 => Syscall::Function(syscalls::memfrob),
+            0 => syscalls::gather_bytes; std::ptr::null_mut(),
+            1 => syscalls::memfrob; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0x01020304 } },
         16
@@ -2186,7 +2191,7 @@ fn test_string_stack() {
         exit",
         [],
         (
-            0 => Syscall::Function(syscalls::strcmp),
+            0 => syscalls::strcmp; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0x0 } },
         28
@@ -2221,7 +2226,7 @@ fn test_relative_call() {
         "tests/elfs/relative_call.so",
         [1],
         (
-            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+            hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 2 } },
         14
@@ -2234,7 +2239,7 @@ fn test_bpf_to_bpf_scratch_registers() {
         "tests/elfs/scratch_registers.so",
         [1],
         (
-            hash_symbol_name(b"log_64") => Syscall::Function(bpf_syscall_u64),
+            hash_symbol_name(b"log_64") => bpf_syscall_u64; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 112 } },
         41
@@ -2264,7 +2269,7 @@ fn test_syscall_parameter_on_stack() {
         exit",
         [],
         (
-            0 => Syscall::Function(bpf_syscall_string),
+            0 => bpf_syscall_string; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         6
@@ -2341,7 +2346,7 @@ fn test_bpf_to_bpf_depth() {
             "tests/elfs/multiple_file.so",
             [i as u8],
             (
-                hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+                hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
             ),
             { |res: ExecResult| { res.unwrap() == 0 } },
             if i == 0 { 4 } else { 3 + 10 * i as u64 }
@@ -2356,7 +2361,7 @@ fn test_err_bpf_to_bpf_too_deep() {
         "tests/elfs/multiple_file.so",
         [config.max_call_depth as u8],
         (
-            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+            hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| {
@@ -2381,7 +2386,7 @@ fn test_err_reg_stack_depth() {
         exit",
         [],
         (
-            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+            hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| {
@@ -2416,7 +2421,7 @@ fn test_call_save() {
         exit",
         [],
         (
-            0 => Syscall::Function(syscalls::trash_registers),
+            0 => syscalls::trash_registers,
         ),
         { |res: ExecResult| { res.unwrap() == 0 } }
     );
@@ -2432,7 +2437,7 @@ fn test_err_syscall_string() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => Syscall::Function(bpf_syscall_string),
+            0 => bpf_syscall_string; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| {
@@ -2456,7 +2461,7 @@ fn test_syscall_string() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => Syscall::Function(bpf_syscall_string),
+            0 => bpf_syscall_string; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         4
@@ -2477,7 +2482,7 @@ fn test_syscall() {
         exit",
         [],
         (
-            0 => Syscall::Function(bpf_syscall_u64),
+            0 => bpf_syscall_u64; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         8
@@ -2497,7 +2502,7 @@ fn test_call_gather_bytes() {
         exit",
         [],
         (
-            0 => Syscall::Function(syscalls::gather_bytes),
+            0 => syscalls::gather_bytes; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0x0102030405 } },
         7
@@ -2519,7 +2524,7 @@ fn test_call_memfrob() {
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
         ],
         (
-            0 => Syscall::Function(syscalls::memfrob),
+            0 => syscalls::memfrob; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0x102292e2f2c0708 } },
         7
@@ -2528,8 +2533,8 @@ fn test_call_memfrob() {
 
 #[test]
 fn test_syscall_with_context() {
-    let number: u64 = 42;
-    let number_ptr = &number as *const u64;
+    let mut syscall_context_object = SyscallWithContext { context: 42 };
+    let number_ptr = &mut syscall_context_object.context as *mut u64;
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, 0xAA
@@ -2542,13 +2547,12 @@ fn test_syscall_with_context() {
         exit",
         [],
         (
-            0 => Syscall::Object(Box::new(SyscallWithContext {
-                context: number_ptr,
-            })),
+            0 => SyscallWithContext::call; &mut syscall_context_object as *mut _ as *mut u8,
         ),
         { |res: ExecResult| {
             unsafe {
-                assert_eq!(*number_ptr, 42);
+                assert_eq!(*number_ptr, 84);
+                *number_ptr = 42;
             }
             res.unwrap() == 0
         }},
@@ -2564,8 +2568,8 @@ fn test_load_elf() {
         "tests/elfs/noop.so",
         [],
         (
-            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
-            hash_symbol_name(b"log_64") => Syscall::Function(bpf_syscall_u64),
+            hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
+            hash_symbol_name(b"log_64") => bpf_syscall_u64; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         11
@@ -2578,7 +2582,7 @@ fn test_load_elf_empty_noro() {
         "tests/elfs/noro.so",
         [],
         (
-            hash_symbol_name(b"log_64") => Syscall::Function(bpf_syscall_u64),
+            hash_symbol_name(b"log_64") => bpf_syscall_u64; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         8
@@ -2591,7 +2595,7 @@ fn test_load_elf_empty_rodata() {
         "tests/elfs/empty_rodata.so",
         [],
         (
-            hash_symbol_name(b"log_64") => Syscall::Function(bpf_syscall_u64),
+            hash_symbol_name(b"log_64") => bpf_syscall_u64; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         8
@@ -2611,8 +2615,8 @@ fn test_custom_entrypoint() {
         executable,
         [],
         (
-            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
-            hash_symbol_name(b"log_64") => Syscall::Function(bpf_syscall_u64),
+            hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
+            hash_symbol_name(b"log_64") => bpf_syscall_u64; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         2
@@ -2631,7 +2635,7 @@ fn test_instruction_count_syscall() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => Syscall::Function(bpf_syscall_string),
+            0 => bpf_syscall_string; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         4
@@ -2648,7 +2652,7 @@ fn test_err_instruction_count_syscall_capped() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => Syscall::Function(bpf_syscall_string),
+            0 => bpf_syscall_string; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| {
@@ -2706,7 +2710,7 @@ fn test_err_non_terminate_capped() {
         exit",
         [],
         (
-            0 => Syscall::Function(bpf_trace_printf),
+            0 => bpf_trace_printf; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| {
@@ -2736,7 +2740,7 @@ fn test_err_non_terminating_capped() {
         exit",
         [],
         (
-            0 => Syscall::Function(bpf_trace_printf),
+            0 => bpf_trace_printf; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| {
@@ -2764,7 +2768,7 @@ fn test_symbol_relocation() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => Syscall::Function(bpf_syscall_string),
+            0 => bpf_syscall_string; std::ptr::null_mut(),
         ),
         { |res: ExecResult| { res.unwrap() == 0 } },
         6
@@ -2813,7 +2817,7 @@ fn test_err_unresolved_elf() {
         "tests/elfs/unresolved_syscall.so",
         [],
         (
-            hash_symbol_name(b"log") => Syscall::Function(bpf_syscall_string),
+            hash_symbol_name(b"log") => bpf_syscall_string; std::ptr::null_mut(),
         ),
         {
             |res: ExecResult| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "log_64" && pc == 550 && offset == 4168)

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -23,7 +23,7 @@ use solana_rbpf::{
 };
 use std::{fs::File, io::Read};
 use test_utils::{
-    BpfSyscallString, BpfSyscallU64, BpfTracePrintf, ExecResult, SyscallWithContext,
+    BpfSyscallString, BpfSyscallU64, BpfTracePrintf, Result, SyscallWithContext,
     TestInstructionMeter, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
 };
 
@@ -99,7 +99,7 @@ fn test_mov() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         3
     );
 }
@@ -112,7 +112,7 @@ fn test_mov32_imm_large() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xffffffff } },
+        { |res: Result| { res.unwrap() == 0xffffffff } },
         2
     );
 }
@@ -126,7 +126,7 @@ fn test_mov_large() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xffffffff } },
+        { |res: Result| { res.unwrap() == 0xffffffff } },
         3
     );
 }
@@ -144,7 +144,7 @@ fn test_bounce() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -160,7 +160,7 @@ fn test_add32() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x3 } },
+        { |res: Result| { res.unwrap() == 0x3 } },
         5
     );
 }
@@ -174,7 +174,7 @@ fn test_neg32() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xfffffffe } },
+        { |res: Result| { res.unwrap() == 0xfffffffe } },
         3
     );
 }
@@ -188,7 +188,7 @@ fn test_neg64() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xfffffffffffffffe } },
+        { |res: Result| { res.unwrap() == 0xfffffffffffffffe } },
         3
     );
 }
@@ -218,7 +218,7 @@ fn test_alu32_arithmetic() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x2a } },
+        { |res: Result| { res.unwrap() == 0x2a } },
         19
     );
 }
@@ -248,7 +248,7 @@ fn test_alu64_arithmetic() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x2a } },
+        { |res: Result| { res.unwrap() == 0x2a } },
         19
     );
 }
@@ -301,7 +301,7 @@ fn test_mul128() {
         exit",
         [0; 16],
         (),
-        { |res: ExecResult| { res.unwrap() == 600 } },
+        { |res: Result| { res.unwrap() == 600 } },
         42
     );
 }
@@ -333,7 +333,7 @@ fn test_alu32_logic() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11 } },
+        { |res: Result| { res.unwrap() == 0x11 } },
         21
     );
 }
@@ -367,7 +367,7 @@ fn test_alu64_logic() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11 } },
+        { |res: Result| { res.unwrap() == 0x11 } },
         23
     );
 }
@@ -382,7 +382,7 @@ fn test_arsh32_high_shift() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x4 } },
+        { |res: Result| { res.unwrap() == 0x4 } },
         4
     );
 }
@@ -397,7 +397,7 @@ fn test_arsh32_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xffff8000 } },
+        { |res: Result| { res.unwrap() == 0xffff8000 } },
         4
     );
 }
@@ -413,7 +413,7 @@ fn test_arsh32_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xffff8000 } },
+        { |res: Result| { res.unwrap() == 0xffff8000 } },
         5
     );
 }
@@ -430,7 +430,7 @@ fn test_arsh64() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xfffffffffffffff8 } },
+        { |res: Result| { res.unwrap() == 0xfffffffffffffff8 } },
         6
     );
 }
@@ -445,7 +445,7 @@ fn test_lsh64_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x10 } },
+        { |res: Result| { res.unwrap() == 0x10 } },
         4
     );
 }
@@ -460,7 +460,7 @@ fn test_rhs32_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x00ffffff } },
+        { |res: Result| { res.unwrap() == 0x00ffffff } },
         4
     );
 }
@@ -475,7 +475,7 @@ fn test_rsh64_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         4
     );
 }
@@ -489,7 +489,7 @@ fn test_be16() {
         exit",
         [0x11, 0x22],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1122 } },
+        { |res: Result| { res.unwrap() == 0x1122 } },
         3
     );
 }
@@ -503,7 +503,7 @@ fn test_be16_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1122 } },
+        { |res: Result| { res.unwrap() == 0x1122 } },
         3
     );
 }
@@ -517,7 +517,7 @@ fn test_be32() {
         exit",
         [0x11, 0x22, 0x33, 0x44],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11223344 } },
+        { |res: Result| { res.unwrap() == 0x11223344 } },
         3
     );
 }
@@ -531,7 +531,7 @@ fn test_be32_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11223344 } },
+        { |res: Result| { res.unwrap() == 0x11223344 } },
         3
     );
 }
@@ -545,7 +545,7 @@ fn test_be64() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1122334455667788 } },
+        { |res: Result| { res.unwrap() == 0x1122334455667788 } },
         3
     );
 }
@@ -559,7 +559,7 @@ fn test_le16() {
         exit",
         [0x22, 0x11],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1122 } },
+        { |res: Result| { res.unwrap() == 0x1122 } },
         3
     );
 }
@@ -573,7 +573,7 @@ fn test_le32() {
         exit",
         [0x44, 0x33, 0x22, 0x11],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11223344 } },
+        { |res: Result| { res.unwrap() == 0x11223344 } },
         3
     );
 }
@@ -587,7 +587,7 @@ fn test_le64() {
         exit",
         [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1122334455667788 } },
+        { |res: Result| { res.unwrap() == 0x1122334455667788 } },
         3
     );
 }
@@ -601,7 +601,7 @@ fn test_mul32_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xc } },
+        { |res: Result| { res.unwrap() == 0xc } },
         3
     );
 }
@@ -616,7 +616,7 @@ fn test_mul32_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xc } },
+        { |res: Result| { res.unwrap() == 0xc } },
         4
     );
 }
@@ -631,7 +631,7 @@ fn test_mul32_reg_overflow() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x4 } },
+        { |res: Result| { res.unwrap() == 0x4 } },
         4
     );
 }
@@ -645,7 +645,7 @@ fn test_mul64_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x100000004 } },
+        { |res: Result| { res.unwrap() == 0x100000004 } },
         3
     );
 }
@@ -660,7 +660,7 @@ fn test_mul64_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x100000004 } },
+        { |res: Result| { res.unwrap() == 0x100000004 } },
         4
     );
 }
@@ -675,7 +675,7 @@ fn test_div32_high_divisor() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x3 } },
+        { |res: Result| { res.unwrap() == 0x3 } },
         4
     );
 }
@@ -689,7 +689,7 @@ fn test_div32_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x3 } },
+        { |res: Result| { res.unwrap() == 0x3 } },
         3
     );
 }
@@ -704,7 +704,7 @@ fn test_div32_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x3 } },
+        { |res: Result| { res.unwrap() == 0x3 } },
         4
     );
 }
@@ -719,7 +719,7 @@ fn test_div64_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x300000000 } },
+        { |res: Result| { res.unwrap() == 0x300000000 } },
         4
     );
 }
@@ -735,7 +735,7 @@ fn test_div64_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x300000000 } },
+        { |res: Result| { res.unwrap() == 0x300000000 } },
         5
     );
 }
@@ -750,7 +750,7 @@ fn test_err_div64_by_zero_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
+        { |res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
 }
@@ -765,7 +765,7 @@ fn test_err_div_by_zero_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
+        { |res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
 }
@@ -781,7 +781,7 @@ fn test_mod32() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x5 } },
+        { |res: Result| { res.unwrap() == 0x5 } },
         5
     );
 }
@@ -795,7 +795,7 @@ fn test_mod32_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         3
     );
 }
@@ -815,7 +815,7 @@ fn test_mod64() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x30ba5a04 } },
+        { |res: Result| { res.unwrap() == 0x30ba5a04 } },
         9
     );
 }
@@ -830,7 +830,7 @@ fn test_err_mod64_by_zero_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
+        { |res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
 }
@@ -845,7 +845,7 @@ fn test_err_mod_by_zero_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
+        { |res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
 }
@@ -863,7 +863,7 @@ fn test_ldabsb() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x33 } },
+        { |res: Result| { res.unwrap() == 0x33 } },
         2
     );
 }
@@ -879,7 +879,7 @@ fn test_ldabsh() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x4433 } },
+        { |res: Result| { res.unwrap() == 0x4433 } },
         2
     );
 }
@@ -895,7 +895,7 @@ fn test_ldabsw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x66554433 } },
+        { |res: Result| { res.unwrap() == 0x66554433 } },
         2
     );
 }
@@ -911,7 +911,7 @@ fn test_ldabsdw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xaa99887766554433 } },
+        { |res: Result| { res.unwrap() == 0xaa99887766554433 } },
         2
     );
 }
@@ -928,7 +928,7 @@ fn test_err_ldabsb_oob() {
         ],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Load && pc == 29
@@ -948,7 +948,7 @@ fn test_err_ldabsb_nomem() {
         [],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Load && pc == 29
@@ -971,7 +971,7 @@ fn test_ldindb() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x88 } },
+        { |res: Result| { res.unwrap() == 0x88 } },
         3
     );
 }
@@ -988,7 +988,7 @@ fn test_ldindh() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x9988 } },
+        { |res: Result| { res.unwrap() == 0x9988 } },
         3
     );
 }
@@ -1005,7 +1005,7 @@ fn test_ldindw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x88776655 } },
+        { |res: Result| { res.unwrap() == 0x88776655 } },
         3
     );
 }
@@ -1022,7 +1022,7 @@ fn test_ldinddw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xccbbaa9988776655 } },
+        { |res: Result| { res.unwrap() == 0xccbbaa9988776655 } },
         3
     );
 }
@@ -1040,7 +1040,7 @@ fn test_err_ldindb_oob() {
         ],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Load && pc == 30
@@ -1061,7 +1061,7 @@ fn test_err_ldindb_nomem() {
         [],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Load && pc == 30
@@ -1080,7 +1080,7 @@ fn test_ldxb() {
         exit",
         [0xaa, 0xbb, 0x11, 0xcc, 0xdd],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11 } },
+        { |res: Result| { res.unwrap() == 0x11 } },
         2
     );
 }
@@ -1093,7 +1093,7 @@ fn test_ldxh() {
         exit",
         [0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x2211 } },
+        { |res: Result| { res.unwrap() == 0x2211 } },
         2
     );
 }
@@ -1108,7 +1108,7 @@ fn test_ldxw() {
             0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x44332211 } },
+        { |res: Result| { res.unwrap() == 0x44332211 } },
         2
     );
 }
@@ -1123,7 +1123,7 @@ fn test_ldxh_same_reg() {
         exit",
         [0xff, 0xff],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1234 } },
+        { |res: Result| { res.unwrap() == 0x1234 } },
         4
     );
 }
@@ -1139,7 +1139,7 @@ fn test_lldxdw() {
             0x77, 0x88, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x8877665544332211 } },
+        { |res: Result| { res.unwrap() == 0x8877665544332211 } },
         2
     );
 }
@@ -1156,7 +1156,7 @@ fn test_err_ldxdw_oob() {
         ],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Load && pc == 29
@@ -1207,7 +1207,7 @@ fn test_ldxb_all() {
             0x08, 0x09, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x9876543210 } },
+        { |res: Result| { res.unwrap() == 0x9876543210 } },
         31
     );
 }
@@ -1263,7 +1263,7 @@ fn test_ldxh_all() {
             0x00, 0x08, 0x00, 0x09, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x9876543210 } },
+        { |res: Result| { res.unwrap() == 0x9876543210 } },
         41
     );
 }
@@ -1309,7 +1309,7 @@ fn test_ldxh_all2() {
             0x01, 0x00, 0x02, 0x00, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x3ff } },
+        { |res: Result| { res.unwrap() == 0x3ff } },
         31
     );
 }
@@ -1357,7 +1357,7 @@ fn test_ldxw_all() {
             0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x030f0f } },
+        { |res: Result| { res.unwrap() == 0x030f0f } },
         31
     );
 }
@@ -1370,7 +1370,7 @@ fn test_lddw() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1122334455667788 } },
+        { |res: Result| { res.unwrap() == 0x1122334455667788 } },
         2
     );
 }
@@ -1383,7 +1383,7 @@ fn test_lddw2() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x80000000 } },
+        { |res: Result| { res.unwrap() == 0x80000000 } },
         2
     );
 }
@@ -1397,7 +1397,7 @@ fn test_stb() {
         exit",
         [0xaa, 0xbb, 0xff, 0xcc, 0xdd],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11 } },
+        { |res: Result| { res.unwrap() == 0x11 } },
         3
     );
 }
@@ -1413,7 +1413,7 @@ fn test_sth() {
             0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x2211 } },
+        { |res: Result| { res.unwrap() == 0x2211 } },
         3
     );
 }
@@ -1429,7 +1429,7 @@ fn test_stw() {
             0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x44332211 } },
+        { |res: Result| { res.unwrap() == 0x44332211 } },
         3
     );
 }
@@ -1446,7 +1446,7 @@ fn test_stdw() {
             0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x44332211 } },
+        { |res: Result| { res.unwrap() == 0x44332211 } },
         3
     );
 }
@@ -1463,7 +1463,7 @@ fn test_stxb() {
             0xaa, 0xbb, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x11 } },
+        { |res: Result| { res.unwrap() == 0x11 } },
         4
     );
 }
@@ -1480,7 +1480,7 @@ fn test_stxh() {
             0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x2211 } },
+        { |res: Result| { res.unwrap() == 0x2211 } },
         4
     );
 }
@@ -1497,7 +1497,7 @@ fn test_stxw() {
             0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x44332211 } },
+        { |res: Result| { res.unwrap() == 0x44332211 } },
         4
     );
 }
@@ -1517,7 +1517,7 @@ fn test_stxdw() {
             0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x8877665544332211 } },
+        { |res: Result| { res.unwrap() == 0x8877665544332211 } },
         6
     );
 }
@@ -1549,7 +1549,7 @@ fn test_stxb_all() {
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xf0f2f3f4f5f6f7f8 } },
+        { |res: Result| { res.unwrap() == 0xf0f2f3f4f5f6f7f8 } },
         19
     );
 }
@@ -1568,7 +1568,7 @@ fn test_stxb_all2() {
         exit",
         [0xff, 0xff],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xf1f9 } },
+        { |res: Result| { res.unwrap() == 0xf1f9 } },
         8
     );
 }
@@ -1603,7 +1603,7 @@ fn test_stxb_chain() {
             0x00, 0x00, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x2a } },
+        { |res: Result| { res.unwrap() == 0x2a } },
         21
     );
 }
@@ -1617,7 +1617,7 @@ fn test_exit_without_value() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         1
     );
 }
@@ -1630,7 +1630,7 @@ fn test_exit() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         2
     );
 }
@@ -1645,7 +1645,7 @@ fn test_early_exit() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x3 } },
+        { |res: Result| { res.unwrap() == 0x3 } },
         2
     );
 }
@@ -1660,7 +1660,7 @@ fn test_ja() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         3
     );
 }
@@ -1679,7 +1679,7 @@ fn test_jeq_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1699,7 +1699,7 @@ fn test_jeq_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         8
     );
 }
@@ -1718,7 +1718,7 @@ fn test_jge_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1738,7 +1738,7 @@ fn test_jge_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         8
     );
 }
@@ -1758,7 +1758,7 @@ fn test_jle_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1780,7 +1780,7 @@ fn test_jle_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         9
     );
 }
@@ -1799,7 +1799,7 @@ fn test_jgt_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1820,7 +1820,7 @@ fn test_jgt_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         9
     );
 }
@@ -1839,7 +1839,7 @@ fn test_jlt_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1860,7 +1860,7 @@ fn test_jlt_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         9
     );
 }
@@ -1879,7 +1879,7 @@ fn test_jne_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1899,7 +1899,7 @@ fn test_jne_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         8
     );
 }
@@ -1918,7 +1918,7 @@ fn test_jset_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -1938,7 +1938,7 @@ fn test_jset_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         8
     );
 }
@@ -1958,7 +1958,7 @@ fn test_jsge_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         8
     );
 }
@@ -1980,7 +1980,7 @@ fn test_jsge_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         10
     );
 }
@@ -2000,7 +2000,7 @@ fn test_jsle_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -2023,7 +2023,7 @@ fn test_jsle_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         10
     );
 }
@@ -2042,7 +2042,7 @@ fn test_jsgt_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -2062,7 +2062,7 @@ fn test_jsgt_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         8
     );
 }
@@ -2081,7 +2081,7 @@ fn test_jslt_imm() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         7
     );
 }
@@ -2102,7 +2102,7 @@ fn test_jslt_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         9
     );
 }
@@ -2124,7 +2124,7 @@ fn test_stack1() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0xcd } },
+        { |res: Result| { res.unwrap() == 0xcd } },
         9
     );
 }
@@ -2154,7 +2154,7 @@ fn test_stack2() {
             0 => syscalls::BpfGatherBytes::call; std::ptr::null_mut(),
             1 => syscalls::BpfMemFrob::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0x01020304 } },
+        { |res: Result| { res.unwrap() == 0x01020304 } },
         16
     );
 }
@@ -2195,7 +2195,7 @@ fn test_string_stack() {
         (
             0 => syscalls::BpfStrCmp::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         28
     );
 }
@@ -2209,7 +2209,7 @@ fn test_err_stack_out_of_bound() {
         [],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Store && pc == 29
@@ -2230,7 +2230,7 @@ fn test_relative_call() {
         (
             hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 2 } },
+        { |res: Result| { res.unwrap() == 2 } },
         14
     );
 }
@@ -2243,7 +2243,7 @@ fn test_bpf_to_bpf_scratch_registers() {
         (
             hash_symbol_name(b"log_64") => BpfSyscallU64::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 112 } },
+        { |res: Result| { res.unwrap() == 112 } },
         41
     );
 }
@@ -2254,7 +2254,7 @@ fn test_bpf_to_bpf_pass_stack_reference() {
         "tests/elfs/pass_stack_reference.so",
         [],
         (),
-        { |res: ExecResult| res.unwrap() == 42 },
+        { |res: Result| res.unwrap() == 42 },
         29
     );
 }
@@ -2273,7 +2273,7 @@ fn test_syscall_parameter_on_stack() {
         (
             0 => BpfSyscallString::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         6
     );
 }
@@ -2292,7 +2292,7 @@ fn test_call_reg() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 42 } },
+        { |res: Result| { res.unwrap() == 42 } },
         8
     );
 }
@@ -2307,7 +2307,7 @@ fn test_err_oob_callx_low() {
         [],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::CallOutsideTextSegment(pc, target_pc)
                     if pc == 30 && target_pc == 0
@@ -2329,7 +2329,7 @@ fn test_err_oob_callx_high() {
         [],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::CallOutsideTextSegment(pc, target_pc)
                     if pc == 31 && target_pc == 0xffffffff00000000
@@ -2350,7 +2350,7 @@ fn test_bpf_to_bpf_depth() {
             (
                 hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
             ),
-            { |res: ExecResult| { res.unwrap() == 0 } },
+            { |res: Result| { res.unwrap() == 0 } },
             if i == 0 { 4 } else { 3 + 10 * i as u64 }
         );
     }
@@ -2366,7 +2366,7 @@ fn test_err_bpf_to_bpf_too_deep() {
             hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::CallDepthExceeded(pc, depth)
                     if pc == 55 && depth == config.max_call_depth
@@ -2391,7 +2391,7 @@ fn test_err_reg_stack_depth() {
             hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::CallDepthExceeded(pc, depth)
                     if pc == 31 && depth == config.max_call_depth
@@ -2425,7 +2425,7 @@ fn test_call_save() {
         (
             0 => syscalls::trash_registers,
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } }
+        { |res: Result| { res.unwrap() == 0 } }
     );
 }*/
 
@@ -2442,7 +2442,7 @@ fn test_err_syscall_string() {
             0 => BpfSyscallString::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::AccessViolation(pc, access_type, _, _, _)
                     if access_type == AccessType::Load && pc == 0
@@ -2465,7 +2465,7 @@ fn test_syscall_string() {
         (
             0 => BpfSyscallString::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         4
     );
 }
@@ -2486,7 +2486,7 @@ fn test_syscall() {
         (
             0 => BpfSyscallU64::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         8
     );
 }
@@ -2506,7 +2506,7 @@ fn test_call_gather_bytes() {
         (
             0 => syscalls::BpfGatherBytes::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0x0102030405 } },
+        { |res: Result| { res.unwrap() == 0x0102030405 } },
         7
     );
 }
@@ -2528,7 +2528,7 @@ fn test_call_memfrob() {
         (
             0 => syscalls::BpfMemFrob::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0x102292e2f2c0708 } },
+        { |res: Result| { res.unwrap() == 0x102292e2f2c0708 } },
         7
     );
 }
@@ -2551,7 +2551,7 @@ fn test_syscall_with_context() {
         (
             0 => SyscallWithContext::call; &mut syscall_context_object as *mut _ as *mut u8,
         ),
-        { |res: ExecResult| {
+        { |res: Result| {
             unsafe {
                 assert_eq!(*number_ptr, 84);
                 *number_ptr = 42;
@@ -2573,7 +2573,7 @@ fn test_load_elf() {
             hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
             hash_symbol_name(b"log_64") => BpfSyscallU64::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         11
     );
 }
@@ -2586,7 +2586,7 @@ fn test_load_elf_empty_noro() {
         (
             hash_symbol_name(b"log_64") => BpfSyscallU64::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         8
     );
 }
@@ -2599,7 +2599,7 @@ fn test_load_elf_empty_rodata() {
         (
             hash_symbol_name(b"log_64") => BpfSyscallU64::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         8
     );
 }
@@ -2620,7 +2620,7 @@ fn test_custom_entrypoint() {
             hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
             hash_symbol_name(b"log_64") => BpfSyscallU64::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         2
     );
 }
@@ -2639,7 +2639,7 @@ fn test_instruction_count_syscall() {
         (
             0 => BpfSyscallString::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         4
     );
 }
@@ -2657,7 +2657,7 @@ fn test_err_instruction_count_syscall_capped() {
             0 => BpfSyscallString::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
                     if pc == 32 && initial_insn_count == 3
@@ -2685,7 +2685,7 @@ fn test_non_terminate_early() {
         [],
         (),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::ELFError(ELFError::UnresolvedSymbol(a, b, c))
                     if a == "Unknown" && b == 35 && c == 48
@@ -2715,7 +2715,7 @@ fn test_err_non_terminate_capped() {
             0 => BpfTracePrintf::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
                     if pc == 35 && initial_insn_count == 6
@@ -2745,7 +2745,7 @@ fn test_err_non_terminating_capped() {
             0 => BpfTracePrintf::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| {
+            |res: Result| {
                 matches!(res.unwrap_err(),
                     EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
                     if pc == 37 && initial_insn_count == 1000
@@ -2772,7 +2772,7 @@ fn test_symbol_relocation() {
         (
             0 => BpfSyscallString::call; std::ptr::null_mut(),
         ),
-        { |res: ExecResult| { res.unwrap() == 0 } },
+        { |res: Result| { res.unwrap() == 0 } },
         6
     );
 }
@@ -2787,7 +2787,7 @@ fn test_err_symbol_unresolved() {
         [],
         (),
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 29 && offset == 0)
+            |res: Result| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 29 && offset == 0)
         },
         1
     );
@@ -2807,7 +2807,7 @@ fn test_err_call_unresolved() {
         [],
         (),
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 34 && offset == 40)
+            |res: Result| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 34 && offset == 40)
         },
         6
     );
@@ -2822,7 +2822,7 @@ fn test_err_unresolved_elf() {
             hash_symbol_name(b"log") => BpfSyscallString::call; std::ptr::null_mut(),
         ),
         {
-            |res: ExecResult| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "log_64" && pc == 550 && offset == 4168)
+            |res: Result| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "log_64" && pc == 550 && offset == 4168)
         },
         9
     );
@@ -2846,7 +2846,7 @@ fn test_mul_loop() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x75db9c97 } },
+        { |res: Result| { res.unwrap() == 0x75db9c97 } },
         37
     );
 }
@@ -2873,7 +2873,7 @@ fn test_prime() {
         exit",
         [],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         655
     );
 }
@@ -2909,7 +2909,7 @@ fn test_subnet() {
             0x03, 0x00, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         11
     );
 }
@@ -2934,7 +2934,7 @@ fn test_tcp_port80_match() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x1 } },
+        { |res: Result| { res.unwrap() == 0x1 } },
         17
     );
 }
@@ -2959,7 +2959,7 @@ fn test_tcp_port80_nomatch() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         18
     );
 }
@@ -2984,7 +2984,7 @@ fn test_tcp_port80_nomatch_ethertype() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         7
     );
 }
@@ -3009,7 +3009,7 @@ fn test_tcp_port80_nomatch_proto() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        { |res: ExecResult| { res.unwrap() == 0x0 } },
+        { |res: Result| { res.unwrap() == 0x0 } },
         9
     );
 }
@@ -3020,7 +3020,7 @@ fn test_tcp_sack_match() {
         TCP_SACK_ASM,
         TCP_SACK_MATCH,
         (),
-        { |res: ExecResult| res.unwrap() == 0x1 },
+        { |res: Result| res.unwrap() == 0x1 },
         79
     );
 }
@@ -3031,7 +3031,7 @@ fn test_tcp_sack_nomatch() {
         TCP_SACK_ASM,
         TCP_SACK_NOMATCH,
         (),
-        { |res: ExecResult| res.unwrap() == 0x0 },
+        { |res: Result| res.unwrap() == 0x0 },
         55
     );
 }
@@ -3102,7 +3102,7 @@ fn test_large_program() {
             executable,
             [],
             (),
-            { |res: ExecResult| res.unwrap() == 0x0 },
+            { |res: Result| res.unwrap() == 0x0 },
             ebpf::PROG_MAX_INSNS as u64
         );
     }

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -51,15 +51,15 @@ fn test_verifier_success() {
         exit",
     )
     .unwrap();
-    let executable =
-        Executable::<VerifierTestError>::from_text_bytes(&prog, Some(verifier_success)).unwrap();
-    let _ = EbpfVm::<VerifierTestError, DefaultInstructionMeter>::new(
-        executable.as_ref(),
+    let executable = Executable::<VerifierTestError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(verifier_success),
         Config::default(),
-        &[],
-        &[],
     )
     .unwrap();
+    let _ =
+        EbpfVm::<VerifierTestError, DefaultInstructionMeter>::new(executable.as_ref(), &[], &[])
+            .unwrap();
 }
 
 #[test]
@@ -74,7 +74,12 @@ fn test_verifier_fail() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<VerifierTestError>::from_text_bytes(&prog, Some(verifier_fail)).unwrap();
+    let _ = Executable::<VerifierTestError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(verifier_fail),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -87,7 +92,12 @@ fn test_verifier_err_div_by_zero_imm() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -98,7 +108,12 @@ fn test_verifier_err_endian_size() {
         0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = Executable::<UserError>::from_text_bytes(prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -109,7 +124,12 @@ fn test_verifier_err_incomplete_lddw() {
         0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = Executable::<UserError>::from_text_bytes(prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -121,7 +141,12 @@ fn test_verifier_err_infinite_loop() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -133,7 +158,12 @@ fn test_verifier_err_invalid_reg_dst() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -145,7 +175,12 @@ fn test_verifier_err_invalid_reg_src() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -158,7 +193,12 @@ fn test_verifier_err_jmp_lddw() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -170,7 +210,12 @@ fn test_verifier_err_jmp_out() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -181,7 +226,12 @@ fn test_verifier_err_no_exit() {
         mov32 r0, 0",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -196,7 +246,12 @@ fn test_verifier_err_too_many_instructions() {
         .collect::<Vec<u8>>();
     prog.append(&mut vec![0x95, 0, 0, 0, 0, 0, 0, 0]);
 
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -206,7 +261,12 @@ fn test_verifier_err_unknown_opcode() {
         0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = Executable::<UserError>::from_text_bytes(prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -218,5 +278,10 @@ fn test_verifier_err_write_r10() {
         exit",
     )
     .unwrap();
-    let _ = Executable::<UserError>::from_text_bytes(&prog, Some(check)).unwrap();
+    let _ = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
+        &prog,
+        Some(check),
+        Config::default(),
+    )
+    .unwrap();
 }


### PR DESCRIPTION
Changes:
- JIT compile and Config moved from VM to Executable
- Syscall registration split:
  - Function pointers are registered in SyscallRegistry (via hash or name)
  - SyscallRegistry is passed to Executable
  - Context objects are bound in VM (via dyn trait)
- All syscalls have context objects now (no more function only)
- The context object instances of syscalls are stored in a table and accessed dynamically at runtime
- Syscalls return type became an &mut parameter (because of conflict with the &mut self parameter)
- PC loc jump table inlined into compiled function
- JIT syscalls became more efficient as the register moves to shuffle the arguments are not necessary anymore
- Security: JIT function permissions corrected (removed write permission on executable pages)