### PR TITLE
JIT delay unresolved symbol to runtime

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -253,7 +253,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> for EBpfElf<E, I
     }
 
     /// Report information on a symbol that failed to be resolved
-    fn report_unresolved_symbol(&self, insn_offset: usize) -> Result<(), EbpfError<E>> {
+    fn report_unresolved_symbol(&self, insn_offset: usize) -> Result<u64, EbpfError<E>> {
         let file_offset = insn_offset
             .saturating_mul(ebpf::INSN_SIZE)
             .saturating_add(self.text_section_info.offset_range.start as usize);

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,9 +37,6 @@ pub enum EbpfError<E: UserDefinedError> {
     /// Syscall already has a bound context object
     #[error("syscall already has a bound context object")]
     SycallAlreadyBound,
-    /// No program or ELF set
-    #[error("no program or ELF set")]
-    NothingToExecute,
     /// Exceeded max BPF to BPF call depth
     #[error("exceeded max BPF to BPF call depth of {1} at instruction #{0}")]
     CallDepthExceeded(usize, usize),
@@ -57,9 +54,6 @@ pub enum EbpfError<E: UserDefinedError> {
         "callx at instruction {0} attempted to call outside of the text segment to addr 0x{1:x}"
     )]
     CallOutsideTextSegment(usize, u64),
-    /// Unresolved symbol
-    #[error("unresolved symbol at instruction #{0}")]
-    UnresolvedSymbol(usize),
     /// Exceeded max instructions allowed
     #[error("exceeded maximum number of instructions allowed ({1}) at instruction #{0}")]
     ExceededMaxInstructions(usize, u64),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -79,26 +79,26 @@ pub struct Syscall {
     pub context_object_slot: usize,
 }
 
-/// A virtual method table for SyscallObject
-pub struct SyscallObjectVtable {
+/// A virtual method table for dyn trait objects
+pub struct DynTraitVtable {
     /// Drops the dyn trait object
     pub drop: fn(*const u8),
     /// Size of the dyn trait object in bytes
     pub size: usize,
     /// Alignment of the dyn trait object in bytes
     pub align: usize,
-    /// The call method of the SyscallObject
-    pub call: *const u8,
+    /// The methods of the trait
+    pub methods: [*const u8; 32],
 }
 
 // Could be replaced by https://doc.rust-lang.org/std/raw/struct.TraitObject.html
 /// A dyn trait fat pointer for SyscallObject
 #[derive(Clone, Copy)]
-pub struct SyscallTraitObject {
+pub struct DynTraitFatPointer {
     /// Pointer to the actual object
     pub data: *mut u8,
     /// Pointer to the virtual method table
-    pub vtable: *const SyscallObjectVtable,
+    pub vtable: &'static DynTraitVtable,
 }
 
 /// Holds the syscall function pointers of an Executable
@@ -498,14 +498,11 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         &mut self,
         syscall_context_object: Box<dyn SyscallObject<E> + 'a>,
     ) -> Result<(), EbpfError<E>> {
-        let fat_ptr_ptr =
-            unsafe { std::mem::transmute::<_, *const SyscallTraitObject>(&syscall_context_object) };
-        let fat_ptr = unsafe { std::mem::transmute::<_, SyscallTraitObject>(*fat_ptr_ptr) };
-        let vtable = unsafe { std::mem::transmute::<_, &SyscallObjectVtable>(&*fat_ptr.vtable) };
+        let fat_ptr: DynTraitFatPointer = unsafe { std::mem::transmute(&*syscall_context_object) };
         let slot = self
             .executable
             .get_syscall_registry()
-            .lookup_context_object_slot(vtable.call as u64)
+            .lookup_context_object_slot(fat_ptr.vtable.methods[0] as u64)
             .unwrap();
         if !self.syscall_context_objects[SYSCALL_CONTEXT_OBJECTS_OFFSET + slot].is_null() {
             Err(EbpfError::SycallAlreadyBound)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -209,7 +209,7 @@ pub trait Executable<E: UserDefinedError, I: InstructionMeter>: Send + Sync {
     /// JIT compile the executable
     fn jit_compile(&mut self) -> Result<(), EbpfError<E>>;
     /// Report information on a symbol that failed to be resolved
-    fn report_unresolved_symbol(&self, insn_offset: usize) -> Result<(), EbpfError<E>>;
+    fn report_unresolved_symbol(&self, insn_offset: usize) -> Result<u64, EbpfError<E>>;
 }
 
 /// Static constructors for Executable


### PR DESCRIPTION
Workaround for unresolved symbols in ELF:
Report error at runtime instead of compiletime