### PR TITLE
Fix PC Reporting Inconsistency

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -349,6 +349,6 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
 /// ```
 pub fn disassemble(prog: &[u8]) {
     for insn in to_insn_vec(prog).iter() {
-        println!("{:5} {}", insn.ptr, insn.desc);
+        println!("{:5} {}", insn.ptr + ebpf::ELF_INSN_DUMP_OFFSET, insn.desc);
     }
 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -58,12 +58,12 @@ fn ldind_str(name: &str, insn: &ebpf::Insn) -> String {
 
 #[inline]
 fn jmp_imm_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, {:#x}, {:+#x}", name, insn.dst, insn.imm, insn.off)
+    format!("{} r{}, {:#x}, {:+}", name, insn.dst, insn.imm, insn.off)
 }
 
 #[inline]
 fn jmp_reg_str(name: &str, insn: &ebpf::Insn) -> String {
-    format!("{} r{}, r{}, {:+#x}", name, insn.dst, insn.src, insn.off)
+    format!("{} r{}, r{}, {:+}", name, insn.dst, insn.src, insn.off)
 }
 
 /// High-level representation of an eBPF instruction.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -290,11 +290,13 @@ impl Tracer {
         }
         for index in 0..self.log.len() {
             let entry = &self.log[index];
-            let ins_index = pc_to_instruction_index[entry[11] as usize];
             writeln!(
                 out,
                 "{:5?} {:016X?} {:5?}: {}",
-                index, entry, ins_index, disassembled[ins_index].desc
+                index,
+                &entry[0..10],
+                entry[11] as usize + ebpf::ELF_INSN_DUMP_OFFSET,
+                disassembled[pc_to_instruction_index[entry[11] as usize]].desc,
             )?;
         }
         Ok(())

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -78,8 +78,8 @@ fn test_ja() {
 // Example for InstructionType::JumpConditional.
 #[test]
 fn test_jeq() {
-    disasm!("jeq r1, 0x4, +0x8");
-    disasm!("jeq r1, r3, +0x8");
+    disasm!("jeq r1, 0x4, +8");
+    disasm!("jeq r1, r3, +8");
 }
 
 // Example for InstructionType::Call.
@@ -263,31 +263,31 @@ stxdw [r1+0x2], r3"
 #[test]
 fn test_jump_conditional() {
     disasm!(
-        "jeq r1, r2, +0x3
-jgt r1, r2, +0x3
-jge r1, r2, +0x3
-jlt r1, r2, +0x3
-jle r1, r2, +0x3
-jset r1, r2, +0x3
-jne r1, r2, +0x3
-jsgt r1, r2, +0x3
-jsge r1, r2, +0x3
-jslt r1, r2, +0x3
-jsle r1, r2, +0x3"
+        "jeq r1, r2, +3
+jgt r1, r2, +3
+jge r1, r2, +3
+jlt r1, r2, +3
+jle r1, r2, +3
+jset r1, r2, +3
+jne r1, r2, +3
+jsgt r1, r2, +3
+jsge r1, r2, +3
+jslt r1, r2, +3
+jsle r1, r2, +3"
     );
 
     disasm!(
-        "jeq r1, 0x2, +0x3
-jgt r1, 0x2, +0x3
-jge r1, 0x2, +0x3
-jlt r1, 0x2, +0x3
-jle r1, 0x2, +0x3
-jset r1, 0x2, +0x3
-jne r1, 0x2, +0x3
-jsgt r1, 0x2, +0x3
-jsge r1, 0x2, +0x3
-jslt r1, 0x2, +0x3
-jsle r1, 0x2, +0x3"
+        "jeq r1, 0x2, +3
+jgt r1, 0x2, +3
+jge r1, 0x2, +3
+jlt r1, 0x2, +3
+jle r1, 0x2, +3
+jset r1, 0x2, +3
+jne r1, 0x2, +3
+jsgt r1, 0x2, +3
+jsge r1, 0x2, +3
+jslt r1, 0x2, +3
+jsle r1, 0x2, +3"
     );
 }
 


### PR DESCRIPTION
* Removes the instruction index output from the tracer
* Moves the instruction pointer / PC from the last register in front of the instruction disassembly
* Adds `ebpf::ELF_INSN_DUMP_OFFSET` to PC values in tracer and disassembler
* Changes jump offset formating in the disassembler from hex to dec