### PR TITLE
Fix crash in to_insn_vec.

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -187,6 +187,9 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
 
             ebpf::LD_DW_IMM  => {
                 insn_ptr += 1;
+                if insn_ptr * ebpf::INSN_SIZE >= prog.len() {
+                    break
+                }
                 let next_insn = ebpf::get_insn(prog, insn_ptr);
                 imm = ((insn.imm as u32) as u64 + ((next_insn.imm as u64) << 32)) as i64;
                 name = "lddw"; desc = format!("{} r{:}, {:#x}", name, insn.dst, imm);


### PR DESCRIPTION
`to_insn_vec` can crash if the last instruction is `LD_DW_IMM`.