### PR TITLE
Fix JIT Machine Code Size Estimation

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -11,9 +11,8 @@ extern crate test;
 extern crate test_utils;
 
 use solana_rbpf::{
-    ebpf::hash_symbol_name,
     user_error::UserError,
-    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject, SyscallRegistry},
+    vm::{Config, DefaultInstructionMeter, Executable, SyscallObject, SyscallRegistry},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -42,6 +41,7 @@ fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
             Config::default(),
         )
         .unwrap();
+        executable
     });
 }
 
@@ -62,5 +62,6 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
             .register_syscall_by_name::<UserError, _>(b"log_64", BpfSyscallU64::call)
             .unwrap();
         executable.set_syscall_registry(syscall_registry);
+        executable
     });
 }

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -9,7 +9,7 @@ use crate::{
 /// One call frame
 #[derive(Clone, Debug)]
 struct CallFrame {
-    stack: MemoryRegion,
+    vm_addr: u64,
     saved_reg: [u64; 4],
     return_ptr: usize,
 }
@@ -20,20 +20,25 @@ struct CallFrame {
 #[derive(Clone, Debug)]
 pub struct CallFrames {
     stack: Vec<u8>,
-    frame: usize,
-    max_frame: usize,
+    region: MemoryRegion,
+    frame_index: usize,
+    frame_index_max: usize,
     frames: Vec<CallFrame>,
 }
 impl CallFrames {
     /// New call frame, depth indicates maximum call depth
-    pub fn new(depth: usize, size: usize) -> Self {
+    pub fn new(depth: usize, frame_size: usize) -> Self {
+        let stack = vec![0u8; depth * frame_size];
+        let region =
+            MemoryRegion::new_from_slice(&stack[..], MM_STACK_START, frame_size as u64, true);
         let mut frames = CallFrames {
-            stack: vec![0u8; depth * size],
-            frame: 0,
-            max_frame: 0,
+            stack,
+            region,
+            frame_index: 0,
+            frame_index_max: 0,
             frames: vec![
                 CallFrame {
-                    stack: MemoryRegion::default(),
+                    vm_addr: 0,
                     saved_reg: [0u64; SCRATCH_REGS],
                     return_ptr: 0
                 };
@@ -41,39 +46,35 @@ impl CallFrames {
             ],
         };
         for i in 0..depth {
-            let start = i * size;
-            let end = start + size;
             // Seperate each stack frame's virtual address so that stack over/under-run is caught explicitly
-            let vm_addr = MM_STACK_START + (i * 2 * size) as u64;
-            frames.frames[i].stack =
-                MemoryRegion::new_from_slice(&frames.stack[start..end], vm_addr, true);
+            frames.frames[i].vm_addr = MM_STACK_START + (i * 2 * frame_size) as u64;
         }
         frames
     }
 
-    /// Get stack pointers
-    pub fn get_stacks(&self) -> Vec<MemoryRegion> {
-        let mut ptrs = Vec::new();
-        for frame in self.frames.iter() {
-            ptrs.push(frame.stack.clone());
-        }
-        ptrs
+    /// Get stack memory region
+    pub fn get_region(&self) -> &MemoryRegion {
+        &self.region
+    }
+
+    /// Get the vm address of the beginning of each stack frame
+    pub fn get_frame_pointers(&self) -> Vec<u64> {
+        self.frames.iter().map(|frame| frame.vm_addr).collect()
     }
 
     /// Get the address of a frame's top of stack
     pub fn get_stack_top(&self) -> u64 {
-        self.frames[self.frame].stack.vm_addr + self.frames[self.frame].stack.len
+        self.frames[self.frame_index].vm_addr + (1 << self.region.vm_gap_shift)
     }
 
     /// Get current call frame index, 0 is the root frame
-    #[allow(dead_code)]
     pub fn get_frame_index(&self) -> usize {
-        self.frame
+        self.frame_index
     }
 
     /// Get max frame index
     pub fn get_max_frame_index(&self) -> usize {
-        self.max_frame
+        self.frame_index_max
     }
 
     /// Push a frame
@@ -82,18 +83,16 @@ impl CallFrames {
         saved_reg: &[u64],
         return_ptr: usize,
     ) -> Result<u64, EbpfError<E>> {
-        if self.frame + 1 >= self.frames.len() {
+        if self.frame_index + 1 >= self.frames.len() {
             return Err(EbpfError::CallDepthExceeded(
                 return_ptr + ELF_INSN_DUMP_OFFSET - 1,
                 self.frames.len(),
             ));
         }
-        self.frames[self.frame].saved_reg[..].copy_from_slice(saved_reg);
-        self.frames[self.frame].return_ptr = return_ptr;
-        self.frame += 1;
-        if self.frame > self.max_frame {
-            self.max_frame = self.frame;
-        }
+        self.frames[self.frame_index].saved_reg[..].copy_from_slice(saved_reg);
+        self.frames[self.frame_index].return_ptr = return_ptr;
+        self.frame_index += 1;
+        self.frame_index_max = self.frame_index_max.max(self.frame_index);
         Ok(self.get_stack_top())
     }
 
@@ -101,14 +100,14 @@ impl CallFrames {
     pub fn pop<E: UserDefinedError>(
         &mut self,
     ) -> Result<([u64; SCRATCH_REGS], u64, usize), EbpfError<E>> {
-        if self.frame == 0 {
+        if self.frame_index == 0 {
             return Err(EbpfError::ExitRootCallFrame);
         }
-        self.frame -= 1;
+        self.frame_index -= 1;
         Ok((
-            self.frames[self.frame].saved_reg,
+            self.frames[self.frame_index].saved_reg,
             self.get_stack_top(),
-            self.frames[self.frame].return_ptr,
+            self.frames[self.frame_index].return_ptr,
         ))
     }
 }
@@ -121,35 +120,31 @@ mod tests {
     #[test]
     fn test_frames() {
         const DEPTH: usize = 10;
-        const SIZE: usize = 5;
-        let mut frames = CallFrames::new(DEPTH, SIZE);
-        let mut ptrs: Vec<MemoryRegion> = Vec::new();
+        const FRAME_SIZE: u64 = 8;
+        let mut frames = CallFrames::new(DEPTH, FRAME_SIZE as usize);
+        let mut ptrs: Vec<u64> = Vec::new();
         for i in 0..DEPTH - 1 {
-            let registers = vec![i as u64; SIZE];
+            let registers = vec![i as u64; FRAME_SIZE as usize];
             assert_eq!(frames.get_frame_index(), i);
-            ptrs.push(frames.get_stacks()[i].clone());
-            assert_eq!(ptrs[i].len, SIZE as u64);
+            ptrs.push(frames.get_frame_pointers()[i]);
 
             let top = frames.push::<UserError>(&registers[0..4], i).unwrap();
-            let new_ptrs = frames.get_stacks();
-            assert_eq!(top, new_ptrs[i + 1].vm_addr + new_ptrs[i + 1].len);
-            assert_ne!(top, ptrs[i].vm_addr + ptrs[i].len - 1);
-            assert!(
-                !(ptrs[i].vm_addr <= new_ptrs[i + 1].vm_addr
-                    && new_ptrs[i + 1].vm_addr < ptrs[i].vm_addr + ptrs[i].len)
-            );
+            let new_ptrs = frames.get_frame_pointers();
+            assert_eq!(top, new_ptrs[i + 1] + FRAME_SIZE);
+            assert_ne!(top, ptrs[i] + FRAME_SIZE - 1);
+            assert!(!(ptrs[i] <= new_ptrs[i + 1] && new_ptrs[i + 1] < ptrs[i] + FRAME_SIZE));
         }
         let i = DEPTH - 1;
-        let registers = vec![i as u64; SIZE];
+        let registers = vec![i as u64; FRAME_SIZE as usize];
         assert_eq!(frames.get_frame_index(), i);
-        ptrs.push(frames.get_stacks()[i].clone());
+        ptrs.push(frames.get_frame_pointers()[i]);
 
         assert!(frames.push::<UserError>(&registers, DEPTH - 1).is_err());
 
         for i in (0..DEPTH - 1).rev() {
             let (saved_reg, stack_ptr, return_ptr) = frames.pop::<UserError>().unwrap();
             assert_eq!(saved_reg, [i as u64, i as u64, i as u64, i as u64]);
-            assert_eq!(ptrs[i].vm_addr + ptrs[i].len, stack_ptr);
+            assert_eq!(ptrs[i] + FRAME_SIZE, stack_ptr);
             assert_eq!(i, return_ptr);
         }
 

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -205,7 +205,7 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 ///
 /// let val = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33];
 /// let val_va = 0x1000;
-/// let memory_mapping = [MemoryRegion::new_from_slice(&val, val_va, true)];
+/// let memory_mapping = [MemoryRegion::new_from_slice(&val, val_va, 0, true)];
 ///
 /// let mut result: Result = Ok(0);
 /// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec()), &mut result);
@@ -302,11 +302,11 @@ impl SyscallObject<UserError> for BpfSqrtI {
 /// let va_foo = 0x1000;
 /// let va_bar = 0x2000;
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, false)];
+/// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false)];
 /// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec()), &mut result);
 /// assert!(result.unwrap() == 0);
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, false)];
+/// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, 0, false)];
 /// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &MemoryMapping::new_from_regions(memory_mapping.to_vec()), &mut result);
 /// assert!(result.unwrap() != 0);
 /// ```


### PR DESCRIPTION
Measured the following sizes of generated machine code for various expensive operations:
* Address translation: 104 bytes
* Instruction profiling and limiting: 20 bytes
* Syscall: 238 bytes
* BPF-to-BPF static call: 98 bytes
* BPF-to-BPF dynamic call: 185 bytes
* Exit / return: 68 bytes

Based on that we can set an upper size limit by estimating a maximal length of 256 bytes per instruction.