### PR TITLE
Validate Overlapping Memory Regions in ELF Loader

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -24,8 +24,12 @@ fn bench_load_elf(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
-            .unwrap()
+        <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
+            &elf,
+            None,
+            Config::default(),
+        )
+        .unwrap()
     });
 }
 
@@ -35,7 +39,7 @@ fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = Executable::<UserError, DefaultInstructionMeter>::from_elf(
+        let executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -51,7 +55,7 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_elf(
+        let mut executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
             &elf,
             None,
             Config::default(),

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -21,9 +21,12 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable =
-        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
-            .unwrap();
+    let executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
+        &elf,
+        None,
+        Config::default(),
+    )
+    .unwrap();
     bencher.iter(|| {
         EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[])
             .unwrap()
@@ -36,8 +39,11 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let mut executable =
-        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
-            .unwrap();
+    let mut executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
+        &elf,
+        None,
+        Config::default(),
+    )
+    .unwrap();
     bencher.iter(|| executable.jit_compile().unwrap());
 }

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -66,7 +66,7 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
         false,
     )];
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     let mut prng = new_prng!();
     bencher.iter(|| {
         assert!(memory_mapping
@@ -84,7 +84,7 @@ fn bench_randomized_access_with_0001_entry(bencher: &mut Bencher) {
     let content = vec![0; 1024 * 2];
     let memory_regions = vec![MemoryRegion::new_from_slice(&content[..], 0, 0, false)];
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     let mut prng = new_prng!();
     bencher.iter(|| {
         assert!(memory_mapping
@@ -102,7 +102,7 @@ fn bench_randomized_mapping_access_with_0004_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, end_address) = generate_memory_regions(4, false, Some(&mut prng));
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
@@ -115,7 +115,7 @@ fn bench_randomized_mapping_access_with_0016_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, end_address) = generate_memory_regions(16, false, Some(&mut prng));
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
@@ -128,7 +128,7 @@ fn bench_randomized_mapping_access_with_0064_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, end_address) = generate_memory_regions(64, false, Some(&mut prng));
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
@@ -141,7 +141,7 @@ fn bench_randomized_mapping_access_with_0256_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, end_address) = generate_memory_regions(256, false, Some(&mut prng));
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
@@ -154,7 +154,7 @@ fn bench_randomized_mapping_access_with_1024_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, end_address) = generate_memory_regions(1024, false, Some(&mut prng));
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
@@ -167,7 +167,7 @@ fn bench_randomized_access_with_1024_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, end_address) = generate_memory_regions(1024, false, None);
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
@@ -180,7 +180,7 @@ fn bench_randomized_mapping_with_1024_entries(bencher: &mut Bencher) {
     let mut prng = new_prng!();
     let (memory_regions, _end_address) = generate_memory_regions(1024, false, Some(&mut prng));
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, 0, 1)
@@ -192,7 +192,7 @@ fn bench_randomized_mapping_with_1024_entries(bencher: &mut Bencher) {
 fn bench_mapping_with_1024_entries(bencher: &mut Bencher) {
     let (memory_regions, _end_address) = generate_memory_regions(1024, false, None);
     let config = Config::default();
-    let memory_mapping = MemoryMapping::new(memory_regions, &config);
+    let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
             .map::<UserError>(AccessType::Load, 0, 1)

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -23,9 +23,12 @@ fn bench_init_interpreter_execution(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable =
-        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
-            .unwrap();
+    let executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
+        &elf,
+        None,
+        Config::default(),
+    )
+    .unwrap();
     let mut vm =
         EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[])
             .unwrap();
@@ -41,9 +44,12 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let mut executable =
-        Executable::<UserError, DefaultInstructionMeter>::from_elf(&elf, None, Config::default())
-            .unwrap();
+    let mut executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_elf(
+        &elf,
+        None,
+        Config::default(),
+    )
+    .unwrap();
     executable.jit_compile().unwrap();
     let mut vm =
         EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[])
@@ -61,7 +67,7 @@ fn bench_jit_vs_interpreter(
     mem: &mut [u8],
 ) {
     let program = assemble(assembly).unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let mut executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
         &program,
         None,
         Config::default(),

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -43,6 +43,9 @@ pub enum ElfError {
     /// Section no found
     #[error("Section not found: {0}")]
     SectionNotFound(String),
+    /// Section overlap
+    #[error("Section overlap found between {0} and {1}")]
+    SectionOverlap(String, String),
     /// Relative jump out of bounds
     #[error("Relative jump out of bounds at instruction #{0}")]
     RelativeJumpOutOfBounds(usize),
@@ -373,7 +376,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
         };
 
         // calculate the read-only section infos
-        let ro_section_infos = elf
+        let mut ro_section_infos = elf
             .section_headers
             .iter()
             .filter_map(|section_header| {
@@ -390,7 +393,21 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
                 }
                 None
             })
-            .collect();
+            .collect::<Vec<_>>();
+        ro_section_infos.sort_by(|a, b| a.vaddr.cmp(&b.vaddr));
+        for i in 0..ro_section_infos.len() {
+            if i > 0
+                && ro_section_infos[i - 1]
+                    .vaddr
+                    .saturating_add(ro_section_infos[i - 1].offset_range.len() as u64)
+                    > ro_section_infos[i].vaddr
+            {
+                return Err(ElfError::SectionOverlap(
+                    ro_section_infos[i - 1].name.clone(),
+                    ro_section_infos[i].name.clone(),
+                ));
+            }
+        }
 
         Ok(Self {
             config,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -374,6 +374,9 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
             vaddr: text_section.sh_addr.saturating_add(ebpf::MM_PROGRAM_START),
             offset_range: text_section.file_range(),
         };
+        if text_section_info.vaddr > ebpf::MM_STACK_START {
+            return Err(ElfError::OutOfBounds);
+        }
 
         // calculate the read-only section infos
         let mut ro_section_infos = elf
@@ -396,6 +399,9 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
             .collect::<Vec<_>>();
         ro_section_infos.sort_by(|a, b| a.vaddr.cmp(&b.vaddr));
         for i in 0..ro_section_infos.len() {
+            if ro_section_infos[i].vaddr > ebpf::MM_STACK_START {
+                return Err(ElfError::OutOfBounds);
+            }
             if i > 0
                 && ro_section_infos[i - 1]
                     .vaddr

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -164,6 +164,7 @@ impl BpfRelocationType {
 
 #[derive(Debug, PartialEq)]
 struct SectionInfo {
+    name: String,
     vaddr: u64,
     offset_range: Range<usize>,
 }
@@ -327,6 +328,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
             elf_bytes: text_bytes.to_vec(),
             entrypoint: 0,
             text_section_info: SectionInfo {
+                name: ".text".to_string(),
                 vaddr: ebpf::MM_PROGRAM_START,
                 offset_range: Range {
                     start: 0,
@@ -360,6 +362,12 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
 
         // calculate the text section info
         let text_section_info = SectionInfo {
+            name: elf
+                .shdr_strtab
+                .get(text_section.sh_name)
+                .unwrap()
+                .unwrap()
+                .to_string(),
             vaddr: text_section.sh_addr.saturating_add(ebpf::MM_PROGRAM_START),
             offset_range: text_section.file_range(),
         };
@@ -369,12 +377,10 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
             .section_headers
             .iter()
             .filter_map(|section_header| {
-                if let Some(Ok(this_name)) = elf.shdr_strtab.get(section_header.sh_name) {
-                    if this_name == ".rodata"
-                        || this_name == ".data.rel.ro"
-                        || this_name == ".eh_frame"
-                    {
+                if let Some(Ok(name)) = elf.shdr_strtab.get(section_header.sh_name) {
+                    if name == ".rodata" || name == ".data.rel.ro" || name == ".eh_frame" {
                         return Some(SectionInfo {
+                            name: name.to_string(),
                             vaddr: section_header
                                 .sh_addr
                                 .saturating_add(ebpf::MM_PROGRAM_START),

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -50,10 +50,12 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 /// use solana_rbpf::syscalls::{BpfTimeGetNs, Result};
 /// use solana_rbpf::memory_region::{MemoryRegion, MemoryMapping};
 /// use solana_rbpf::vm::{Config, SyscallObject};
+/// use solana_rbpf::user_error::UserError;
 ///
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::default()];
-/// BpfTimeGetNs::call(&mut BpfTimeGetNs {}, 0, 0, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// BpfTimeGetNs::call(&mut BpfTimeGetNs {}, 0, 0, 0, 0, 0, &memory_mapping, &mut result);
 /// let t = result.unwrap();
 /// let d =  t / 10u64.pow(9)  / 60   / 60  / 24;
 /// let h = (t / 10u64.pow(9)  / 60   / 60) % 24;
@@ -96,10 +98,12 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// use solana_rbpf::syscalls::{BpfTracePrintf, Result};
 /// use solana_rbpf::memory_region::{MemoryRegion, MemoryMapping};
 /// use solana_rbpf::vm::{Config, SyscallObject};
+/// use solana_rbpf::user_error::UserError;
 ///
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::default()];
-/// BpfTracePrintf::call(&mut BpfTracePrintf {}, 0, 0, 1, 15, 32, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// BpfTracePrintf::call(&mut BpfTracePrintf {}, 0, 0, 1, 15, 32, &memory_mapping, &mut result);
 /// assert_eq!(result.unwrap() as usize, "BpfTracePrintf: 0x1, 0xf, 0x20\n".len());
 /// ```
 ///
@@ -163,10 +167,12 @@ impl SyscallObject<UserError> for BpfTracePrintf {
 /// use solana_rbpf::syscalls::{BpfGatherBytes, Result};
 /// use solana_rbpf::memory_region::{MemoryRegion, MemoryMapping};
 /// use solana_rbpf::vm::{Config, SyscallObject};
+/// use solana_rbpf::user_error::UserError;
 ///
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::default()];
-/// BpfGatherBytes::call(&mut BpfGatherBytes {}, 0x11, 0x22, 0x33, 0x44, 0x55, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// BpfGatherBytes::call(&mut BpfGatherBytes {}, 0x11, 0x22, 0x33, 0x44, 0x55, &memory_mapping, &mut result);
 /// assert_eq!(result.unwrap(), 0x1122334455);
 /// ```
 pub struct BpfGatherBytes {}
@@ -201,15 +207,17 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 /// use solana_rbpf::syscalls::{BpfMemFrob, Result};
 /// use solana_rbpf::memory_region::{MemoryRegion, MemoryMapping};
 /// use solana_rbpf::vm::{Config, SyscallObject};
+/// use solana_rbpf::user_error::UserError;
 ///
 /// let val = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33];
 /// let val_va = 0x1000;
-/// let memory_mapping = [MemoryRegion::new_from_slice(&val, val_va, 0, true)];
 ///
 /// let mut result: Result = Ok(0);
-/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::new_from_slice(&val, val_va, 0, true)], &config).unwrap();
+/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
 /// assert_eq!(val, vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
-/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
 /// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub struct BpfMemFrob {}
@@ -265,10 +273,12 @@ impl SyscallObject<UserError> for BpfMemFrob {
 /// use solana_rbpf::syscalls::{BpfSqrtI, Result};
 /// use solana_rbpf::memory_region::{MemoryRegion, MemoryMapping};
 /// use solana_rbpf::vm::{Config, SyscallObject};
+/// use solana_rbpf::user_error::UserError;
 ///
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::default()];
-/// BpfSqrtI::call(&mut BpfSqrtI {}, 9, 0, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// BpfSqrtI::call(&mut BpfSqrtI {}, 9, 0, 0, 0, 0, &memory_mapping, &mut result);
 /// assert_eq!(result.unwrap(), 3);
 /// ```
 pub struct BpfSqrtI {}
@@ -300,13 +310,16 @@ impl SyscallObject<UserError> for BpfSqrtI {
 /// let bar = "This is another sting.";
 /// let va_foo = 0x1000;
 /// let va_bar = 0x2000;
+/// use solana_rbpf::user_error::UserError;
+///
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false)];
-/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false)], &config).unwrap();
+/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &memory_mapping, &mut result);
 /// assert!(result.unwrap() == 0);
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, 0, false)];
-/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, 0, false)], &config).unwrap();
+/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &memory_mapping, &mut result);
 /// assert!(result.unwrap() != 0);
 /// ```
 pub struct BpfStrCmp {}
