### PR TITLE
Test: Fuzzy + Tracer

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -745,12 +745,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 ebpf::SUB32_REG  => reg[dst] = (reg[dst] as i32).wrapping_sub(reg[src] as i32)   as u64,
                 ebpf::MUL32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_mul(insn.imm)          as u64,
                 ebpf::MUL32_REG  => reg[dst] = (reg[dst] as i32).wrapping_mul(reg[src] as i32)   as u64,
-                ebpf::DIV32_IMM  => {
-                    if insn.imm == 0 {
-                        return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
-                    }
-                                    reg[dst] = (reg[dst] as u32 / insn.imm as u32)               as u64;
-                },
+                ebpf::DIV32_IMM  => reg[dst] = (reg[dst] as u32 / insn.imm as u32)               as u64,
                 ebpf::DIV32_REG  => {
                     if reg[src] as u32 == 0 {
                         return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
@@ -766,12 +761,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 ebpf::RSH32_IMM  =>   reg[dst] = (reg[dst] as u32).wrapping_shr(insn.imm as u32) as u64,
                 ebpf::RSH32_REG  =>   reg[dst] = (reg[dst] as u32).wrapping_shr(reg[src] as u32) as u64,
                 ebpf::NEG32      => { reg[dst] = (reg[dst] as i32).wrapping_neg()                as u64; reg[dst] &= U32MAX; },
-                ebpf::MOD32_IMM  => {
-                    if insn.imm == 0 {
-                        return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
-                    }
-                                      reg[dst] = (reg[dst] as u32             % insn.imm as u32) as u64;
-                },
+                ebpf::MOD32_IMM  =>   reg[dst] = (reg[dst] as u32             % insn.imm as u32) as u64,
                 ebpf::MOD32_REG  => {
                     if reg[src] as u32 == 0 {
                         return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
@@ -789,7 +779,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                         16 => (reg[dst] as u16).to_le() as u64,
                         32 => (reg[dst] as u32).to_le() as u64,
                         64 =>  reg[dst].to_le(),
-                        _  => return Err(EbpfError::InvalidInstruction(pc + ebpf::ELF_INSN_DUMP_OFFSET)),
+                        _  => unreachable!(),
                     };
                 },
                 ebpf::BE         => {
@@ -797,7 +787,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                         16 => (reg[dst] as u16).to_be() as u64,
                         32 => (reg[dst] as u32).to_be() as u64,
                         64 =>  reg[dst].to_be(),
-                        _  => return Err(EbpfError::InvalidInstruction(pc + ebpf::ELF_INSN_DUMP_OFFSET)),
+                        _  => unreachable!(),
                     };
                 },
 
@@ -808,12 +798,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 ebpf::SUB64_REG  => reg[dst] = reg[dst].wrapping_sub(reg[src]),
                 ebpf::MUL64_IMM  => reg[dst] = reg[dst].wrapping_mul(insn.imm as u64),
                 ebpf::MUL64_REG  => reg[dst] = reg[dst].wrapping_mul(reg[src]),
-                ebpf::DIV64_IMM  => {
-                    if insn.imm == 0 {
-                        return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
-                    }
-                                    reg[dst] /= insn.imm as u64;
-                },
+                ebpf::DIV64_IMM  => reg[dst] /= insn.imm as u64,
                 ebpf::DIV64_REG  => {
                     if reg[src] == 0 {
                         return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
@@ -829,12 +814,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 ebpf::RSH64_IMM  => reg[dst] = reg[dst].wrapping_shr(insn.imm as u32),
                 ebpf::RSH64_REG  => reg[dst] = reg[dst].wrapping_shr(reg[src] as u32),
                 ebpf::NEG64      => reg[dst] = (reg[dst] as i64).wrapping_neg() as u64,
-                ebpf::MOD64_IMM  => {
-                    if insn.imm == 0 {
-                        return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));
-                    }
-                                    reg[dst] %= insn.imm  as u64;
-                },
+                ebpf::MOD64_IMM  => reg[dst] %= insn.imm  as u64,
                 ebpf::MOD64_REG  => {
                     if reg[src] == 0 {
                         return Err(EbpfError::DivideByZero(pc + ebpf::ELF_INSN_DUMP_OFFSET));

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -3215,7 +3215,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
                 .write(&mut tracer_display, vm.get_program())
                 .unwrap();
             println!("{}", tracer_display);
-            assert!(false);
+            panic!();
         }
         assert_eq!(_result_interpreter, result_jit);
         if executable.get_config().enable_instruction_meter {

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -10,7 +10,8 @@ extern crate solana_rbpf;
 extern crate test_utils;
 extern crate thiserror;
 
-use rand::{rngs::SmallRng, Rng, RngCore, SeedableRng};
+#[cfg(not(windows))]
+use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use solana_rbpf::{
     assembler::assemble,
     ebpf::{self, hash_symbol_name},


### PR DESCRIPTION
Adds the actual fuzzy testing code which compares the execution of the interpreter and JIT instruction by instruction and reverts duplicate validation checks.

Additional fixes in JIT:
* Instruction limit was allowing one more loop iteration at last branch.
* Bugs in shift operations: There were so many that I did a complete rewrite there.
* 32 bit div and mod operations should not be sign extended.