### PR TITLE
Fix LDDW Related Bugs

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,7 @@ use clap::{App, Arg};
 use rustc_demangle::demangle;
 use solana_rbpf::{
     assembler::assemble,
-    disassembler::{to_insn_vec, HLInsn},
+    disassembler::{to_insn_vec, HlInsn},
     ebpf,
     memory_region::{MemoryMapping, MemoryRegion},
     user_error::UserError,
@@ -63,7 +63,7 @@ macro_rules! resolve_label {
 }
 
 struct AnalysisResult {
-    instructions: Vec<HLInsn>,
+    instructions: Vec<HlInsn>,
     destinations: BTreeMap<usize, Label>,
     sources: BTreeMap<usize, Vec<usize>>,
 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -82,7 +82,7 @@ fn jmp_reg_str(name: &str, insn: &ebpf::Insn) -> String {
 /// documentation about eBPF, or <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md> for a
 /// more concise version.
 #[derive(Debug, PartialEq)]
-pub struct HLInsn {
+pub struct HlInsn {
     /// Instruction pointer.
     pub ptr: usize,
     /// Operation code.
@@ -102,7 +102,7 @@ pub struct HLInsn {
     pub imm: i64,
 }
 
-/// Return a vector of `struct HLInsn` built from an eBPF program.
+/// Return a vector of `struct HlInsn` built from an eBPF program.
 ///
 /// This is made public to provide a way to manipulate a program as a vector of instructions, in a
 /// high-level format, for example for dumping the program instruction after instruction with a
@@ -133,7 +133,7 @@ pub struct HLInsn {
 ///
 /// let v = disassembler::to_insn_vec(prog);
 /// assert_eq!(v, vec![
-///     disassembler::HLInsn {
+///     disassembler::HlInsn {
 ///         ptr: 0,
 ///         opc: 0x18,
 ///         name: "lddw".to_string(),
@@ -143,7 +143,7 @@ pub struct HLInsn {
 ///         off: 0,
 ///         imm: 0x1122334455667788
 ///     },
-///     disassembler::HLInsn {
+///     disassembler::HlInsn {
 ///         ptr: 2,
 ///         opc: 0x95,
 ///         name: "exit".to_string(),
@@ -156,7 +156,7 @@ pub struct HLInsn {
 /// ]);
 /// ```
 #[rustfmt::skip]
-pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
+pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
     debug_assert!(prog.len() % ebpf::INSN_SIZE == 0, "eBPF program length must be a multiple of {:?} octets is {:?}", ebpf::INSN_SIZE, prog.len());
 
     if prog.is_empty() {
@@ -301,7 +301,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HLInsn> {
             },
         };
 
-        res.push(HLInsn {
+        res.push(HlInsn {
             ptr,
             opc:  insn.opc,
             name: name.to_string(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
-use crate::{elf::ELFError, memory_region::AccessType};
+use crate::{elf::ElfError, memory_region::AccessType};
 
 /// User defined errors must implement this trait
 pub trait UserDefinedError: 'static + std::error::Error {}
@@ -30,7 +30,7 @@ pub enum EbpfError<E: UserDefinedError> {
     UserError(#[from] E),
     /// ELF error
     #[error("ELF error: {0}")]
-    ELFError(#[from] ELFError),
+    ElfError(#[from] ElfError),
     /// Syscall was already registered before
     #[error("syscall #{0} was already registered before")]
     SycallAlreadyRegistered(usize),
@@ -62,7 +62,7 @@ pub enum EbpfError<E: UserDefinedError> {
     ExceededMaxInstructions(usize, u64),
     /// Program has not been JIT-compiled
     #[error("program has not been JIT-compiled")]
-    JITNotCompiled,
+    JitNotCompiled,
     /// Invalid virtual address
     #[error("invalid virtual address {0:x?}")]
     InvalidVirtualAddress(u64),

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -923,6 +923,7 @@ impl<'a> JitCompiler<'a> {
         let entry = executable.get_entrypoint_instruction_offset().unwrap_or(0);
         if entry != 0 {
             emit_profile_instruction_count(self, Some(entry + 1))?;
+            emit_load_imm(self, R11, entry as i64)?;
             emit_jmp(self, entry)?;
         }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -56,20 +56,19 @@ impl<E: UserDefinedError, I: InstructionMeter> PartialEq for JitProgram<E, I> {
 }
 
 // Special values for target_pc in struct Jump
-const TARGET_OFFSET: usize = ebpf::PROG_MAX_INSNS;
-const TARGET_PC_TRACE: usize = TARGET_OFFSET + 1;
-const TARGET_PC_TRANSLATE_PC: usize = TARGET_OFFSET + 2;
-const TARGET_PC_TRANSLATE_PC_LOOP: usize = TARGET_OFFSET + 3;
-const TARGET_PC_CALL_EXCEEDED_MAX_INSTRUCTIONS: usize = TARGET_OFFSET + 4;
-const TARGET_PC_CALL_DEPTH_EXCEEDED: usize = TARGET_OFFSET + 5;
-const TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT: usize = TARGET_OFFSET + 6;
-const TARGET_PC_CALLX_UNSUPPORTED_INSTRUCTION: usize = TARGET_OFFSET + 7;
-const TARGET_PC_CALL_UNSUPPORTED_INSTRUCTION: usize = TARGET_OFFSET + 8;
-const TARGET_PC_DIV_BY_ZERO: usize = TARGET_OFFSET + 9;
-const TARGET_PC_EXCEPTION_AT: usize = TARGET_OFFSET + 10;
-const TARGET_PC_SYSCALL_EXCEPTION: usize = TARGET_OFFSET + 11;
-const TARGET_PC_EXIT: usize = TARGET_OFFSET + 12;
-const TARGET_PC_EPILOGUE: usize = TARGET_OFFSET + 13;
+const TARGET_PC_TRACE: usize = std::usize::MAX - 13;
+const TARGET_PC_TRANSLATE_PC: usize = std::usize::MAX - 12;
+const TARGET_PC_TRANSLATE_PC_LOOP: usize = std::usize::MAX - 11;
+const TARGET_PC_CALL_EXCEEDED_MAX_INSTRUCTIONS: usize = std::usize::MAX - 10;
+const TARGET_PC_CALL_DEPTH_EXCEEDED: usize = std::usize::MAX - 9;
+const TARGET_PC_CALL_OUTSIDE_TEXT_SEGMENT: usize = std::usize::MAX - 8;
+const TARGET_PC_CALLX_UNSUPPORTED_INSTRUCTION: usize = std::usize::MAX - 7;
+const TARGET_PC_CALL_UNSUPPORTED_INSTRUCTION: usize = std::usize::MAX - 6;
+const TARGET_PC_DIV_BY_ZERO: usize = std::usize::MAX - 5;
+const TARGET_PC_EXCEPTION_AT: usize = std::usize::MAX - 4;
+const TARGET_PC_SYSCALL_EXCEPTION: usize = std::usize::MAX - 3;
+const TARGET_PC_EXIT: usize = std::usize::MAX - 2;
+const TARGET_PC_EPILOGUE: usize = std::usize::MAX - 1;
 
 #[derive(Copy, Clone)]
 enum OperandSize {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -41,24 +41,24 @@ pub enum VerifierError {
     /// DivisionByZero
     #[error("division by 0 (insn #{0})")]
     DivisionByZero(usize),
-    /// UnsupportedLEBEArgument
+    /// UnsupportedLeBeArgument
     #[error("unsupported argument for LE/BE (insn #{0})")]
-    UnsupportedLEBEArgument(usize),
-    /// LDDWCannotBeLast
+    UnsupportedLeBeArgument(usize),
+    /// LddwCannotBeLast
     #[error("LD_DW instruction cannot be last in program")]
-    LDDWCannotBeLast,
-    /// IncompleteLDDW
+    LddwCannotBeLast,
+    /// IncompleteLddw
     #[error("incomplete LD_DW instruction (insn #{0})")]
-    IncompleteLDDW(usize),
+    IncompleteLddw(usize),
     /// InfiniteLoop
     #[error("infinite loop (insn #{0})")]
     InfiniteLoop(usize),
     /// JumpOutOfCode
     #[error("jump out of code to #{0} (insn #{1})")]
     JumpOutOfCode(usize, usize),
-    /// JumpToMiddleOfLDDW
+    /// JumpToMiddleOfLddw
     #[error("jump to middle of LD_DW at #{0} (insn #{1})")]
-    JumpToMiddleOfLDDW(usize, usize),
+    JumpToMiddleOfLddw(usize, usize),
     /// InvalidSourceRegister
     #[error("invalid source register (insn #{0})")]
     InvalidSourceRegister(usize),
@@ -114,7 +114,7 @@ fn check_imm_nonzero(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierE
 fn check_imm_endian(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierError> {
     match insn.imm {
         16 | 32 | 64 => Ok(()),
-        _ => Err(VerifierError::UnsupportedLEBEArgument(insn_ptr)),
+        _ => Err(VerifierError::UnsupportedLeBeArgument(insn_ptr)),
     }
 }
 
@@ -123,7 +123,7 @@ fn check_load_dw(prog: &[u8], insn_ptr: usize) -> Result<(), VerifierError> {
     // this function should be called only for LD_DW insn, that cannot be last in program.
     let next_insn = ebpf::get_insn(prog, insn_ptr + 1);
     if next_insn.opc != 0 {
-        return Err(VerifierError::IncompleteLDDW(insn_ptr));
+        return Err(VerifierError::IncompleteLddw(insn_ptr));
     }
     Ok(())
 }
@@ -143,7 +143,7 @@ fn check_jmp_offset(prog: &[u8], insn_ptr: usize) -> Result<(), VerifierError> {
     }
     let dst_insn = ebpf::get_insn(prog, dst_insn_ptr as usize);
     if dst_insn.opc == 0 {
-        return Err(VerifierError::JumpToMiddleOfLDDW(
+        return Err(VerifierError::JumpToMiddleOfLddw(
             dst_insn_ptr as usize,
             insn_ptr,
         ));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -984,7 +984,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         let compiled_program = self
             .executable
             .get_compiled_program()
-            .ok_or(EbpfError::JITNotCompiled)?;
+            .ok_or(EbpfError::JitNotCompiled)?;
         unsafe {
             self.syscall_context_objects[SYSCALL_CONTEXT_OBJECTS_OFFSET - 1] =
                 &mut self.tracer as *mut _ as *mut u8;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -283,9 +283,10 @@ impl Tracer {
     ) -> Result<(), std::fmt::Error> {
         let disassembled = disassembler::to_insn_vec(program);
         let mut pc_to_instruction_index =
-            vec![0usize; disassembled.last().map(|ins| ins.ptr + 1).unwrap_or(0)];
+            vec![0usize; disassembled.last().map(|ins| ins.ptr + 2).unwrap_or(0)];
         for index in 0..disassembled.len() {
             pc_to_instruction_index[disassembled[index].ptr] = index;
+            pc_to_instruction_index[disassembled[index].ptr + 1] = index;
         }
         for index in 0..self.log.len() {
             let entry = &self.log[index];

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -15,7 +15,7 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use solana_rbpf::{
     assembler::assemble,
     ebpf::{self, hash_symbol_name},
-    elf::ELFError,
+    elf::ElfError,
     error::EbpfError,
     memory_region::AccessType,
     syscalls,
@@ -2870,7 +2870,7 @@ fn test_non_terminate_early() {
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
-                    EbpfError::ELFError(ELFError::UnresolvedSymbol(a, b, c))
+                    EbpfError::ElfError(ElfError::UnresolvedSymbol(a, b, c))
                     if a == "Unknown" && b == 35 && c == 48
                 )
             }
@@ -2970,7 +2970,7 @@ fn test_err_symbol_unresolved() {
         [],
         (),
         {
-            |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 29 && offset == 0)
+            |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 29 && offset == 0)
         },
         1
     );
@@ -2990,7 +2990,7 @@ fn test_err_call_unresolved() {
         [],
         (),
         {
-            |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 34 && offset == 40)
+            |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "Unknown" && pc == 34 && offset == 40)
         },
         6
     );
@@ -3005,7 +3005,7 @@ fn test_err_unresolved_elf() {
             hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
         ),
         {
-            |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ELFError(ELFError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "log_64" && pc == 550 && offset == 4168)
+            |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "log_64" && pc == 550 && offset == 4168)
         },
         9
     );

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -3221,72 +3221,52 @@ fn test_tcp_sack_nomatch() {
 
 #[test]
 fn test_large_program() {
-    fn write_insn(prog: &mut [u8], insn: usize, asm: &str) {
-        prog[insn * ebpf::INSN_SIZE..insn * ebpf::INSN_SIZE + ebpf::INSN_SIZE]
-            .copy_from_slice(&assemble(asm).unwrap());
+    fn write_insn(prog: &mut [u8], index: usize, asm: &str) {
+        let insn = assemble(asm).unwrap();
+        prog[index * ebpf::INSN_SIZE..index * ebpf::INSN_SIZE + insn.len()].copy_from_slice(&insn);
     }
 
-    let mut prog = vec![0; ebpf::PROG_MAX_INSNS * ebpf::INSN_SIZE];
-    let mut add_insn = vec![0; ebpf::INSN_SIZE];
-    write_insn(&mut add_insn, 0, "mov64 r0, 0");
-    for insn in (0..(ebpf::PROG_MAX_INSNS - 1) * ebpf::INSN_SIZE).step_by(ebpf::INSN_SIZE) {
-        prog[insn..insn + ebpf::INSN_SIZE].copy_from_slice(&add_insn);
-    }
-    write_insn(&mut prog, ebpf::PROG_MAX_INSNS - 1, "exit");
-
+    let mut prog = vec![0; (ebpf::PROG_MAX_INSNS * 2 - 1) * ebpf::INSN_SIZE];
+    let mut insn = vec![0; ebpf::INSN_SIZE * 2];
+    write_insn(&mut insn, 0, "lddw r0, 0");
+    for index in (0..(ebpf::PROG_MAX_INSNS - 1) * ebpf::INSN_SIZE * 2).step_by(ebpf::INSN_SIZE * 2)
     {
-        // Test jumping to pc larger then i16
-        write_insn(&mut prog, ebpf::PROG_MAX_INSNS - 2, "ja 0x0");
+        prog[index..index + ebpf::INSN_SIZE * 2].copy_from_slice(&insn);
+    }
+    write_insn(&mut prog, ebpf::PROG_MAX_INSNS - 4, "ja 9");
+    write_insn(&mut prog, ebpf::PROG_MAX_INSNS - 3, "mov r0, 0");
+    write_insn(&mut prog, ebpf::PROG_MAX_INSNS * 2 - 2, "exit");
 
-        let executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
-            &prog,
-            None,
-            Config::default(),
-        )
-        .unwrap();
-        let mut vm =
-            EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[])
+    let config = Config {
+        enable_instruction_tracing: true,
+        ..Config::default()
+    };
+
+    #[allow(unused_mut)]
+    {
+        let mut executable =
+            Executable::<UserError, TestInstructionMeter>::from_text_bytes(&prog, None, config)
                 .unwrap();
-        assert_eq!(
-            0,
-            vm.execute_program_interpreted(&mut DefaultInstructionMeter {})
-                .unwrap()
+        test_interpreter_and_jit!(
+            executable,
+            [],
+            (),
+            { |_vm, res: Result| res.unwrap() == 0x0 },
+            ebpf::PROG_MAX_INSNS as u64 - 4
         );
     }
-    // reset program
-    write_insn(&mut prog, ebpf::PROG_MAX_INSNS - 2, "mov64 r0, 0");
 
     {
-        // test program that is too large
+        // Test program that is too large
         prog.extend_from_slice(&assemble("exit").unwrap());
 
         assert!(
             Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(
                 &prog,
                 Some(check),
-                Config::default()
+                config,
             )
             .is_err()
-        );
-    }
-    // reset program
-    prog.truncate(ebpf::PROG_MAX_INSNS * ebpf::INSN_SIZE);
-
-    // verify program still works
-    #[allow(unused_mut)]
-    {
-        let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
-            &prog,
-            None,
-            Config::default(),
-        )
-        .unwrap();
-        test_interpreter_and_jit!(
-            executable,
-            [],
-            (),
-            { |_vm, res: Result| res.unwrap() == 0x0 },
-            ebpf::PROG_MAX_INSNS as u64
         );
     }
 }

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -101,7 +101,7 @@ fn test_verifier_err_div_by_zero_imm() {
 }
 
 #[test]
-#[should_panic(expected = "UnsupportedLEBEArgument(0)")]
+#[should_panic(expected = "UnsupportedLeBeArgument(0)")]
 fn test_verifier_err_endian_size() {
     let prog = &[
         0xdc, 0x01, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, //
@@ -117,7 +117,7 @@ fn test_verifier_err_endian_size() {
 }
 
 #[test]
-#[should_panic(expected = "IncompleteLDDW(0)")]
+#[should_panic(expected = "IncompleteLddw(0)")]
 fn test_verifier_err_incomplete_lddw() {
     // Note: ubpf has test-err-incomplete-lddw2, which is the same
     let prog = &[
@@ -184,7 +184,7 @@ fn test_verifier_err_invalid_reg_src() {
 }
 
 #[test]
-#[should_panic(expected = "JumpToMiddleOfLDDW(2, 0)")]
+#[should_panic(expected = "JumpToMiddleOfLddw(2, 0)")]
 fn test_verifier_err_jmp_lddw() {
     let prog = assemble(
         "


### PR DESCRIPTION
- When placing the entrypoint to the middle of a `lddw` instruction
- Showing traces with jumps to the middle of a `lddw` instruction
- Jumps close to the max length of a program, which contains at least one `lddw` instruction