@@ -364,14 +377,16 @@ impl SyscallObject<UserError> for BpfStrCmp {
 /// use solana_rbpf::syscalls::{BpfRand, Result};
 /// use solana_rbpf::memory_region::{MemoryRegion, MemoryMapping};
 /// use solana_rbpf::vm::{Config, SyscallObject};
+/// use solana_rbpf::user_error::UserError;
 ///
 /// unsafe {
 ///     libc::srand(time::precise_time_ns() as u32)
 /// }
 ///
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = [MemoryRegion::default()];
-/// BpfRand::call(&mut BpfRand {}, 3, 6, 0, 0, 0, &MemoryMapping::new(memory_mapping.to_vec(), &Config::default()), &mut result);
+/// let config = Config::default();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// BpfRand::call(&mut BpfRand {}, 3, 6, 0, 0, 0, &memory_mapping, &mut result);
 /// let n = result.unwrap();
 /// assert!(3 <= n && n <= 6);
 /// ```

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -440,7 +440,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
             executable,
             program,
             program_vm_addr,
-            memory_mapping: MemoryMapping::new(regions, &config),
+            memory_mapping: MemoryMapping::new(regions, &config)?,
             tracer: Tracer::default(),
             syscall_context_objects: vec![
                 std::ptr::null_mut();


### PR DESCRIPTION
* Adds a name field to the `SectionInfo` struct for error messages
* Throws `VirtualAddressOverlap` if adjacent `MemorRegion`s overlap in virtual address space
* Throws `OutOfBounds` if sections from `MM_PROGRAM_START` reach into `MM_STACK_START`