### PR TITLE
Improves Address Translation Speed

### DIFF
--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -99,19 +99,31 @@ pub struct MemoryMapping<'a> {
     config: &'a Config,
 }
 impl<'a> MemoryMapping<'a> {
+    fn construct_eytzinger_order(
+        &mut self,
+        ascending_regions: &[MemoryRegion],
+        mut in_index: usize,
+        out_index: usize,
+    ) -> usize {
+        if out_index >= self.regions.len() {
+            return in_index;
+        }
+        in_index = self.construct_eytzinger_order(ascending_regions, in_index, 2 * out_index + 1);
+        self.regions[out_index] = ascending_regions[in_index].clone();
+        self.dense_keys[out_index] = ascending_regions[in_index].vm_addr;
+        self.construct_eytzinger_order(ascending_regions, in_index + 1, 2 * out_index + 2)
+    }
+
     /// Creates a new MemoryMapping structure from the given regions
     pub fn new(mut regions: Vec<MemoryRegion>, config: &'a Config) -> Self {
-        regions.sort();
-        let dense_keys = regions
-            .iter()
-            .map(|region| region.vm_addr)
-            .collect::<Vec<u64>>()
-            .into_boxed_slice();
-        Self {
-            regions: regions.into_boxed_slice(),
-            dense_keys,
+        let mut result = Self {
+            regions: vec![MemoryRegion::default(); regions.len()].into_boxed_slice(),
+            dense_keys: vec![0; regions.len()].into_boxed_slice(),
             config,
-        }
+        };
+        regions.sort();
+        result.construct_eytzinger_order(&regions, 0, 0);
+        result
     }
 
     /// Given a list of regions translate from virtual machine to host address
@@ -121,16 +133,15 @@ impl<'a> MemoryMapping<'a> {
         vm_addr: u64,
         len: u64,
     ) -> Result<u64, EbpfError<E>> {
-        let index = match self.dense_keys.binary_search(&vm_addr) {
-            Ok(index) => index,
-            Err(index) => {
-                if index == 0 {
-                    return Err(self.generate_access_violation(access_type, vm_addr, len));
-                }
-                index - 1
-            }
-        };
-        let region = &self.regions[index];
+        let mut index = 1;
+        while index <= self.dense_keys.len() {
+            index = (index << 1) + (self.dense_keys[index - 1] <= vm_addr) as usize;
+        }
+        index >>= index.trailing_zeros() + 1;
+        if index == 0 {
+            return Err(self.generate_access_violation(access_type, vm_addr, len));
+        }
+        let region = &self.regions[index - 1];
         if access_type == AccessType::Load || region.is_writable {
             if let Ok(host_addr) = region.vm_to_host::<E>(vm_addr, len as u64) {
                 return Ok(host_addr);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -342,7 +342,7 @@ macro_rules! translate_memory_access {
 }
 
 /// The syscall_context_objects field also stores some metadata in the front, thus the entries are shifted
-pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 4;
+pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 6;
 
 /// A virtual machine to run eBPF program.
 ///

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -103,10 +103,6 @@ fn test_fuzz_execute() {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
 
-    fn user_check(prog: &[u8]) -> Result<(), UserError> {
-        check(prog)
-    }
-
     println!("mangle the whole file");
     fuzz(
         &elf,
@@ -117,7 +113,7 @@ fn test_fuzz_execute() {
         |bytes: &mut [u8]| {
             if let Ok(mut executable) = Executable::<UserError, DefaultInstructionMeter>::from_elf(
                 &bytes,
-                Some(user_check),
+                Some(check),
                 Config::default(),
             ) {
                 let mut syscall_registry = SyscallRegistry::default();

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -42,9 +42,6 @@ impl UserDefinedError for VerifierTestError {}
 
 #[test]
 fn test_verifier_success() {
-    fn verifier_success(_prog: &[u8]) -> Result<(), VerifierTestError> {
-        Ok(())
-    }
     let prog = assemble(
         "
         mov32 r0, 0xBEE
@@ -53,7 +50,7 @@ fn test_verifier_success() {
     .unwrap();
     let executable = Executable::<VerifierTestError, DefaultInstructionMeter>::from_text_bytes(
         &prog,
-        Some(verifier_success),
+        Some(|_prog: &[u8]| Ok(())),
         Config::default(),
     )
     .unwrap();


### PR DESCRIPTION
... by using the eytzinger order instead of performing a binary search on the `regions` in ascending order.
Additionally, the keys are copied into a dense vector without any gaps or stride, for better utilization of the cache.

## Benchmarks
Overall, the performance benchmarks indicate a ~ 30% speed up in address translation.

### Binary Search, Regions Directly
test bench_gapped_randomized_access_with_1024_entries  ... bench:          18 ns/iter (+/- 7)
test bench_mapping_with_1024_entries                   ... bench:          18 ns/iter (+/- 3)
test bench_randomized_access_with_0001_entry           ... bench:          20 ns/iter (+/- 4)
test bench_randomized_access_with_1024_entries         ... bench:          74 ns/iter (+/- 14)
test bench_randomized_mapping_access_with_0004_entries ... bench:          28 ns/iter (+/- 5)
test bench_randomized_mapping_access_with_0016_entries ... bench:          41 ns/iter (+/- 9)
test bench_randomized_mapping_access_with_0064_entries ... bench:          52 ns/iter (+/- 10)
test bench_randomized_mapping_access_with_0256_entries ... bench:          62 ns/iter (+/- 8)
test bench_randomized_mapping_access_with_1024_entries ... bench:          70 ns/iter (+/- 12)
test bench_randomized_mapping_with_1024_entries        ... bench:          18 ns/iter (+/- 9)

### Binary Search, Dense Keys
test bench_gapped_randomized_access_with_1024_entries  ... bench:          19 ns/iter (+/- 9)
test bench_mapping_with_1024_entries                   ... bench:          18 ns/iter (+/- 3)
test bench_randomized_access_with_0001_entry           ... bench:          18 ns/iter (+/- 7)
test bench_randomized_access_with_1024_entries         ... bench:          77 ns/iter (+/- 11)
test bench_randomized_mapping_access_with_0004_entries ... bench:          28 ns/iter (+/- 5)
test bench_randomized_mapping_access_with_0016_entries ... bench:          42 ns/iter (+/- 10)
test bench_randomized_mapping_access_with_0064_entries ... bench:          52 ns/iter (+/- 10)
test bench_randomized_mapping_access_with_0256_entries ... bench:          63 ns/iter (+/- 11)
test bench_randomized_mapping_access_with_1024_entries ... bench:          73 ns/iter (+/- 16)
test bench_randomized_mapping_with_1024_entries        ... bench:          17 ns/iter (+/- 2)

### Eytzinger Heap, Regions Directly
test bench_gapped_randomized_access_with_1024_entries  ... bench:          23 ns/iter (+/- 4)
test bench_mapping_with_1024_entries                   ... bench:          40 ns/iter (+/- 7)
test bench_randomized_access_with_0001_entry           ... bench:          22 ns/iter (+/- 4)
test bench_randomized_access_with_1024_entries         ... bench:          50 ns/iter (+/- 10)
test bench_randomized_mapping_access_with_0004_entries ... bench:          29 ns/iter (+/- 5)
test bench_randomized_mapping_access_with_0016_entries ... bench:          31 ns/iter (+/- 5)
test bench_randomized_mapping_access_with_0064_entries ... bench:          37 ns/iter (+/- 7)
test bench_randomized_mapping_access_with_0256_entries ... bench:          43 ns/iter (+/- 6)
test bench_randomized_mapping_access_with_1024_entries ... bench:          45 ns/iter (+/- 21)
test bench_randomized_mapping_with_1024_entries        ... bench:          40 ns/iter (+/- 6)

### Eytzinger Heap, Dense Keys
test bench_gapped_randomized_access_with_1024_entries  ... bench:          22 ns/iter (+/- 3)
test bench_mapping_with_1024_entries                   ... bench:          35 ns/iter (+/- 7)
test bench_randomized_access_with_0001_entry           ... bench:          22 ns/iter (+/- 4)
test bench_randomized_access_with_1024_entries         ... bench:          45 ns/iter (+/- 8)
test bench_randomized_mapping_access_with_0004_entries ... bench:          26 ns/iter (+/- 13)
test bench_randomized_mapping_access_with_0016_entries ... bench:          29 ns/iter (+/- 7)
test bench_randomized_mapping_access_with_0064_entries ... bench:          35 ns/iter (+/- 6)
test bench_randomized_mapping_access_with_0256_entries ... bench:          40 ns/iter (+/- 8)
test bench_randomized_mapping_access_with_1024_entries ... bench:          45 ns/iter (+/- 7)
test bench_randomized_mapping_with_1024_entries        ... bench:          35 ns/iter (+/- 5)