### PR TITLE
Refactor LDDW and Insn Struct Immediate Field

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -156,6 +156,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
         return Err(format!("Invalid immediate {}", imm));
     }
     Ok(Insn {
+        ptr: 0,
         opc,
         dst: dst as u8,
         src: src as u8,
@@ -217,11 +218,8 @@ fn assemble_internal(parsed: &[Instruction]) -> Result<Vec<Insn>, String> {
                 if let LoadImm = inst_type {
                     if let Integer(imm) = instruction.operands[1] {
                         result.push(Insn {
-                            opc: 0,
-                            dst: 0,
-                            src: 0,
-                            off: 0,
                             imm: (imm >> 32) as i64,
+                            ..Insn::default()
                         });
                     }
                 }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -160,7 +160,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
         dst: dst as u8,
         src: src as u8,
         off: off as i16,
-        imm: imm as i32,
+        imm,
     })
 }
 
@@ -221,7 +221,7 @@ fn assemble_internal(parsed: &[Instruction]) -> Result<Vec<Insn>, String> {
                             dst: 0,
                             src: 0,
                             off: 0,
-                            imm: (imm >> 32) as i32,
+                            imm: (imm >> 32) as i64,
                         });
                     }
                 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -71,12 +71,12 @@ fn jmp_reg_str(name: &str, insn: &ebpf::Insn) -> String {
 /// In addition to standard operation code and various operand, this struct has the following
 /// properties:
 ///
+/// * It stores the instruction pointer (this can diverge from the instruction index if LD_DW_IMM
+///   instructions are present).
 /// * It stores a name, corresponding to a mnemonic for the operation code.
 /// * It also stores a description, which is a mnemonic for the full instruction, using the actual
 ///   values of the relevant operands, and that can be used for disassembling the eBPF program for
 ///   example.
-/// * Immediate values are stored in an `i64` instead of a traditional i32, in order to merge the
-///   two parts of (otherwise double-length) `LD_DW_IMM` instructions.
 ///
 /// See <https://www.kernel.org/doc/Documentation/networking/filter.txt> for the Linux kernel
 /// documentation about eBPF, or <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md> for a
@@ -116,7 +116,7 @@ pub struct HlInsn {
 /// To do so, the immediate value operand is stored as an `i64` instead as an i32, so be careful
 /// when you use it (see example `examples/to_json.rs`).
 ///
-/// This is to oppose to `ebpf::to_insn_vec()` function, that treats instructions on a low-level
+/// This is opposed to `ebpf::to_insn_vec()` function, that treats instructions on a low-level
 /// ground and do not merge the parts of `LD_DW_IMM`. Also, the version in `ebpf` module does not
 /// use names or descriptions when storing the instructions.
 ///
@@ -167,12 +167,11 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
     let mut insn_ptr: usize = 0;
 
     while insn_ptr * ebpf::INSN_SIZE < prog.len() {
-        let insn = ebpf::get_insn(prog, insn_ptr);
+        let mut insn = ebpf::get_insn(prog, insn_ptr);
         let ptr = insn_ptr;
 
         let name;
         let desc;
-        let mut imm = insn.imm as i64;
         match insn.opc {
 
             // BPF_LD class
@@ -190,9 +189,8 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
                 if insn_ptr * ebpf::INSN_SIZE >= prog.len() {
                     break
                 }
-                let next_insn = ebpf::get_insn(prog, insn_ptr);
-                imm = ((insn.imm as u32) as u64 + ((next_insn.imm as u64) << 32)) as i64;
-                name = "lddw"; desc = format!("{} r{:}, {:#x}", name, insn.dst, imm);
+                ebpf::augment_lddw_unchecked(prog, insn_ptr, &mut insn);
+                name = "lddw"; desc = format!("{} r{:}, {:#x}", name, insn.dst, insn.imm);
             },
 
             // BPF_LDX class
@@ -312,7 +310,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
             dst:  insn.dst,
             src:  insn.src,
             off:  insn.off,
-            imm,
+            imm:  insn.imm,
         });
 
         insn_ptr += 1;

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -71,8 +71,6 @@ fn jmp_reg_str(name: &str, insn: &ebpf::Insn) -> String {
 /// In addition to standard operation code and various operand, this struct has the following
 /// properties:
 ///
-/// * It stores the instruction pointer (this can diverge from the instruction index if LD_DW_IMM
-///   instructions are present).
 /// * It stores a name, corresponding to a mnemonic for the operation code.
 /// * It also stores a description, which is a mnemonic for the full instruction, using the actual
 ///   values of the relevant operands, and that can be used for disassembling the eBPF program for
@@ -189,7 +187,7 @@ pub fn to_insn_vec(prog: &[u8]) -> Vec<HlInsn> {
                 if insn_ptr * ebpf::INSN_SIZE >= prog.len() {
                     break
                 }
-                ebpf::augment_lddw_unchecked(prog, insn_ptr, &mut insn);
+                ebpf::augment_lddw_unchecked(prog, &mut insn);
                 name = "lddw"; desc = format!("{} r{:}, {:#x}", name, insn.dst, insn.imm);
             },
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -559,6 +559,12 @@ pub fn get_insn_unchecked(prog: &[u8], idx: usize) -> Insn {
     }
 }
 
+/// Merge the two halves of a LD_DW_IMM instruction
+pub fn augment_lddw_unchecked(prog: &[u8], idx: usize, insn: &mut Insn) {
+    let more_significant_half = LittleEndian::read_i32(&prog[(INSN_SIZE * idx + 4)..]);
+    insn.imm = ((insn.imm as u64 & 0xffffffff) | ((more_significant_half as u64) << 32)) as i64;
+}
+
 /// Return a vector of `struct Insn` built from a program.
 ///
 /// This is provided as a convenience for users wishing to manipulate a vector of instructions, for

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -433,7 +433,7 @@ pub struct Insn {
     /// Offset operand.
     pub off: i16,
     /// Immediate value operand.
-    pub imm: i32,
+    pub imm: i64,
 }
 
 impl fmt::Debug for Insn {
@@ -500,16 +500,7 @@ impl Insn {
     /// assert_eq!(insn.to_vec(), prog);
     /// ```
     pub fn to_vec(&self) -> Vec<u8> {
-        vec![
-            self.opc,
-            self.src.wrapping_shl(4) | self.dst,
-            (self.off & 0xff) as u8,
-            self.off.wrapping_shr(8) as u8,
-            (self.imm & 0xff) as u8,
-            (self.imm & 0xff_00).wrapping_shr(8) as u8,
-            (self.imm as u32 & 0xff_00_00).wrapping_shr(16) as u8,
-            (self.imm as u32 & 0xff_00_00_00).wrapping_shr(24) as u8,
-        ]
+        self.to_array().to_vec()
     }
 }
 
@@ -564,7 +555,7 @@ pub fn get_insn_unchecked(prog: &[u8], idx: usize) -> Insn {
         dst: prog[INSN_SIZE * idx + 1] & 0x0f,
         src: (prog[INSN_SIZE * idx + 1] & 0xf0) >> 4,
         off: LittleEndian::read_i16(&prog[(INSN_SIZE * idx + 2)..]),
-        imm: LittleEndian::read_i32(&prog[(INSN_SIZE * idx + 4)..]),
+        imm: LittleEndian::read_i32(&prog[(INSN_SIZE * idx + 4)..]) as i64,
     }
 }
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -569,66 +569,6 @@ pub fn augment_lddw_unchecked(prog: &[u8], insn: &mut Insn) {
     insn.imm = ((insn.imm as u64 & 0xffffffff) | ((more_significant_half as u64) << 32)) as i64;
 }
 
-/// Return a vector of `struct Insn` built from a program.
-///
-/// This is provided as a convenience for users wishing to manipulate a vector of instructions, for
-/// example for dumping the program instruction after instruction with a custom format.
-///
-/// Note that the two parts of `LD_DW_IMM` instructions (spanning on 64 bits) are considered as two
-/// distinct instructions.
-///
-/// # Examples
-///
-/// ```
-/// use solana_rbpf::ebpf;
-///
-/// let prog = &[
-///     0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55,
-///     0x00, 0x00, 0x00, 0x00, 0x44, 0x33, 0x22, 0x11,
-///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-/// ];
-///
-/// let v = ebpf::to_insn_vec(prog);
-/// assert_eq!(v, vec![
-///     ebpf::Insn {
-///         ptr: 0x00,
-///         opc: 0x18,
-///         dst: 0,
-///         src: 0,
-///         off: 0,
-///         imm: 0x55667788
-///     },
-///     ebpf::Insn {
-///         ptr: 0x08,
-///         opc: 0,
-///         dst: 0,
-///         src: 0,
-///         off: 0,
-///         imm: 0x11223344
-///     },
-///     ebpf::Insn {
-///         ptr: 0x10,
-///         opc: 0x95,
-///         dst: 0,
-///         src: 0,
-///         off: 0,
-///         imm: 0
-///     },
-/// ]);
-/// ```
-pub fn to_insn_vec(prog: &[u8]) -> Vec<Insn> {
-    debug_assert!(
-        prog.len() % INSN_SIZE == 0,
-        "eBPF program length {:?} must be a multiple of {:?} octets",
-        prog.len(),
-        INSN_SIZE
-    );
-
-    (0..prog.len() / INSN_SIZE)
-        .map(|insn_ptr| get_insn(prog, insn_ptr))
-        .collect()
-}
-
 /// Hash a symbol name
 ///
 /// This function is used by both the relocator and the VM to translate symbol names

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -787,8 +787,8 @@ mod test {
             opc: 0x85,
             dst: 0,
             src: 1,
-            off: 0,
             imm: key as i64,
+            ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[40..]);
         assert_eq!(*calls.get(&key).unwrap(), 4);
@@ -802,8 +802,8 @@ mod test {
             opc: 0x85,
             dst: 0,
             src: 1,
-            off: 0,
             imm: key as i64,
+            ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[40..]);
         assert_eq!(*calls.get(&key).unwrap(), 0);
@@ -828,8 +828,8 @@ mod test {
             opc: 0x85,
             dst: 0,
             src: 1,
-            off: 0,
             imm: key as i64,
+            ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[..8]);
         assert_eq!(*calls.get(&key).unwrap(), 1);
@@ -843,8 +843,8 @@ mod test {
             opc: 0x85,
             dst: 0,
             src: 1,
-            off: 0,
             imm: key as i64,
+            ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[..8]);
         assert_eq!(*calls.get(&key).unwrap(), 5);
@@ -872,8 +872,8 @@ mod test {
             opc: 0x85,
             dst: 0,
             src: 1,
-            off: 0,
             imm: key as i64,
+            ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[..8]);
         assert_eq!(*calls.get(&key).unwrap(), 1);
@@ -901,8 +901,8 @@ mod test {
             opc: 0x85,
             dst: 0,
             src: 1,
-            off: 0,
             imm: key as i64,
+            ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[40..]);
         assert_eq!(*calls.get(&key).unwrap(), 4);

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -445,7 +445,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
                     ));
                 }
 
