### PR TITLE
Fix bump to v0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "byteorder 1.2.7",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana_rbpf"
-version = "0.2.7"
+version = "0.2.8"
 description = "Virtual machine and JIT compiler for eBPF programs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/rbpf"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf_cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "clap",
  "rustc-demangle",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "byteorder",
  "combine",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "libc",
  "solana_rbpf",

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -32,7 +32,7 @@ for ignore in "${ignores[@]}"; do
 done
 
 # shellcheck disable=2207
-Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml "${not_paths[@]}"))
+Cargo_tomls=($(find . -mindepth 1 -name Cargo.toml "${not_paths[@]}"))
 # shellcheck disable=2207
 markdownFiles=($(find . -name "*.md" "${not_paths[@]}"))
 

--- a/test_utils/Cargo.lock
+++ b/test_utils/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "byteorder",
  "combine",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "libc",
  "solana_rbpf",


### PR DESCRIPTION
- Enforce the use of host aligned memory for regions mapping into program space
- Export aligned memory utility that can be used when passing memory into the VM that will be mapped into program space