### PR TITLE
Fix JIT Inconsistencies: Multiply by constant 0 and le16 / le32 masking

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -756,13 +756,13 @@ fn emit_shift(jit: &mut JitCompiler, width: OperationWidth, opc: u8, src: u8, ds
     }
 }
 
-fn emit_muldivmod(jit: &mut JitCompiler, opc: u8, src: u8, dst: u8, imm: i32) {
+fn emit_muldivmod(jit: &mut JitCompiler, opc: u8, src: u8, dst: u8, imm: Option<i32>) {
     let mul = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MUL32_IMM & ebpf::BPF_ALU_OP_MASK);
     let div = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::DIV32_IMM & ebpf::BPF_ALU_OP_MASK);
     let modrm = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MOD32_IMM & ebpf::BPF_ALU_OP_MASK);
     let width = if (opc & ebpf::BPF_CLS_MASK) == ebpf::BPF_ALU64 { OperationWidth::Bit64 } else { OperationWidth::Bit32 };
 
-    if (div || modrm) && imm == 0 {
+    if (div || modrm) && imm.is_none() {
         // Save pc
         emit_load_imm(jit, R11, jit.pc as i64);
 
@@ -780,7 +780,7 @@ fn emit_muldivmod(jit: &mut JitCompiler, opc: u8, src: u8, dst: u8, imm: i32) {
         emit_push(jit, RDX);
     }
 
-    if imm != 0 {
+    if let Some(imm) = imm {
         emit_load_imm(jit, R11, imm as i64);
     } else {
         emit_mov(jit, OperationWidth::Bit64, src, R11);
@@ -1038,9 +1038,9 @@ impl<'a> JitCompiler<'a> {
                     sign_extend_i32_to_i64(self, dst, dst);
                 },
                 ebpf::MUL32_IMM | ebpf::DIV32_IMM | ebpf::MOD32_IMM  =>
-                    emit_muldivmod(self, insn.opc, dst, dst, insn.imm),
+                    emit_muldivmod(self, insn.opc, dst, dst, Some(insn.imm)),
                 ebpf::MUL32_REG | ebpf::DIV32_REG | ebpf::MOD32_REG  =>
-                    emit_muldivmod(self, insn.opc, src, dst, 0),
+                    emit_muldivmod(self, insn.opc, src, dst, None),
                 ebpf::OR32_IMM   => emit_alu(self, OperationWidth::Bit32, 0x81, 1, dst, insn.imm, None),
                 ebpf::OR32_REG   => emit_alu(self, OperationWidth::Bit32, 0x09, src, dst, 0, None),
                 ebpf::AND32_IMM  => emit_alu(self, OperationWidth::Bit32, 0x81, 4, dst, insn.imm, None),
@@ -1085,9 +1085,9 @@ impl<'a> JitCompiler<'a> {
                 ebpf::SUB64_IMM  => emit_alu(self, OperationWidth::Bit64, 0x81, 5, dst, insn.imm, None),
                 ebpf::SUB64_REG  => emit_alu(self, OperationWidth::Bit64, 0x29, src, dst, 0, None),
                 ebpf::MUL64_IMM | ebpf::DIV64_IMM | ebpf::MOD64_IMM  =>
-                    emit_muldivmod(self, insn.opc, dst, dst, insn.imm),
+                    emit_muldivmod(self, insn.opc, dst, dst, Some(insn.imm)),
                 ebpf::MUL64_REG | ebpf::DIV64_REG | ebpf::MOD64_REG  =>
-                    emit_muldivmod(self, insn.opc, src, dst, 0),
+                    emit_muldivmod(self, insn.opc, src, dst, None),
                 ebpf::OR64_IMM   => emit_alu(self, OperationWidth::Bit64, 0x81, 1, dst, insn.imm, None),
                 ebpf::OR64_REG   => emit_alu(self, OperationWidth::Bit64, 0x09, src, dst, 0, None),
                 ebpf::AND64_IMM  => emit_alu(self, OperationWidth::Bit64, 0x81, 4, dst, insn.imm, None),

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1057,7 +1057,16 @@ impl<'a> JitCompiler<'a> {
                 ebpf::ARSH32_IMM => emit_alu(self, OperationWidth::Bit32, 0xc1, 7, dst, insn.imm, None),
                 ebpf::ARSH32_REG => emit_shift(self, OperationWidth::Bit32, 7, src, dst),
                 ebpf::LE         => {
-                    // No-op
+                    match insn.imm {
+                        16 => {
+                            emit_alu(self, OperationWidth::Bit32, 0x81, 4, dst, 0xffff, None); // Mask to 16 bit
+                        }
+                        32 => {
+                            emit_alu(self, OperationWidth::Bit32, 0x81, 4, dst, -1, None); // Mask to 32 bit
+                        }
+                        64 => {}
+                        _ => unreachable!()
+                    }
                 },
                 ebpf::BE         => {
                     match insn.imm {
@@ -1065,8 +1074,7 @@ impl<'a> JitCompiler<'a> {
                             // rol
                             emit1(self, 0x66); // 16-bit override
                             emit_alu(self, OperationWidth::Bit32, 0xc1, 0, dst, 8, None);
-                            // and
-                            emit_alu(self, OperationWidth::Bit32, 0x81, 4, dst, 0xffff, None);
+                            emit_alu(self, OperationWidth::Bit32, 0x81, 4, dst, 0xffff, None); // Mask to 16 bit
                         }
                         32 | 64 => {
                             // bswap

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -589,6 +589,20 @@ fn test_le16() {
 }
 
 #[test]
+fn test_le16_high() {
+    test_interpreter_and_jit_asm!(
+        "
+        ldxdw r0, [r1]
+        le16 r0
+        exit",
+        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        (),
+        { |_vm, res: Result| { res.unwrap() == 0x2211 } },
+        3
+    );
+}
+
+#[test]
 fn test_le32() {
     test_interpreter_and_jit_asm!(
         "
@@ -598,6 +612,20 @@ fn test_le32() {
         [0x44, 0x33, 0x22, 0x11],
         (),
         { |_vm, res: Result| { res.unwrap() == 0x11223344 } },
+        3
+    );
+}
+
+#[test]
+fn test_le32_high() {
+    test_interpreter_and_jit_asm!(
+        "
+        ldxdw r0, [r1]
+        le32 r0
+        exit",
+        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        (),
+        { |_vm, res: Result| { res.unwrap() == 0x44332211 } },
         3
     );
 }


### PR DESCRIPTION
Fixes:
- `mul r0, 0x0` producing code for `mul r0, r0` (32 bit and 64 bit) in JIT.
- Missing masking of `le16` and `le32` instructions in JIT.