-                insn.imm = hash as i32;
+                insn.imm = hash as i64;
                 let checked_slice = elf_bytes
                     .get_mut(i * ebpf::INSN_SIZE..(i * ebpf::INSN_SIZE) + ebpf::INSN_SIZE)
                     .ok_or(ElfError::OutOfBounds)?;
@@ -788,7 +788,7 @@ mod test {
             dst: 0,
             src: 1,
             off: 0,
-            imm: key as i32,
+            imm: key as i64,
         };
         assert_eq!(insn.to_array(), prog[40..]);
         assert_eq!(*calls.get(&key).unwrap(), 4);
@@ -803,7 +803,7 @@ mod test {
             dst: 0,
             src: 1,
             off: 0,
-            imm: key as i32,
+            imm: key as i64,
         };
         assert_eq!(insn.to_array(), prog[40..]);
         assert_eq!(*calls.get(&key).unwrap(), 0);
@@ -829,7 +829,7 @@ mod test {
             dst: 0,
             src: 1,
             off: 0,
-            imm: key as i32,
+            imm: key as i64,
         };
         assert_eq!(insn.to_array(), prog[..8]);
         assert_eq!(*calls.get(&key).unwrap(), 1);
@@ -844,7 +844,7 @@ mod test {
             dst: 0,
             src: 1,
             off: 0,
-            imm: key as i32,
+            imm: key as i64,
         };
         assert_eq!(insn.to_array(), prog[..8]);
         assert_eq!(*calls.get(&key).unwrap(), 5);
@@ -873,7 +873,7 @@ mod test {
             dst: 0,
             src: 1,
             off: 0,
-            imm: key as i32,
+            imm: key as i64,
         };
         assert_eq!(insn.to_array(), prog[..8]);
         assert_eq!(*calls.get(&key).unwrap(), 1);
