### PR TITLE
JIT Machine Code Emitter

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -311,9 +311,8 @@ impl X86Instruction {
                         sib.base &= 0b111;
                     } else {
                         debug_assert_ne!(self.second_operand & 0b111, RSP); // Reserved for SIB addressing
-                        if indirect.displacement == 0 {
-                            debug_assert_ne!(self.second_operand & 0b111, RBP); // Reserved for RIP relative addressing (position independent code)
-                        } else if indirect.displacement >= -128 && indirect.displacement <= 127 {
+                        if (indirect.displacement >= -128 && indirect.displacement <= 127) ||
+                           (indirect.displacement == 0 && self.second_operand & 0b111 == RBP) {
                             displacement_size = OperandSize::S8;
                             modrm.mode = 1;
                         } else {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -229,7 +229,7 @@ struct X86Rex {
     b: bool,
 }
 
-struct X86ModRM {
+struct X86ModRm {
     mode: u8,
     r: u8,
     m: u8,
@@ -285,7 +285,7 @@ impl X86Instruction {
             x: false,
             b: self.second_operand & 0b1000 != 0,
         };
-        let mut modrm = X86ModRM {
+        let mut modrm = X86ModRm {
             mode: 0,
             r: self.first_operand & 0b111,
             m: self.second_operand & 0b111,


### PR DESCRIPTION
- Replaces many of the individual handcrafted instruction assembler helper functions by one structured instruction assembler.
- Removes `OperationWidth` which was redundant and replaces its usage by `OperandSize`
- Adds support for SIB (scale, index, base, displacement) indirect operand addressing.