### PR TITLE
Instruction Tracing

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -248,7 +248,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> for EBpfElf<E, I
 
     /// JIT compile the executable
     fn jit_compile(&mut self) -> Result<(), EbpfError<E>> {
-        self.compiled_program = Some(compile::<E, I>(self, true)?);
+        self.compiled_program = Some(compile::<E, I>(self)?);
         Ok(())
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -180,7 +180,7 @@ impl Default for Config {
         Self {
             max_call_depth: 20,
             stack_frame_size: 4_096,
-            enable_trace: true,
+            enable_trace: false,
         }
     }
 }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -63,14 +63,18 @@ macro_rules! test_interpreter_and_jit {
                     test_interpreter_and_jit!(2, vm, $($location => $syscall_function; $syscall_context_object),*);
                     let result = vm.execute_program_jit(&mut TestInstructionMeter { remaining: $expected_instruction_count });
                     assert!(check_closure(&vm, result));
-                    let instruction_count_jit = vm.get_total_instruction_count();
-                    assert_eq!(instruction_count_interpreter, instruction_count_jit);
+                    if $executable.get_config().enable_instruction_meter {
+                        let instruction_count_jit = vm.get_total_instruction_count();
+                        assert_eq!(instruction_count_interpreter, instruction_count_jit);
+                    }
                     let tracer_jit = vm.get_tracer();
                     assert!(solana_rbpf::vm::Tracer::compare(&_tracer_interpreter, tracer_jit));
                 },
             }
         }
-        assert_eq!(instruction_count_interpreter, $expected_instruction_count);
+        if $executable.get_config().enable_instruction_meter {
+            assert_eq!(instruction_count_interpreter, $expected_instruction_count);
+        }
     };
 }
 
@@ -79,8 +83,10 @@ macro_rules! test_interpreter_and_jit_asm {
         let program = assemble($source).unwrap();
         #[allow(unused_mut)]
         {
-            let mut config = Config::default();
-            config.enable_trace = true;
+            let config = Config {
+                enable_instruction_tracing: true,
+                ..Default::default()
+            };
             let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(&program, None, config).unwrap();
             test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
         }
@@ -94,8 +100,10 @@ macro_rules! test_interpreter_and_jit_elf {
         file.read_to_end(&mut elf).unwrap();
         #[allow(unused_mut)]
         {
-            let mut config = Config::default();
-            config.enable_trace = true;
+            let config = Config {
+                enable_instruction_tracing: true,
+                ..Default::default()
+            };
             let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, config).unwrap();
             test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
         }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -79,7 +79,9 @@ macro_rules! test_interpreter_and_jit_asm {
         let program = assemble($source).unwrap();
         #[allow(unused_mut)]
         {
-            let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(&program, None, Config::default()).unwrap();
+            let mut config = Config::default();
+            config.enable_trace = true;
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(&program, None, config).unwrap();
             test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
         }
     };
@@ -92,7 +94,9 @@ macro_rules! test_interpreter_and_jit_elf {
         file.read_to_end(&mut elf).unwrap();
         #[allow(unused_mut)]
         {
-            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, Config::default()).unwrap();
+            let mut config = Config::default();
+            config.enable_trace = true;
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, config).unwrap();
             test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
         }
     };

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -19,9 +19,7 @@ use solana_rbpf::{
     syscalls,
     user_error::UserError,
     verifier::check,
-    vm::{
-        Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject, SyscallRegistry, Tracer,
-    },
+    vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject, SyscallRegistry},
 };
 use std::{fs::File, io::Read};
 use test_utils::{
@@ -41,7 +39,7 @@ macro_rules! test_interpreter_and_jit {
         let mut syscall_registry = SyscallRegistry::default();
         test_interpreter_and_jit!(1, syscall_registry, $($location => $syscall_function; $syscall_context_object),*);
         $executable.set_syscall_registry(syscall_registry);
-        let (instruction_count_interpreter, tracer_interpreter) = {
+        let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
             let mut vm = EbpfVm::new($executable.as_ref(), &mut mem, &[]).unwrap();
             test_interpreter_and_jit!(2, vm, $($location => $syscall_function; $syscall_context_object),*);
@@ -68,7 +66,7 @@ macro_rules! test_interpreter_and_jit {
                     let instruction_count_jit = vm.get_total_instruction_count();
                     assert_eq!(instruction_count_interpreter, instruction_count_jit);
                     let tracer_jit = vm.get_tracer();
-                    assert!(Tracer::compare(&tracer_interpreter, tracer_jit));
+                    assert!(solana_rbpf::vm::Tracer::compare(&_tracer_interpreter, tracer_jit));
                 },
             }
         }


### PR DESCRIPTION
Reimplements the instruction tracer for the interpreter and introduces it to the JIT as well.
Now the log is not printed directly but stored in a vector and used for testing.
The tests compare the trace logs of interpreter and JIT, thus make sure that they stay in sync on an instruction level.
The display formatting of the trace log is also more efficient than before,
as it only needs to disassemble the program once instead of for each line.

This feature uncovered two bugs in the JIT which were fixed as well.