@@ -902,7 +902,7 @@ mod test {
             dst: 0,
             src: 1,
             off: 0,
-            imm: key as i32,
+            imm: key as i64,
         };
         assert_eq!(insn.to_array(), prog[40..]);
         assert_eq!(*calls.get(&key).unwrap(), 4);

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -181,13 +181,7 @@ impl BpfCode {
             src_bit: source,
             op_bits,
             arch_bits,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 
@@ -196,13 +190,7 @@ impl BpfCode {
         SwapBytes {
             bpf_code: self,
             endian,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 
@@ -233,13 +221,7 @@ impl BpfCode {
             addressing,
             mem_size,
             source,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 
@@ -259,13 +241,7 @@ impl BpfCode {
             bpf_code: self,
             mem_size,
             source,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 
@@ -280,13 +256,7 @@ impl BpfCode {
             bpf_code: self,
             cond,
             src_bit,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 
@@ -294,13 +264,7 @@ impl BpfCode {
     pub fn call(&mut self) -> FunctionCall {
         FunctionCall {
             bpf_code: self,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 
@@ -308,13 +272,7 @@ impl BpfCode {
     pub fn exit(&mut self) -> Exit {
         Exit {
             bpf_code: self,
-            insn: Insn {
-                opc: 0x00,
-                dst: 0x00,
-                src: 0x00,
-                off: 0x00_00,
-                imm: 0x00_00_00_00,
-            },
+            insn: Insn::default(),
         }
     }
 }

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -29,7 +29,7 @@ pub trait Instruction: Sized {
     }
 
     /// returns immediate value
-    fn get_imm(&self) -> i32 {
+    fn get_imm(&self) -> i64 {
         self.get_insn().imm
     }
 
@@ -52,7 +52,7 @@ pub trait Instruction: Sized {
     }
 
     /// sets immediate value
-    fn set_imm(mut self, imm: i32) -> Self {
+    fn set_imm(mut self, imm: i64) -> Self {
         self.get_insn_mut().imm = imm;
         self
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -826,7 +826,7 @@ impl JitCompiler {
                     emit_validate_and_profile_instruction_count(self, true, Some(self.pc + 2))?;
                     self.pc += 1;
                     self.pc_section_jumps.push(Jump { location: self.pc, target_pc: TARGET_PC_CALL_UNSUPPORTED_INSTRUCTION });
-                    ebpf::augment_lddw_unchecked(program, self.pc, &mut insn);
+                    ebpf::augment_lddw_unchecked(program, &mut insn);
                     X86Instruction::load_immediate(OperandSize::S64, dst, insn.imm).emit(self)?;
                 },
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -194,7 +194,7 @@ pub enum OperandSize {
 }
 
 #[inline]
-fn emit_alu<E: UserDefinedError>(jit: &mut JitCompiler, size: OperandSize, opcode: u8, source: u8, destination: u8, immediate: i32, indirect: Option<X86IndirectAccess>) -> Result<(), EbpfError<E>> {
+fn emit_alu<E: UserDefinedError>(jit: &mut JitCompiler, size: OperandSize, opcode: u8, source: u8, destination: u8, immediate: i64, indirect: Option<X86IndirectAccess>) -> Result<(), EbpfError<E>> {
     X86Instruction {
         size,
         opcode,
@@ -206,7 +206,7 @@ fn emit_alu<E: UserDefinedError>(jit: &mut JitCompiler, size: OperandSize, opcod
             0xf7 if source == 0 => OperandSize::S32,
             _ => OperandSize::S0,
         },
-        immediate: immediate as i64,
+        immediate,
         indirect,
         ..X86Instruction::default()
     }.emit(jit)
@@ -296,12 +296,12 @@ fn emit_profile_instruction_count<E: UserDefinedError>(jit: &mut JitCompiler, ta
     if jit.config.enable_instruction_meter {
         match target_pc {
             Some(target_pc) => {
-                emit_alu(jit, OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], target_pc as i32 - jit.pc as i32 - 1, None)?; // instruction_meter += target_pc - (jit.pc + 1);
+                emit_alu(jit, OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], target_pc as i64 - jit.pc as i64 - 1, None)?; // instruction_meter += target_pc - (jit.pc + 1);
             },
             None => { // If no constant target_pc is given, it is expected to be on the stack instead
                 X86Instruction::pop(R11).emit(jit)?;
-                emit_alu(jit, OperandSize::S64, 0x81, 5, ARGUMENT_REGISTERS[0], jit.pc as i32 + 1, None)?; // instruction_meter -= jit.pc + 1;
-                emit_alu(jit, OperandSize::S64, 0x01, R11, ARGUMENT_REGISTERS[0], jit.pc as i32, None)?; // instruction_meter += target_pc;
+                emit_alu(jit, OperandSize::S64, 0x81, 5, ARGUMENT_REGISTERS[0], jit.pc as i64 + 1, None)?; // instruction_meter -= jit.pc + 1;
+                emit_alu(jit, OperandSize::S64, 0x01, R11, ARGUMENT_REGISTERS[0], jit.pc as i64, None)?; // instruction_meter += target_pc;
             },
         }
     }
@@ -321,7 +321,7 @@ fn emit_validate_and_profile_instruction_count<E: UserDefinedError>(jit: &mut Ji
 #[inline]
 fn emit_undo_profile_instruction_count<E: UserDefinedError>(jit: &mut JitCompiler, target_pc: usize) -> Result<(), EbpfError<E>> {
     if jit.config.enable_instruction_meter {
-        emit_alu(jit, OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], jit.pc as i32 + 1 - target_pc as i32, None)?; // instruction_meter += (jit.pc + 1) - target_pc;
+        emit_alu(jit, OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], jit.pc as i64 + 1 - target_pc as i64, None)?; // instruction_meter += (jit.pc + 1) - target_pc;
     }
     Ok(())
 }
@@ -344,9 +344,9 @@ fn emit_conditional_branch_reg<E: UserDefinedError>(jit: &mut JitCompiler, op: u
 }
 
 #[inline]
-fn emit_conditional_branch_imm<E: UserDefinedError>(jit: &mut JitCompiler, op: u8, imm: i32, dst: u8, target_pc: usize) -> Result<(), EbpfError<E>> {
+fn emit_conditional_branch_imm<E: UserDefinedError>(jit: &mut JitCompiler, op: u8, imm: i64, dst: u8, target_pc: usize) -> Result<(), EbpfError<E>> {
     emit_validate_and_profile_instruction_count(jit, false, Some(target_pc))?;
-    X86Instruction::cmp_immediate(OperandSize::S64, dst, imm as i64, None).emit(jit)?;
+    X86Instruction::cmp_immediate(OperandSize::S64, dst, imm, None).emit(jit)?;
     emit_jcc(jit, op, target_pc)?;
     emit_undo_profile_instruction_count(jit, target_pc)
 }
@@ -373,7 +373,7 @@ fn emit_bpf_call<E: UserDefinedError>(jit: &mut JitCompiler, dst: Value, number_
                 X86Instruction::mov(OperandSize::S64, reg, REGISTER_MAP[0]).emit(jit)?;
             }
             // Force alignment of RAX
-            emit_alu(jit, OperandSize::S64, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i32 - 1), None)?; // RAX &= !(INSN_SIZE - 1);
+            emit_alu(jit, OperandSize::S64, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i64 - 1), None)?; // RAX &= !(INSN_SIZE - 1);
             // Store PC in case the bounds check fails
             X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64).emit(jit)?;
             // Upper bound check
@@ -393,7 +393,7 @@ fn emit_bpf_call<E: UserDefinedError>(jit: &mut JitCompiler, dst: Value, number_
                 let shift_amount = INSN_SIZE.trailing_zeros();
                 debug_assert_eq!(INSN_SIZE, 1<<shift_amount);
                 X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], REGISTER_MAP[STACK_REG]).emit(jit)?;
-                emit_alu(jit, OperandSize::S64, 0xc1, 5, REGISTER_MAP[STACK_REG], shift_amount as i32, None)?;
+                emit_alu(jit, OperandSize::S64, 0xc1, 5, REGISTER_MAP[STACK_REG], shift_amount as i64, None)?;
                 X86Instruction::push(REGISTER_MAP[STACK_REG]).emit(jit)?;
             }
             // Load host target_address from JitProgramArgument.instruction_addresses
@@ -411,8 +411,8 @@ fn emit_bpf_call<E: UserDefinedError>(jit: &mut JitCompiler, dst: Value, number_
     }
 
     X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[STACK_REG], X86IndirectAccess::Offset(-8 * CALLEE_SAVED_REGISTERS.len() as i32)).emit(jit)?; // load stack_ptr
-    emit_alu(jit, OperandSize::S64, 0x81, 4, REGISTER_MAP[STACK_REG], !(jit.config.stack_frame_size as i32 * 2 - 1), None)?; // stack_ptr &= !(jit.config.stack_frame_size * 2 - 1);
-    emit_alu(jit, OperandSize::S64, 0x81, 0, REGISTER_MAP[STACK_REG], jit.config.stack_frame_size as i32 * 3, None)?; // stack_ptr += jit.config.stack_frame_size * 3;
+    emit_alu(jit, OperandSize::S64, 0x81, 4, REGISTER_MAP[STACK_REG], !(jit.config.stack_frame_size as i64 * 2 - 1), None)?; // stack_ptr &= !(jit.config.stack_frame_size * 2 - 1);
+    emit_alu(jit, OperandSize::S64, 0x81, 0, REGISTER_MAP[STACK_REG], jit.config.stack_frame_size as i64 * 3, None)?; // stack_ptr += jit.config.stack_frame_size * 3;
     X86Instruction::store(OperandSize::S64, REGISTER_MAP[STACK_REG], RBP, X86IndirectAccess::Offset(-8 * CALLEE_SAVED_REGISTERS.len() as i32)).emit(jit)?; // store stack_ptr
 
     // if(stack_ptr >= MM_STACK_START + jit.config.max_call_depth * jit.config.stack_frame_size * 2) throw EbpfError::CallDepthExeeded;
@@ -594,7 +594,7 @@ fn emit_shift<E: UserDefinedError>(jit: &mut JitCompiler, size: OperandSize, opc
     }
 }
 
-fn emit_muldivmod<E: UserDefinedError>(jit: &mut JitCompiler, opc: u8, src: u8, dst: u8, imm: Option<i32>) -> Result<(), EbpfError<E>> {
+fn emit_muldivmod<E: UserDefinedError>(jit: &mut JitCompiler, opc: u8, src: u8, dst: u8, imm: Option<i64>) -> Result<(), EbpfError<E>> {
     let mul = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MUL32_IMM & ebpf::BPF_ALU_OP_MASK);
     let div = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::DIV32_IMM & ebpf::BPF_ALU_OP_MASK);
     let modrm = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MOD32_IMM & ebpf::BPF_ALU_OP_MASK);
@@ -619,7 +619,7 @@ fn emit_muldivmod<E: UserDefinedError>(jit: &mut JitCompiler, opc: u8, src: u8, 
     }
 
     if let Some(imm) = imm {
-        X86Instruction::load_immediate(OperandSize::S64, R11, imm as i64).emit(jit)?;
+        X86Instruction::load_immediate(OperandSize::S64, R11, imm).emit(jit)?;
     } else {
         X86Instruction::mov(OperandSize::S64, src, R11).emit(jit)?;
     }
@@ -1083,8 +1083,8 @@ impl JitCompiler {
                     emit_validate_and_profile_instruction_count(self, true, Some(0))?;
 
                     X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[STACK_REG], X86IndirectAccess::Offset(-8 * CALLEE_SAVED_REGISTERS.len() as i32)).emit(self)?; // load stack_ptr
-                    emit_alu(self, OperandSize::S64, 0x81, 4, REGISTER_MAP[STACK_REG], !(self.config.stack_frame_size as i32 * 2 - 1), None)?; // stack_ptr &= !(jit.config.stack_frame_size * 2 - 1);
-                    emit_alu(self, OperandSize::S64, 0x81, 5, REGISTER_MAP[STACK_REG], self.config.stack_frame_size as i32 * 2, None)?; // stack_ptr -= jit.config.stack_frame_size * 2;
+                    emit_alu(self, OperandSize::S64, 0x81, 4, REGISTER_MAP[STACK_REG], !(self.config.stack_frame_size as i64 * 2 - 1), None)?; // stack_ptr &= !(jit.config.stack_frame_size * 2 - 1);
+                    emit_alu(self, OperandSize::S64, 0x81, 5, REGISTER_MAP[STACK_REG], self.config.stack_frame_size as i64 * 2, None)?; // stack_ptr -= jit.config.stack_frame_size * 2;
                     X86Instruction::store(OperandSize::S64, REGISTER_MAP[STACK_REG], RBP, X86IndirectAccess::Offset(-8 * CALLEE_SAVED_REGISTERS.len() as i32)).emit(self)?; // store stack_ptr
 
                     // if(stack_ptr < MM_STACK_START) goto exit;
@@ -1136,7 +1136,7 @@ impl JitCompiler {
             // Pop stack and return
             emit_alu(self, OperandSize::S64, 0x81, 0, RSP, 8 * 3, None)?; // RSP += 8 * 3;
             X86Instruction::pop(REGISTER_MAP[0]).emit(self)?;
-            emit_alu(self, OperandSize::S64, 0x81, 0, RSP, 8 * (REGISTER_MAP.len() - 1) as i32, None)?; // RSP += 8 * (REGISTER_MAP.len() - 1);
+            emit_alu(self, OperandSize::S64, 0x81, 0, RSP, 8 * (REGISTER_MAP.len() - 1) as i64, None)?; // RSP += 8 * (REGISTER_MAP.len() - 1);
             X86Instruction::pop(R11).emit(self)?;
             X86Instruction::return_near().emit(self)?;
         }
@@ -1202,7 +1202,7 @@ impl JitCompiler {
         emit_profile_instruction_count_of_exception(self)?;
         X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(-8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32)).emit(self)?;
         X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(0), 1).emit(self)?; // is_err = true;
-        emit_alu(self, OperandSize::S64, 0x81, 0, R11, ebpf::ELF_INSN_DUMP_OFFSET as i32 - 1, None)?;
+        emit_alu(self, OperandSize::S64, 0x81, 0, R11, ebpf::ELF_INSN_DUMP_OFFSET as i64 - 1, None)?;
         X86Instruction::store(OperandSize::S64, R11, R10, X86IndirectAccess::Offset(16)).emit(self)?; // pc = self.pc + ebpf::ELF_INSN_DUMP_OFFSET;
         emit_jmp(self, TARGET_PC_EPILOGUE)?;
 
@@ -1263,7 +1263,7 @@ impl JitCompiler {
 
         // Restore stack pointer in case the BPF stack was used
         X86Instruction::mov(OperandSize::S64, RBP, R11).emit(self)?;
-        emit_alu(self, OperandSize::S64, 0x81, 5, R11, 8 * (CALLEE_SAVED_REGISTERS.len()-1) as i32, None)?;
+        emit_alu(self, OperandSize::S64, 0x81, 5, R11, 8 * (CALLEE_SAVED_REGISTERS.len() - 1) as i64, None)?;
         X86Instruction::mov(OperandSize::S64, R11, RSP).emit(self)?; // RSP = RBP - 8 * (CALLEE_SAVED_REGISTERS.len() - 1).emit(self);
 
         // Restore registers

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -675,7 +675,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 },
 
                 ebpf::LD_DW_IMM  => {
-                    ebpf::augment_lddw_unchecked(self.program, next_pc, &mut insn);
+                    ebpf::augment_lddw_unchecked(self.program, &mut insn);
                     next_pc += 1;
                     reg[dst] = insn.imm as u64;
                 },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -616,7 +616,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         while next_pc * ebpf::INSN_SIZE + ebpf::INSN_SIZE <= self.program.len() {
             let pc = next_pc;
             next_pc += 1;
-            let insn = ebpf::get_insn_unchecked(self.program, pc);
+            let mut insn = ebpf::get_insn_unchecked(self.program, pc);
             let dst = insn.dst as usize;
             let src = insn.src as usize;
             self.last_insn_count += 1;
@@ -675,9 +675,9 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 },
 
                 ebpf::LD_DW_IMM  => {
-                    let next_insn = ebpf::get_insn(self.program, next_pc);
+                    ebpf::augment_lddw_unchecked(self.program, next_pc, &mut insn);
                     next_pc += 1;
-                    reg[dst] = (insn.imm as u32) as u64 + ((next_insn.imm as u64) << 32);
+                    reg[dst] = insn.imm as u64;
                 },
 
                 // BPF_LDX class

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -747,11 +747,11 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
                 },
 
                 // BPF_ALU class
-                ebpf::ADD32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_add(insn.imm)          as u64,
+                ebpf::ADD32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_add(insn.imm as i32)   as u64,
                 ebpf::ADD32_REG  => reg[dst] = (reg[dst] as i32).wrapping_add(reg[src] as i32)   as u64,
-                ebpf::SUB32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_sub(insn.imm)          as u64,
+                ebpf::SUB32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_sub(insn.imm as i32)   as u64,
                 ebpf::SUB32_REG  => reg[dst] = (reg[dst] as i32).wrapping_sub(reg[src] as i32)   as u64,
-                ebpf::MUL32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_mul(insn.imm)          as u64,
+                ebpf::MUL32_IMM  => reg[dst] = (reg[dst] as i32).wrapping_mul(insn.imm as i32)   as u64,
                 ebpf::MUL32_REG  => reg[dst] = (reg[dst] as i32).wrapping_mul(reg[src] as i32)   as u64,
                 ebpf::DIV32_IMM  => reg[dst] = (reg[dst] as u32 / insn.imm as u32)               as u64,
                 ebpf::DIV32_REG  => {

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -11,12 +11,19 @@ use solana_rbpf::assembler::assemble;
 use solana_rbpf::ebpf;
 use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
 
-fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
-    Ok(ebpf::to_insn_vec(&assemble(src)?))
+pub fn to_insn_vec(prog: &[u8]) -> Vec<ebpf::Insn> {
+    (0..prog.len() / ebpf::INSN_SIZE)
+        .map(|insn_ptr| ebpf::get_insn(prog, insn_ptr))
+        .collect()
 }
 
-fn insn(opc: u8, dst: u8, src: u8, off: i16, imm: i64) -> ebpf::Insn {
+fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
+    Ok(to_insn_vec(&assemble(src)?))
+}
+
+fn insn(ptr: usize, opc: u8, dst: u8, src: u8, off: i16, imm: i64) -> ebpf::Insn {
     ebpf::Insn {
+        ptr: ptr * ebpf::INSN_SIZE,
         opc,
         dst,
         src,
@@ -33,7 +40,7 @@ fn test_empty() {
 // Example for InstructionType::NoOperand.
 #[test]
 fn test_exit() {
-    assert_eq!(asm("exit"), Ok(vec![insn(ebpf::EXIT, 0, 0, 0, 0)]));
+    assert_eq!(asm("exit"), Ok(vec![insn(0, ebpf::EXIT, 0, 0, 0, 0)]));
 }
 
 // Example for InstructionType::AluBinary.
@@ -41,18 +48,18 @@ fn test_exit() {
 fn test_add64() {
     assert_eq!(
         asm("add64 r1, r3"),
-        Ok(vec![insn(ebpf::ADD64_REG, 1, 3, 0, 0)])
+        Ok(vec![insn(0, ebpf::ADD64_REG, 1, 3, 0, 0)])
     );
     assert_eq!(
         asm("add64 r1, 5"),
-        Ok(vec![insn(ebpf::ADD64_IMM, 1, 0, 0, 5)])
+        Ok(vec![insn(0, ebpf::ADD64_IMM, 1, 0, 0, 5)])
     );
 }
 
 // Example for InstructionType::AluUnary.
 #[test]
 fn test_neg64() {
-    assert_eq!(asm("neg64 r1"), Ok(vec![insn(ebpf::NEG64, 1, 0, 0, 0)]));
+    assert_eq!(asm("neg64 r1"), Ok(vec![insn(0, ebpf::NEG64, 1, 0, 0, 0)]));
 }
 
 // Example for InstructionType::LoadReg.
@@ -60,7 +67,7 @@ fn test_neg64() {
 fn test_ldxw() {
     assert_eq!(
         asm("ldxw r1, [r2+5]"),
-        Ok(vec![insn(ebpf::LD_W_REG, 1, 2, 5, 0)])
+        Ok(vec![insn(0, ebpf::LD_W_REG, 1, 2, 5, 0)])
     );
 }
 
@@ -69,7 +76,7 @@ fn test_ldxw() {
 fn test_stw() {
     assert_eq!(
         asm("stw [r2+5], 7"),
-        Ok(vec![insn(ebpf::ST_W_IMM, 2, 0, 5, 7)])
+        Ok(vec![insn(0, ebpf::ST_W_IMM, 2, 0, 5, 7)])
     );
 }
 
@@ -78,15 +85,15 @@ fn test_stw() {
 fn test_stxw() {
     assert_eq!(
         asm("stxw [r2+5], r8"),
-        Ok(vec![insn(ebpf::ST_W_REG, 2, 8, 5, 0)])
+        Ok(vec![insn(0, ebpf::ST_W_REG, 2, 8, 5, 0)])
     );
 }
 
 // Example for InstructionType::JumpUnconditional.
 #[test]
 fn test_ja() {
-    assert_eq!(asm("ja +8"), Ok(vec![insn(ebpf::JA, 0, 0, 8, 0)]));
-    assert_eq!(asm("ja -3"), Ok(vec![insn(ebpf::JA, 0, 0, -3, 0)]));
+    assert_eq!(asm("ja +8"), Ok(vec![insn(0, ebpf::JA, 0, 0, 8, 0)]));
+    assert_eq!(asm("ja -3"), Ok(vec![insn(0, ebpf::JA, 0, 0, -3, 0)]));
 }
 
 // Example for InstructionType::JumpConditional.
@@ -94,17 +101,20 @@ fn test_ja() {
 fn test_jeq() {
     assert_eq!(
         asm("jeq r1, 4, +8"),
-        Ok(vec![insn(ebpf::JEQ_IMM, 1, 0, 8, 4)])
+        Ok(vec![insn(0, ebpf::JEQ_IMM, 1, 0, 8, 4)])
     );
     assert_eq!(
         asm("jeq r1, r3, +8"),
-        Ok(vec![insn(ebpf::JEQ_REG, 1, 3, 8, 0)])
+        Ok(vec![insn(0, ebpf::JEQ_REG, 1, 3, 8, 0)])
     );
 }
 
 #[test]
 fn test_call_reg() {
-    assert_eq!(asm("callx 3"), Ok(vec![insn(ebpf::CALL_REG, 0, 0, 0, 3)]));
+    assert_eq!(
+        asm("callx 3"),
+        Ok(vec![insn(0, ebpf::CALL_REG, 0, 0, 0, 3)])
+    );
 }
 
 // Example for InstructionType::Call.
@@ -112,14 +122,14 @@ fn test_call_reg() {
 fn test_call_imm() {
     assert_eq!(
         asm("call 300"),
-        Ok(vec![insn(ebpf::CALL_IMM, 0, 0, 0, 300)])
+        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 0, 0, 300)])
     );
 }
 
 // Example for InstructionType::Endian.
 #[test]
 fn test_be32() {
-    assert_eq!(asm("be32 r1"), Ok(vec![insn(ebpf::BE, 1, 0, 0, 32)]));
+    assert_eq!(asm("be32 r1"), Ok(vec![insn(0, ebpf::BE, 1, 0, 0, 32)]));
 }
 
 // Example for InstructionType::LoadImm.
@@ -128,15 +138,15 @@ fn test_lddw() {
     assert_eq!(
         asm("lddw r1, 0x1234abcd5678eeff"),
         Ok(vec![
-            insn(ebpf::LD_DW_IMM, 1, 0, 0, 0x5678eeff),
-            insn(0, 0, 0, 0, 0x1234abcd)
+            insn(0, ebpf::LD_DW_IMM, 1, 0, 0, 0x5678eeff),
+            insn(1, 0, 0, 0, 0, 0x1234abcd)
         ])
     );
     assert_eq!(
         asm("lddw r1, 0xff11ee22dd33cc44"),
         Ok(vec![
-            insn(ebpf::LD_DW_IMM, 1, 0, 0, 0xffffffffdd33cc44u64 as i64),
-            insn(0, 0, 0, 0, 0xffffffffff11ee22u64 as i64)
+            insn(0, ebpf::LD_DW_IMM, 1, 0, 0, 0xffffffffdd33cc44u64 as i64),
+            insn(1, 0, 0, 0, 0, 0xffffffffff11ee22u64 as i64)
         ])
     );
 }
@@ -144,7 +154,10 @@ fn test_lddw() {
 // Example for InstructionType::LoadAbs.
 #[test]
 fn test_ldabsw() {
-    assert_eq!(asm("ldabsw 1"), Ok(vec![insn(ebpf::LD_ABS_W, 0, 0, 0, 1)]));
+    assert_eq!(
+        asm("ldabsw 1"),
+        Ok(vec![insn(0, ebpf::LD_ABS_W, 0, 0, 0, 1)])
+    );
 }
 
 // Example for InstructionType::LoadInd.
@@ -152,7 +165,7 @@ fn test_ldabsw() {
 fn test_ldindw() {
     assert_eq!(
         asm("ldindw r1, 2"),
-        Ok(vec![insn(ebpf::LD_IND_W, 0, 1, 0, 2)])
+        Ok(vec![insn(0, ebpf::LD_IND_W, 0, 1, 0, 2)])
     );
 }
 
@@ -161,7 +174,7 @@ fn test_ldindw() {
 fn test_ldxdw() {
     assert_eq!(
         asm("ldxdw r1, [r2+3]"),
-        Ok(vec![insn(ebpf::LD_DW_REG, 1, 2, 3, 0)])
+        Ok(vec![insn(0, ebpf::LD_DW_REG, 1, 2, 3, 0)])
     );
 }
 
@@ -170,7 +183,7 @@ fn test_ldxdw() {
 fn test_sth() {
     assert_eq!(
         asm("sth [r1+2], 3"),
-        Ok(vec![insn(ebpf::ST_H_IMM, 1, 0, 2, 3)])
+        Ok(vec![insn(0, ebpf::ST_H_IMM, 1, 0, 2, 3)])
     );
 }
 
@@ -179,7 +192,7 @@ fn test_sth() {
 fn test_stxh() {
     assert_eq!(
         asm("stxh [r1+2], r3"),
-        Ok(vec![insn(ebpf::ST_H_REG, 1, 3, 2, 0)])
+        Ok(vec![insn(0, ebpf::ST_H_REG, 1, 3, 2, 0)])
     );
 }
 
@@ -188,175 +201,175 @@ fn test_stxh() {
 fn test_alu_binary() {
     assert_eq!(
         asm("add r1, r2
-                    sub r1, r2
-                    mul r1, r2
-                    div r1, r2
-                    or r1, r2
-                    and r1, r2
-                    lsh r1, r2
-                    rsh r1, r2
-                    mod r1, r2
-                    xor r1, r2
-                    mov r1, r2
-                    arsh r1, r2"),
+             sub r1, r2
+             mul r1, r2
+             div r1, r2
+             or r1, r2
+             and r1, r2
+             lsh r1, r2
+             rsh r1, r2
+             mod r1, r2
+             xor r1, r2
+             mov r1, r2
+             arsh r1, r2"),
         Ok(vec![
-            insn(ebpf::ADD64_REG, 1, 2, 0, 0),
-            insn(ebpf::SUB64_REG, 1, 2, 0, 0),
-            insn(ebpf::MUL64_REG, 1, 2, 0, 0),
-            insn(ebpf::DIV64_REG, 1, 2, 0, 0),
-            insn(ebpf::OR64_REG, 1, 2, 0, 0),
-            insn(ebpf::AND64_REG, 1, 2, 0, 0),
-            insn(ebpf::LSH64_REG, 1, 2, 0, 0),
-            insn(ebpf::RSH64_REG, 1, 2, 0, 0),
-            insn(ebpf::MOD64_REG, 1, 2, 0, 0),
-            insn(ebpf::XOR64_REG, 1, 2, 0, 0),
-            insn(ebpf::MOV64_REG, 1, 2, 0, 0),
-            insn(ebpf::ARSH64_REG, 1, 2, 0, 0)
+            insn(0, ebpf::ADD64_REG, 1, 2, 0, 0),
+            insn(1, ebpf::SUB64_REG, 1, 2, 0, 0),
+            insn(2, ebpf::MUL64_REG, 1, 2, 0, 0),
+            insn(3, ebpf::DIV64_REG, 1, 2, 0, 0),
+            insn(4, ebpf::OR64_REG, 1, 2, 0, 0),
+            insn(5, ebpf::AND64_REG, 1, 2, 0, 0),
+            insn(6, ebpf::LSH64_REG, 1, 2, 0, 0),
+            insn(7, ebpf::RSH64_REG, 1, 2, 0, 0),
+            insn(8, ebpf::MOD64_REG, 1, 2, 0, 0),
+            insn(9, ebpf::XOR64_REG, 1, 2, 0, 0),
+            insn(10, ebpf::MOV64_REG, 1, 2, 0, 0),
+            insn(11, ebpf::ARSH64_REG, 1, 2, 0, 0)
         ])
     );
 
     assert_eq!(
         asm("add r1, 2
-                    sub r1, 2
-                    mul r1, 2
-                    div r1, 2
-                    or r1, 2
-                    and r1, 2
-                    lsh r1, 2
-                    rsh r1, 2
-                    mod r1, 2
-                    xor r1, 2
-                    mov r1, 2
-                    arsh r1, 2"),
+             sub r1, 2
+             mul r1, 2
+             div r1, 2
+             or r1, 2
+             and r1, 2
+             lsh r1, 2
+             rsh r1, 2
+             mod r1, 2
+             xor r1, 2
+             mov r1, 2
+             arsh r1, 2"),
         Ok(vec![
-            insn(ebpf::ADD64_IMM, 1, 0, 0, 2),
-            insn(ebpf::SUB64_IMM, 1, 0, 0, 2),
-            insn(ebpf::MUL64_IMM, 1, 0, 0, 2),
-            insn(ebpf::DIV64_IMM, 1, 0, 0, 2),
-            insn(ebpf::OR64_IMM, 1, 0, 0, 2),
-            insn(ebpf::AND64_IMM, 1, 0, 0, 2),
-            insn(ebpf::LSH64_IMM, 1, 0, 0, 2),
-            insn(ebpf::RSH64_IMM, 1, 0, 0, 2),
-            insn(ebpf::MOD64_IMM, 1, 0, 0, 2),
-            insn(ebpf::XOR64_IMM, 1, 0, 0, 2),
-            insn(ebpf::MOV64_IMM, 1, 0, 0, 2),
-            insn(ebpf::ARSH64_IMM, 1, 0, 0, 2)
+            insn(0, ebpf::ADD64_IMM, 1, 0, 0, 2),
+            insn(1, ebpf::SUB64_IMM, 1, 0, 0, 2),
+            insn(2, ebpf::MUL64_IMM, 1, 0, 0, 2),
+            insn(3, ebpf::DIV64_IMM, 1, 0, 0, 2),
+            insn(4, ebpf::OR64_IMM, 1, 0, 0, 2),
+            insn(5, ebpf::AND64_IMM, 1, 0, 0, 2),
+            insn(6, ebpf::LSH64_IMM, 1, 0, 0, 2),
+            insn(7, ebpf::RSH64_IMM, 1, 0, 0, 2),
+            insn(8, ebpf::MOD64_IMM, 1, 0, 0, 2),
+            insn(9, ebpf::XOR64_IMM, 1, 0, 0, 2),
+            insn(10, ebpf::MOV64_IMM, 1, 0, 0, 2),
+            insn(11, ebpf::ARSH64_IMM, 1, 0, 0, 2)
         ])
     );
 
     assert_eq!(
         asm("add64 r1, r2
-                    sub64 r1, r2
-                    mul64 r1, r2
-                    div64 r1, r2
-                    or64 r1, r2
-                    and64 r1, r2
-                    lsh64 r1, r2
-                    rsh64 r1, r2
-                    mod64 r1, r2
-                    xor64 r1, r2
-                    mov64 r1, r2
-                    arsh64 r1, r2"),
+             sub64 r1, r2
+             mul64 r1, r2
+             div64 r1, r2
+             or64 r1, r2
+             and64 r1, r2
+             lsh64 r1, r2
+             rsh64 r1, r2
+             mod64 r1, r2
+             xor64 r1, r2
+             mov64 r1, r2
+             arsh64 r1, r2"),
         Ok(vec![
-            insn(ebpf::ADD64_REG, 1, 2, 0, 0),
-            insn(ebpf::SUB64_REG, 1, 2, 0, 0),
-            insn(ebpf::MUL64_REG, 1, 2, 0, 0),
-            insn(ebpf::DIV64_REG, 1, 2, 0, 0),
-            insn(ebpf::OR64_REG, 1, 2, 0, 0),
-            insn(ebpf::AND64_REG, 1, 2, 0, 0),
-            insn(ebpf::LSH64_REG, 1, 2, 0, 0),
-            insn(ebpf::RSH64_REG, 1, 2, 0, 0),
-            insn(ebpf::MOD64_REG, 1, 2, 0, 0),
-            insn(ebpf::XOR64_REG, 1, 2, 0, 0),
-            insn(ebpf::MOV64_REG, 1, 2, 0, 0),
-            insn(ebpf::ARSH64_REG, 1, 2, 0, 0)
+            insn(0, ebpf::ADD64_REG, 1, 2, 0, 0),
+            insn(1, ebpf::SUB64_REG, 1, 2, 0, 0),
+            insn(2, ebpf::MUL64_REG, 1, 2, 0, 0),
+            insn(3, ebpf::DIV64_REG, 1, 2, 0, 0),
+            insn(4, ebpf::OR64_REG, 1, 2, 0, 0),
+            insn(5, ebpf::AND64_REG, 1, 2, 0, 0),
+            insn(6, ebpf::LSH64_REG, 1, 2, 0, 0),
+            insn(7, ebpf::RSH64_REG, 1, 2, 0, 0),
+            insn(8, ebpf::MOD64_REG, 1, 2, 0, 0),
+            insn(9, ebpf::XOR64_REG, 1, 2, 0, 0),
+            insn(10, ebpf::MOV64_REG, 1, 2, 0, 0),
+            insn(11, ebpf::ARSH64_REG, 1, 2, 0, 0)
         ])
     );
 
     assert_eq!(
         asm("add64 r1, 2
-                    sub64 r1, 2
-                    mul64 r1, 2
-                    div64 r1, 2
-                    or64 r1, 2
-                    and64 r1, 2
-                    lsh64 r1, 2
-                    rsh64 r1, 2
-                    mod64 r1, 2
-                    xor64 r1, 2
-                    mov64 r1, 2
-                    arsh64 r1, 2"),
+             sub64 r1, 2
+             mul64 r1, 2
+             div64 r1, 2
+             or64 r1, 2
+             and64 r1, 2
+             lsh64 r1, 2
+             rsh64 r1, 2
+             mod64 r1, 2
+             xor64 r1, 2
+             mov64 r1, 2
+             arsh64 r1, 2"),
         Ok(vec![
-            insn(ebpf::ADD64_IMM, 1, 0, 0, 2),
-            insn(ebpf::SUB64_IMM, 1, 0, 0, 2),
-            insn(ebpf::MUL64_IMM, 1, 0, 0, 2),
-            insn(ebpf::DIV64_IMM, 1, 0, 0, 2),
-            insn(ebpf::OR64_IMM, 1, 0, 0, 2),
-            insn(ebpf::AND64_IMM, 1, 0, 0, 2),
-            insn(ebpf::LSH64_IMM, 1, 0, 0, 2),
-            insn(ebpf::RSH64_IMM, 1, 0, 0, 2),
-            insn(ebpf::MOD64_IMM, 1, 0, 0, 2),
-            insn(ebpf::XOR64_IMM, 1, 0, 0, 2),
-            insn(ebpf::MOV64_IMM, 1, 0, 0, 2),
-            insn(ebpf::ARSH64_IMM, 1, 0, 0, 2)
+            insn(0, ebpf::ADD64_IMM, 1, 0, 0, 2),
+            insn(1, ebpf::SUB64_IMM, 1, 0, 0, 2),
+            insn(2, ebpf::MUL64_IMM, 1, 0, 0, 2),
+            insn(3, ebpf::DIV64_IMM, 1, 0, 0, 2),
+            insn(4, ebpf::OR64_IMM, 1, 0, 0, 2),
+            insn(5, ebpf::AND64_IMM, 1, 0, 0, 2),
+            insn(6, ebpf::LSH64_IMM, 1, 0, 0, 2),
+            insn(7, ebpf::RSH64_IMM, 1, 0, 0, 2),
+            insn(8, ebpf::MOD64_IMM, 1, 0, 0, 2),
+            insn(9, ebpf::XOR64_IMM, 1, 0, 0, 2),
+            insn(10, ebpf::MOV64_IMM, 1, 0, 0, 2),
+            insn(11, ebpf::ARSH64_IMM, 1, 0, 0, 2)
         ])
     );
 
     assert_eq!(
         asm("add32 r1, r2
-                    sub32 r1, r2
-                    mul32 r1, r2
-                    div32 r1, r2
-                    or32 r1, r2
-                    and32 r1, r2
-                    lsh32 r1, r2
-                    rsh32 r1, r2
-                    mod32 r1, r2
-                    xor32 r1, r2
-                    mov32 r1, r2
-                    arsh32 r1, r2"),
+             sub32 r1, r2
+             mul32 r1, r2
+             div32 r1, r2
+             or32 r1, r2
+             and32 r1, r2
+             lsh32 r1, r2
+             rsh32 r1, r2
+             mod32 r1, r2
+             xor32 r1, r2
+             mov32 r1, r2
+             arsh32 r1, r2"),
         Ok(vec![
-            insn(ebpf::ADD32_REG, 1, 2, 0, 0),
-            insn(ebpf::SUB32_REG, 1, 2, 0, 0),
-            insn(ebpf::MUL32_REG, 1, 2, 0, 0),
-            insn(ebpf::DIV32_REG, 1, 2, 0, 0),
-            insn(ebpf::OR32_REG, 1, 2, 0, 0),
-            insn(ebpf::AND32_REG, 1, 2, 0, 0),
-            insn(ebpf::LSH32_REG, 1, 2, 0, 0),
-            insn(ebpf::RSH32_REG, 1, 2, 0, 0),
-            insn(ebpf::MOD32_REG, 1, 2, 0, 0),
-            insn(ebpf::XOR32_REG, 1, 2, 0, 0),
-            insn(ebpf::MOV32_REG, 1, 2, 0, 0),
-            insn(ebpf::ARSH32_REG, 1, 2, 0, 0)
+            insn(0, ebpf::ADD32_REG, 1, 2, 0, 0),
+            insn(1, ebpf::SUB32_REG, 1, 2, 0, 0),
+            insn(2, ebpf::MUL32_REG, 1, 2, 0, 0),
+            insn(3, ebpf::DIV32_REG, 1, 2, 0, 0),
+            insn(4, ebpf::OR32_REG, 1, 2, 0, 0),
+            insn(5, ebpf::AND32_REG, 1, 2, 0, 0),
+            insn(6, ebpf::LSH32_REG, 1, 2, 0, 0),
+            insn(7, ebpf::RSH32_REG, 1, 2, 0, 0),
+            insn(8, ebpf::MOD32_REG, 1, 2, 0, 0),
+            insn(9, ebpf::XOR32_REG, 1, 2, 0, 0),
+            insn(10, ebpf::MOV32_REG, 1, 2, 0, 0),
+            insn(11, ebpf::ARSH32_REG, 1, 2, 0, 0)
         ])
     );
 
     assert_eq!(
         asm("add32 r1, 2
-                    sub32 r1, 2
-                    mul32 r1, 2
-                    div32 r1, 2
-                    or32 r1, 2
-                    and32 r1, 2
-                    lsh32 r1, 2
-                    rsh32 r1, 2
-                    mod32 r1, 2
-                    xor32 r1, 2
-                    mov32 r1, 2
-                    arsh32 r1, 2"),
+             sub32 r1, 2
+             mul32 r1, 2
+             div32 r1, 2
+             or32 r1, 2
+             and32 r1, 2
+             lsh32 r1, 2
+             rsh32 r1, 2
+             mod32 r1, 2
+             xor32 r1, 2
+             mov32 r1, 2
+             arsh32 r1, 2"),
         Ok(vec![
-            insn(ebpf::ADD32_IMM, 1, 0, 0, 2),
-            insn(ebpf::SUB32_IMM, 1, 0, 0, 2),
-            insn(ebpf::MUL32_IMM, 1, 0, 0, 2),
-            insn(ebpf::DIV32_IMM, 1, 0, 0, 2),
-            insn(ebpf::OR32_IMM, 1, 0, 0, 2),
-            insn(ebpf::AND32_IMM, 1, 0, 0, 2),
-            insn(ebpf::LSH32_IMM, 1, 0, 0, 2),
-            insn(ebpf::RSH32_IMM, 1, 0, 0, 2),
-            insn(ebpf::MOD32_IMM, 1, 0, 0, 2),
-            insn(ebpf::XOR32_IMM, 1, 0, 0, 2),
-            insn(ebpf::MOV32_IMM, 1, 0, 0, 2),
-            insn(ebpf::ARSH32_IMM, 1, 0, 0, 2)
+            insn(0, ebpf::ADD32_IMM, 1, 0, 0, 2),
+            insn(1, ebpf::SUB32_IMM, 1, 0, 0, 2),
+            insn(2, ebpf::MUL32_IMM, 1, 0, 0, 2),
+            insn(3, ebpf::DIV32_IMM, 1, 0, 0, 2),
+            insn(4, ebpf::OR32_IMM, 1, 0, 0, 2),
+            insn(5, ebpf::AND32_IMM, 1, 0, 0, 2),
+            insn(6, ebpf::LSH32_IMM, 1, 0, 0, 2),
+            insn(7, ebpf::RSH32_IMM, 1, 0, 0, 2),
+            insn(8, ebpf::MOD32_IMM, 1, 0, 0, 2),
+            insn(9, ebpf::XOR32_IMM, 1, 0, 0, 2),
+            insn(10, ebpf::MOV32_IMM, 1, 0, 0, 2),
+            insn(11, ebpf::ARSH32_IMM, 1, 0, 0, 2)
         ])
     );
 }
@@ -366,12 +379,12 @@ fn test_alu_binary() {
 fn test_alu_unary() {
     assert_eq!(
         asm("neg r1
-                    neg64 r1
-                    neg32 r1"),
+             neg64 r1
+             neg32 r1"),
         Ok(vec![
-            insn(ebpf::NEG64, 1, 0, 0, 0),
-            insn(ebpf::NEG64, 1, 0, 0, 0),
-            insn(ebpf::NEG32, 1, 0, 0, 0)
+            insn(0, ebpf::NEG64, 1, 0, 0, 0),
+            insn(1, ebpf::NEG64, 1, 0, 0, 0),
+            insn(2, ebpf::NEG32, 1, 0, 0, 0)
         ])
     );
 }
@@ -381,14 +394,14 @@ fn test_alu_unary() {
 fn test_load_abs() {
     assert_eq!(
         asm("ldabsw 1
-                    ldabsh 1
-                    ldabsb 1
-                    ldabsdw 1"),
+             ldabsh 1
+             ldabsb 1
+             ldabsdw 1"),
         Ok(vec![
-            insn(ebpf::LD_ABS_W, 0, 0, 0, 1),
-            insn(ebpf::LD_ABS_H, 0, 0, 0, 1),
-            insn(ebpf::LD_ABS_B, 0, 0, 0, 1),
-            insn(ebpf::LD_ABS_DW, 0, 0, 0, 1)
+            insn(0, ebpf::LD_ABS_W, 0, 0, 0, 1),
+            insn(1, ebpf::LD_ABS_H, 0, 0, 0, 1),
+            insn(2, ebpf::LD_ABS_B, 0, 0, 0, 1),
+            insn(3, ebpf::LD_ABS_DW, 0, 0, 0, 1)
         ])
     );
 }
@@ -398,14 +411,14 @@ fn test_load_abs() {
 fn test_load_ind() {
     assert_eq!(
         asm("ldindw r1, 2
-                    ldindh r1, 2
-                    ldindb r1, 2
-                    ldinddw r1, 2"),
+             ldindh r1, 2
+             ldindb r1, 2
+             ldinddw r1, 2"),
         Ok(vec![
-            insn(ebpf::LD_IND_W, 0, 1, 0, 2),
-            insn(ebpf::LD_IND_H, 0, 1, 0, 2),
-            insn(ebpf::LD_IND_B, 0, 1, 0, 2),
-            insn(ebpf::LD_IND_DW, 0, 1, 0, 2)
+            insn(0, ebpf::LD_IND_W, 0, 1, 0, 2),
+            insn(1, ebpf::LD_IND_H, 0, 1, 0, 2),
+            insn(2, ebpf::LD_IND_B, 0, 1, 0, 2),
+            insn(3, ebpf::LD_IND_DW, 0, 1, 0, 2)
         ])
     );
 }
@@ -415,14 +428,14 @@ fn test_load_ind() {
 fn test_load_reg() {
     assert_eq!(
         asm("ldxw r1, [r2+3]
-                    ldxh r1, [r2+3]
-                    ldxb r1, [r2+3]
-                    ldxdw r1, [r2+3]"),
+             ldxh r1, [r2+3]
+             ldxb r1, [r2+3]
+             ldxdw r1, [r2+3]"),
         Ok(vec![
-            insn(ebpf::LD_W_REG, 1, 2, 3, 0),
-            insn(ebpf::LD_H_REG, 1, 2, 3, 0),
-            insn(ebpf::LD_B_REG, 1, 2, 3, 0),
-            insn(ebpf::LD_DW_REG, 1, 2, 3, 0)
+            insn(0, ebpf::LD_W_REG, 1, 2, 3, 0),
+            insn(1, ebpf::LD_H_REG, 1, 2, 3, 0),
+            insn(2, ebpf::LD_B_REG, 1, 2, 3, 0),
+            insn(3, ebpf::LD_DW_REG, 1, 2, 3, 0)
         ])
     );
 }
@@ -432,14 +445,14 @@ fn test_load_reg() {
 fn test_store_imm() {
     assert_eq!(
         asm("stw [r1+2], 3
-                    sth [r1+2], 3
-                    stb [r1+2], 3
-                    stdw [r1+2], 3"),
+             sth [r1+2], 3
+             stb [r1+2], 3
+             stdw [r1+2], 3"),
         Ok(vec![
-            insn(ebpf::ST_W_IMM, 1, 0, 2, 3),
-            insn(ebpf::ST_H_IMM, 1, 0, 2, 3),
-            insn(ebpf::ST_B_IMM, 1, 0, 2, 3),
-            insn(ebpf::ST_DW_IMM, 1, 0, 2, 3)
+            insn(0, ebpf::ST_W_IMM, 1, 0, 2, 3),
+            insn(1, ebpf::ST_H_IMM, 1, 0, 2, 3),
+            insn(2, ebpf::ST_B_IMM, 1, 0, 2, 3),
+            insn(3, ebpf::ST_DW_IMM, 1, 0, 2, 3)
         ])
     );
 }
@@ -449,14 +462,14 @@ fn test_store_imm() {
 fn test_store_reg() {
     assert_eq!(
         asm("stxw [r1+2], r3
-                    stxh [r1+2], r3
-                    stxb [r1+2], r3
-                    stxdw [r1+2], r3"),
+             stxh [r1+2], r3
+             stxb [r1+2], r3
+             stxdw [r1+2], r3"),
         Ok(vec![
-            insn(ebpf::ST_W_REG, 1, 3, 2, 0),
-            insn(ebpf::ST_H_REG, 1, 3, 2, 0),
-            insn(ebpf::ST_B_REG, 1, 3, 2, 0),
-            insn(ebpf::ST_DW_REG, 1, 3, 2, 0)
+            insn(0, ebpf::ST_W_REG, 1, 3, 2, 0),
+            insn(1, ebpf::ST_H_REG, 1, 3, 2, 0),
+            insn(2, ebpf::ST_B_REG, 1, 3, 2, 0),
+            insn(3, ebpf::ST_DW_REG, 1, 3, 2, 0)
         ])
     );
 }
@@ -466,55 +479,55 @@ fn test_store_reg() {
 fn test_jump_conditional() {
     assert_eq!(
         asm("jeq r1, r2, +3
-                    jgt r1, r2, +3
-                    jge r1, r2, +3
-                    jlt r1, r2, +3
-                    jle r1, r2, +3
-                    jset r1, r2, +3
-                    jne r1, r2, +3
-                    jsgt r1, r2, +3
-                    jsge r1, r2, +3
-                    jslt r1, r2, +3
-                    jsle r1, r2, +3"),
+             jgt r1, r2, +3
+             jge r1, r2, +3
+             jlt r1, r2, +3
+             jle r1, r2, +3
+             jset r1, r2, +3
+             jne r1, r2, +3
+             jsgt r1, r2, +3
+             jsge r1, r2, +3
+             jslt r1, r2, +3
+             jsle r1, r2, +3"),
         Ok(vec![
-            insn(ebpf::JEQ_REG, 1, 2, 3, 0),
-            insn(ebpf::JGT_REG, 1, 2, 3, 0),
-            insn(ebpf::JGE_REG, 1, 2, 3, 0),
-            insn(ebpf::JLT_REG, 1, 2, 3, 0),
-            insn(ebpf::JLE_REG, 1, 2, 3, 0),
-            insn(ebpf::JSET_REG, 1, 2, 3, 0),
-            insn(ebpf::JNE_REG, 1, 2, 3, 0),
-            insn(ebpf::JSGT_REG, 1, 2, 3, 0),
-            insn(ebpf::JSGE_REG, 1, 2, 3, 0),
-            insn(ebpf::JSLT_REG, 1, 2, 3, 0),
-            insn(ebpf::JSLE_REG, 1, 2, 3, 0)
+            insn(0, ebpf::JEQ_REG, 1, 2, 3, 0),
+            insn(1, ebpf::JGT_REG, 1, 2, 3, 0),
+            insn(2, ebpf::JGE_REG, 1, 2, 3, 0),
+            insn(3, ebpf::JLT_REG, 1, 2, 3, 0),
+            insn(4, ebpf::JLE_REG, 1, 2, 3, 0),
+            insn(5, ebpf::JSET_REG, 1, 2, 3, 0),
+            insn(6, ebpf::JNE_REG, 1, 2, 3, 0),
+            insn(7, ebpf::JSGT_REG, 1, 2, 3, 0),
+            insn(8, ebpf::JSGE_REG, 1, 2, 3, 0),
+            insn(9, ebpf::JSLT_REG, 1, 2, 3, 0),
+            insn(10, ebpf::JSLE_REG, 1, 2, 3, 0)
         ])
     );
 
     assert_eq!(
         asm("jeq r1, 2, +3
-                    jgt r1, 2, +3
-                    jge r1, 2, +3
-                    jlt r1, 2, +3
-                    jle r1, 2, +3
-                    jset r1, 2, +3
-                    jne r1, 2, +3
-                    jsgt r1, 2, +3
-                    jsge r1, 2, +3
-                    jslt r1, 2, +3
-                    jsle r1, 2, +3"),
+             jgt r1, 2, +3
+             jge r1, 2, +3
+             jlt r1, 2, +3
+             jle r1, 2, +3
+             jset r1, 2, +3
+             jne r1, 2, +3
+             jsgt r1, 2, +3
+             jsge r1, 2, +3
+             jslt r1, 2, +3
+             jsle r1, 2, +3"),
         Ok(vec![
-            insn(ebpf::JEQ_IMM, 1, 0, 3, 2),
-            insn(ebpf::JGT_IMM, 1, 0, 3, 2),
-            insn(ebpf::JGE_IMM, 1, 0, 3, 2),
-            insn(ebpf::JLT_IMM, 1, 0, 3, 2),
-            insn(ebpf::JLE_IMM, 1, 0, 3, 2),
-            insn(ebpf::JSET_IMM, 1, 0, 3, 2),
-            insn(ebpf::JNE_IMM, 1, 0, 3, 2),
-            insn(ebpf::JSGT_IMM, 1, 0, 3, 2),
-            insn(ebpf::JSGE_IMM, 1, 0, 3, 2),
-            insn(ebpf::JSLT_IMM, 1, 0, 3, 2),
-            insn(ebpf::JSLE_IMM, 1, 0, 3, 2)
+            insn(0, ebpf::JEQ_IMM, 1, 0, 3, 2),
+            insn(1, ebpf::JGT_IMM, 1, 0, 3, 2),
+            insn(2, ebpf::JGE_IMM, 1, 0, 3, 2),
+            insn(3, ebpf::JLT_IMM, 1, 0, 3, 2),
+            insn(4, ebpf::JLE_IMM, 1, 0, 3, 2),
+            insn(5, ebpf::JSET_IMM, 1, 0, 3, 2),
+            insn(6, ebpf::JNE_IMM, 1, 0, 3, 2),
+            insn(7, ebpf::JSGT_IMM, 1, 0, 3, 2),
+            insn(8, ebpf::JSGE_IMM, 1, 0, 3, 2),
+            insn(9, ebpf::JSLT_IMM, 1, 0, 3, 2),
+            insn(10, ebpf::JSLE_IMM, 1, 0, 3, 2)
         ])
     );
 }
@@ -524,18 +537,18 @@ fn test_jump_conditional() {
 fn test_endian() {
     assert_eq!(
         asm("be16 r1
-                    be32 r1
-                    be64 r1
-                    le16 r1
-                    le32 r1
-                    le64 r1"),
+             be32 r1
+             be64 r1
+             le16 r1
+             le32 r1
+             le64 r1"),
         Ok(vec![
-            insn(ebpf::BE, 1, 0, 0, 16),
-            insn(ebpf::BE, 1, 0, 0, 32),
-            insn(ebpf::BE, 1, 0, 0, 64),
-            insn(ebpf::LE, 1, 0, 0, 16),
-            insn(ebpf::LE, 1, 0, 0, 32),
-            insn(ebpf::LE, 1, 0, 0, 64)
+            insn(0, ebpf::BE, 1, 0, 0, 16),
+            insn(1, ebpf::BE, 1, 0, 0, 32),
+            insn(2, ebpf::BE, 1, 0, 0, 64),
+            insn(3, ebpf::LE, 1, 0, 0, 16),
+            insn(4, ebpf::LE, 1, 0, 0, 32),
+            insn(5, ebpf::LE, 1, 0, 0, 64)
         ])
     );
 }
@@ -544,11 +557,11 @@ fn test_endian() {
 fn test_large_immediate() {
     assert_eq!(
         asm("add64 r1, 2147483647"),
-        Ok(vec![insn(ebpf::ADD64_IMM, 1, 0, 0, 2147483647)])
+        Ok(vec![insn(0, ebpf::ADD64_IMM, 1, 0, 0, 2147483647)])
     );
     assert_eq!(
         asm("add64 r1, -2147483648"),
-        Ok(vec![insn(ebpf::ADD64_IMM, 1, 0, 0, -2147483648)])
+        Ok(vec![insn(0, ebpf::ADD64_IMM, 1, 0, 0, -2147483648)])
     );
 }
 

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -15,7 +15,7 @@ fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
     Ok(ebpf::to_insn_vec(&assemble(src)?))
 }
 
-fn insn(opc: u8, dst: u8, src: u8, off: i16, imm: i32) -> ebpf::Insn {
+fn insn(opc: u8, dst: u8, src: u8, off: i16, imm: i64) -> ebpf::Insn {
     ebpf::Insn {
         opc,
         dst,
@@ -135,8 +135,8 @@ fn test_lddw() {
     assert_eq!(
         asm("lddw r1, 0xff11ee22dd33cc44"),
         Ok(vec![
-            insn(ebpf::LD_DW_IMM, 1, 0, 0, 0xdd33cc44u32 as i32),
-            insn(0, 0, 0, 0, 0xff11ee22u32 as i32)
+            insn(ebpf::LD_DW_IMM, 1, 0, 0, 0xffffffffdd33cc44u64 as i64),
+            insn(0, 0, 0, 0, 0xffffffffff11ee22u64 as i64)
         ])
     );
 }


### PR DESCRIPTION
Promotes the immediate value of an instruction from `i32` to `i64`.
This way `LD_DW_IMM` can be represented by the `Insn` struct and the decoding be unified.

Also, adds the instruction pointer as an explicit field to the `Insn` struct.
