### PR TITLE
Use host aligned memory regions

### DIFF
--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -44,7 +44,7 @@ impl AlignedMemory {
     pub fn fill(&mut self, num: usize, value: u8) -> std::io::Result<()> {
         if self.write_index + num >= self.len {
             return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+                std::io::ErrorKind::InvalidInput,
                 "aligned memory fill failed",
             ));
         }
@@ -61,7 +61,7 @@ impl std::io::Write for AlignedMemory {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.write_index + buf.len() >= self.mem.len() {
             return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+                std::io::ErrorKind::InvalidInput,
                 "aligned memory write failed",
             ));
         }

--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -1,0 +1,75 @@
+//! Aligned memory
+
+/// Provides u8 slices at a specified alignment
+#[derive(Clone, Debug, PartialEq)]
+pub struct AlignedMemory {
+    len: usize,
+    align_offset: usize,
+    write_index: usize,
+    mem: Vec<u8>,
+}
+impl AlignedMemory {
+    /// Return a new AlignedMem type
+    pub fn new(len: usize, align: usize) -> Self {
+        let mem = vec![0u8; len + align];
+        let align_offset = mem.as_ptr().align_offset(align);
+        Self {
+            len,
+            align_offset,
+            mem,
+            write_index: align_offset,
+        }
+    }
+    /// Get the length of the data
+    pub fn len(&self) -> usize {
+        self.len
+    }
+    /// Is the memory empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+    /// Get the current write index
+    pub fn write_index(&self) -> usize {
+        self.write_index
+    }
+    /// Get an aligned slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.mem[self.align_offset..self.align_offset + self.len]
+    }
+    /// Get an aligned mutable slice
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        &mut self.mem[self.align_offset..self.align_offset + self.len]
+    }
+    /// Fill memory with value starting at the write_index
+    pub fn fill(&mut self, num: usize, value: u8) -> std::io::Result<()> {
+        if self.write_index + num >= self.len {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "aligned memory fill failed",
+            ));
+        }
+        if value != 0 {
+            for i in 0..num {
+                self.mem[self.write_index + i] = value;
+            }
+        }
+        self.write_index += num;
+        Ok(())
+    }
+}
+impl std::io::Write for AlignedMemory {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.write_index + buf.len() >= self.mem.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "aligned memory write failed",
+            ));
+        }
+        self.mem[self.write_index..self.write_index + buf.len()].copy_from_slice(buf);
+        self.write_index += buf.len();
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -1,7 +1,8 @@
 //! Call frame handler
 
 use crate::{
-    ebpf::{ELF_INSN_DUMP_OFFSET, MM_STACK_START, SCRATCH_REGS},
+    aligned_memory::AlignedMemory,
+    ebpf::{ELF_INSN_DUMP_OFFSET, HOST_ALIGN, MM_STACK_START, SCRATCH_REGS},
     error::{EbpfError, UserDefinedError},
     memory_region::MemoryRegion,
 };
@@ -19,7 +20,7 @@ struct CallFrame {
 /// call frames
 #[derive(Clone, Debug)]
 pub struct CallFrames {
-    stack: Vec<u8>,
+    stack: AlignedMemory,
     region: MemoryRegion,
     frame_index: usize,
     frame_index_max: usize,
@@ -28,9 +29,9 @@ pub struct CallFrames {
 impl CallFrames {
     /// New call frame, depth indicates maximum call depth
     pub fn new(depth: usize, frame_size: usize) -> Self {
-        let stack = vec![0u8; depth * frame_size];
+        let stack = AlignedMemory::new(depth * frame_size, HOST_ALIGN);
         let region =
-            MemoryRegion::new_from_slice(&stack[..], MM_STACK_START, frame_size as u64, true);
+            MemoryRegion::new_from_slice(stack.as_slice(), MM_STACK_START, frame_size as u64, true);
         let mut frames = CallFrames {
             stack,
             region,

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -62,6 +62,9 @@ pub const MM_HEAP_START: u64 = 0x300000000;
 /// Start of the input buffers in the memory map
 pub const MM_INPUT_START: u64 = 0x400000000;
 
+/// Alignment of the memory regions in host address space
+pub const HOST_ALIGN: usize = 16;
+
 // eBPF op codes.
 // See also https://www.kernel.org/doc/Documentation/networking/filter.txt
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -62,7 +62,7 @@ pub const MM_HEAP_START: u64 = 0x300000000;
 /// Start of the input buffers in the memory map
 pub const MM_INPUT_START: u64 = 0x400000000;
 
-/// Alignment of the memory regions in host address space
+/// Alignment of the memory regions in host address space in bytes
 pub const HOST_ALIGN: usize = 16;
 
 // eBPF op codes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate rand;
 extern crate thiserror;
 extern crate time;
 
+pub mod aligned_memory;
 mod asm_parser;
 pub mod assembler;
 pub mod call_frames;


### PR DESCRIPTION
The host addresses of the memory regions could be unaligned which could lead to unaligned accesses when translating a program address to a host address.  Host align the memory mapped into the program space.