### PR TITLE
Refactoring of BPF Function Symbols in Executable

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -343,12 +343,15 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
         <dyn Executable<E, I>>::from_text_bytes(&program, verifier, config).unwrap();
     functions.insert("entrypoint");
     for label in functions {
-        executable.register_bpf_function(
-            ebpf::hash_symbol_name(label.as_bytes()),
-            *labels
-                .get(label)
-                .ok_or_else(|| format!("Label not found {}", label))?,
-        );
+        executable
+            .register_bpf_function(
+                ebpf::hash_symbol_name(label.as_bytes()),
+                *labels
+                    .get(label)
+                    .ok_or_else(|| format!("Label not found {}", label))?,
+                label,
+            )
+            .map_err(|_| format!("Label hash collision {}", label))?;
     }
     Ok(executable)
 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -232,7 +232,7 @@ pub fn disassemble_instruction<E: UserDefinedError, I: InstructionMeter>(insn: &
                 name = "call";
                 format!("{} {}", name,
                     resolve_label(analysis,
-                        *analysis
+                        analysis
                         .executable
                         .lookup_bpf_function(insn.imm as u32)
                         .unwrap()),

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -21,13 +21,7 @@ use goblin::{
     elf::{header::*, reloc::*, section_header::*, Elf},
     error::Error as GoblinError,
 };
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt::Debug,
-    mem,
-    ops::Range,
-    str,
-};
+use std::{collections::BTreeMap, fmt::Debug, mem, ops::Range, str};
 
 /// Error definitions
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -53,9 +47,9 @@ pub enum ElfError {
     /// Relative jump out of bounds
     #[error("Relative jump out of bounds at instruction #{0}")]
     RelativeJumpOutOfBounds(usize),
-    /// Relocation hash collision
-    #[error("Relocation hash collision while encoding instruction #{0}")]
-    RelocationHashCollision(usize),
+    /// Symbol hash collision
+    #[error("Symbol hash collision {0:#x}")]
+    SymbolHashCollision(u32),
     /// Incompatible ELF: wrong endianess
     #[error("Incompatible ELF: wrong endianess")]
     WrongEndianess,
@@ -187,8 +181,8 @@ pub struct EBpfElf<E: UserDefinedError, I: InstructionMeter> {
     text_section_info: SectionInfo,
     /// Read-only section info
     ro_section_infos: Vec<SectionInfo>,
-    /// Call resolution map
-    calls: HashMap<u32, usize>,
+    /// Call resolution map (pc, hash, name)
+    bpf_functions: BTreeMap<u32, (usize, String)>,
     /// Syscall resolution map
     syscall_registry: SyscallRegistry,
     /// Compiled program and argument
@@ -231,20 +225,33 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> for EBpfElf<E, I
 
     /// Get the entry point offset into the text section
     fn get_entrypoint_instruction_offset(&self) -> Result<usize, EbpfError<E>> {
-        self.calls
+        self.bpf_functions
             .get(&ebpf::hash_symbol_name(b"entrypoint"))
-            .cloned()
+            .map(|(pc, _name)| *pc)
             .ok_or(EbpfError::ElfError(ElfError::InvalidEntrypoint))
     }
 
     /// Set a symbol's instruction offset
-    fn register_bpf_function(&mut self, hash: u32, pc: usize) {
-        self.calls.insert(hash, pc);
+    fn register_bpf_function(
+        &mut self,
+        hash: u32,
+        pc: usize,
+        name: &str,
+    ) -> Result<(), EbpfError<E>> {
+        if self
+            .bpf_functions
+            .insert(hash, (pc, name.to_string()))
+            .is_none()
+        {
+            Ok(())
+        } else {
+            Err(EbpfError::ElfError(ElfError::SymbolHashCollision(hash)))
+        }
     }
 
     /// Get a symbol's instruction offset
-    fn lookup_bpf_function(&self, hash: u32) -> Option<&usize> {
-        self.calls.get(&hash)
+    fn lookup_bpf_function(&self, hash: u32) -> Option<usize> {
+        self.bpf_functions.get(&hash).map(|(pc, _name)| *pc)
     }
 
     /// Get the syscall registry
@@ -303,7 +310,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> for EBpfElf<E, I
     }
 
     /// Get syscalls and BPF functions (if debug symbols are not stripped)
-    fn get_symbols(&self) -> (BTreeMap<u32, String>, BTreeMap<usize, String>) {
+    fn get_symbols(&self) -> (BTreeMap<u32, String>, BTreeMap<usize, (u32, String)>) {
         let mut syscalls = BTreeMap::new();
         let mut bpf_functions = BTreeMap::new();
         if let Ok(elf) = Elf::parse(self.elf_bytes.as_slice()) {
@@ -315,16 +322,9 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> for EBpfElf<E, I
                 let hash = ebpf::hash_symbol_name(&name.as_bytes());
                 syscalls.insert(hash, name.to_string());
             }
-            for symbol in &elf.syms {
-                if symbol.st_info & 0xEF != 0x02 {
-                    continue;
-                }
-                let name = elf.strtab.get(symbol.st_name).unwrap().unwrap();
-                bpf_functions.insert(
-                    symbol.st_value as usize / ebpf::INSN_SIZE - ebpf::ELF_INSN_DUMP_OFFSET,
-                    name.to_string(),
-                );
-            }
+        }
+        for (hash, (pc, name)) in self.bpf_functions.iter() {
+            bpf_functions.insert(*pc, (*hash, name.clone()));
         }
         (syscalls, bpf_functions)
     }
@@ -347,7 +347,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
                 },
             },
             ro_section_infos: vec![],
-            calls: HashMap::default(),
+            bpf_functions: BTreeMap::default(),
             syscall_registry: SyscallRegistry::default(),
             compiled_program: None,
         }
@@ -361,8 +361,8 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
 
         Self::validate(&elf, &elf_bytes.as_slice())?;
 
-        let mut calls = HashMap::default();
-        Self::relocate(&elf, elf_bytes.as_slice_mut(), &mut calls)?;
+        let mut bpf_functions = BTreeMap::default();
+        Self::relocate(&elf, elf_bytes.as_slice_mut(), &mut bpf_functions)?;
 
         let text_section = Self::get_section(&elf, ".text")?;
 
@@ -372,7 +372,10 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
             return Err(ElfError::InvalidEntrypoint);
         }
         let entrypoint = offset as usize / ebpf::INSN_SIZE;
-        calls.insert(ebpf::hash_symbol_name(b"entrypoint"), entrypoint);
+        bpf_functions.insert(
+            ebpf::hash_symbol_name(b"entrypoint"),
+            (entrypoint, "entrypoint".to_string()),
+        );
 
         // calculate the text section info
         let text_section_info = SectionInfo {
@@ -419,7 +422,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
             elf_bytes,
             text_section_info,
             ro_section_infos,
-            calls,
+            bpf_functions,
             syscall_registry: SyscallRegistry::default(),
             compiled_program: None,
         })
@@ -429,12 +432,12 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
 
     /// Fix-ups relative calls
     pub fn fixup_relative_calls(
-        calls: &mut HashMap<u32, usize>,
+        bpf_functions: &mut BTreeMap<u32, (usize, String)>,
         elf_bytes: &mut [u8],
     ) -> Result<(), ElfError> {
         for i in 0..elf_bytes.len() / ebpf::INSN_SIZE {
             let mut insn = ebpf::get_insn(elf_bytes, i);
-            if insn.opc == 0x85 && insn.imm != -1 {
+            if insn.opc == ebpf::CALL_IMM && insn.imm != -1 {
                 let insn_idx = i as isize + 1 + insn.imm as isize;
                 if insn_idx < 0 || insn_idx >= (elf_bytes.len() / ebpf::INSN_SIZE) as isize {
                     return Err(ElfError::RelativeJumpOutOfBounds(
@@ -442,13 +445,14 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
                     ));
                 }
                 // use the instruction index as the key
-                let mut key = [0u8; mem::size_of::<i64>()];
+                let mut key = [0u8; mem::size_of::<u64>()];
                 LittleEndian::write_u64(&mut key, i as u64);
                 let hash = ebpf::hash_symbol_name(&key);
-                if calls.insert(hash, insn_idx as usize).is_some() {
-                    return Err(ElfError::RelocationHashCollision(
-                        i + ebpf::ELF_INSN_DUMP_OFFSET,
-                    ));
+                if bpf_functions
+                    .insert(hash, (insn_idx as usize, "".to_string()))
+                    .is_some()
+                {
+                    return Err(ElfError::SymbolHashCollision(hash));
                 }
 
                 insn.imm = hash as i64;
@@ -537,13 +541,13 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
     fn relocate(
         elf: &Elf,
         elf_bytes: &mut [u8],
-        calls: &mut HashMap<u32, usize>,
+        bpf_functions: &mut BTreeMap<u32, (usize, String)>,
     ) -> Result<(), ElfError> {
         let text_section = Self::get_section(elf, ".text")?;
 
         // Fixup all program counter relative call instructions
         Self::fixup_relative_calls(
-            calls,
+            bpf_functions,
             &mut elf_bytes
                 .get_mut(text_section.file_range())
                 .ok_or(ElfError::OutOfBounds)?,
@@ -629,9 +633,12 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EBpfElf<E, I> {
                         if !text_section.vm_range().contains(&(sym.st_value as usize)) {
                             return Err(ElfError::OutOfBounds);
                         }
-                        calls.insert(
+                        bpf_functions.insert(
                             hash,
-                            (sym.st_value - text_section.sh_addr) as usize / ebpf::INSN_SIZE,
+                            (
+                                (sym.st_value - text_section.sh_addr) as usize / ebpf::INSN_SIZE,
+                                name.to_string(),
+                            ),
                         );
                     }
                 }
@@ -664,7 +671,7 @@ mod test {
         ebpf, elf::scroll::Pwrite, fuzz::fuzz, user_error::UserError, vm::DefaultInstructionMeter,
     };
     use rand::{distributions::Uniform, Rng};
-    use std::{collections::HashMap, fs::File, io::Read};
+    use std::{fs::File, io::Read};
     type ElfExecutable = EBpfElf<UserError, DefaultInstructionMeter>;
 
     #[test]
@@ -777,7 +784,7 @@ mod test {
     #[test]
     fn test_fixup_relative_calls_back() {
         // call -2
-        let mut calls: HashMap<u32, usize> = HashMap::new();
+        let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
         #[rustfmt::skip]
         let mut prog = vec![
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -787,7 +794,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x85, 0x10, 0x00, 0x00, 0xfe, 0xff, 0xff, 0xff];
 
-        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut bpf_functions, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[5, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -797,12 +804,12 @@ mod test {
             ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[40..]);
-        assert_eq!(*calls.get(&key).unwrap(), 4);
+        assert_eq!(*bpf_functions.get(&key).unwrap(), (4, "".to_string()));
 
         // // call +6
-        let mut calls: HashMap<u32, usize> = HashMap::new();
+        let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
         prog.splice(44.., vec![0xfa, 0xff, 0xff, 0xff]);
-        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut bpf_functions, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[5, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -812,13 +819,13 @@ mod test {
             ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[40..]);
-        assert_eq!(*calls.get(&key).unwrap(), 0);
+        assert_eq!(*bpf_functions.get(&key).unwrap(), (0, "".to_string()));
     }
 
     #[test]
     fn test_fixup_relative_calls_forward() {
         // call +0
-        let mut calls: HashMap<u32, usize> = HashMap::new();
+        let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
         #[rustfmt::skip]
         let mut prog = vec![
             0x85, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -828,7 +835,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
-        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut bpf_functions, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[0, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -838,12 +845,12 @@ mod test {
             ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[..8]);
-        assert_eq!(*calls.get(&key).unwrap(), 1);
+        assert_eq!(*bpf_functions.get(&key).unwrap(), (1, "".to_string()));
 
         // call +4
-        let mut calls: HashMap<u32, usize> = HashMap::new();
+        let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
         prog.splice(4..8, vec![0x04, 0x00, 0x00, 0x00]);
-        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut bpf_functions, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[0, 0, 0, 0, 0, 0, 0, 0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -853,7 +860,7 @@ mod test {
             ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[..8]);
-        assert_eq!(*calls.get(&key).unwrap(), 5);
+        assert_eq!(*bpf_functions.get(&key).unwrap(), (5, "".to_string()));
     }
 
     #[test]
@@ -861,7 +868,7 @@ mod test {
         expected = "called `Result::unwrap()` on an `Err` value: RelativeJumpOutOfBounds(29)"
     )]
     fn test_fixup_relative_calls_out_of_bounds_forward() {
-        let mut calls: HashMap<u32, usize> = HashMap::new();
+        let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
         // call +5
         #[rustfmt::skip]
         let mut prog = vec![
@@ -872,7 +879,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
-        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut bpf_functions, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[0]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -882,7 +889,7 @@ mod test {
             ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[..8]);
-        assert_eq!(*calls.get(&key).unwrap(), 1);
+        assert_eq!(*bpf_functions.get(&key).unwrap(), (1, "".to_string()));
     }
 
     #[test]
@@ -890,7 +897,7 @@ mod test {
         expected = "called `Result::unwrap()` on an `Err` value: RelativeJumpOutOfBounds(34)"
     )]
     fn test_fixup_relative_calls_out_of_bounds_back() {
-        let mut calls: HashMap<u32, usize> = HashMap::new();
+        let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
         // call -7
         #[rustfmt::skip]
         let mut prog = vec![
@@ -901,7 +908,7 @@ mod test {
             0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x85, 0x10, 0x00, 0x00, 0xf9, 0xff, 0xff, 0xff];
 
-        ElfExecutable::fixup_relative_calls(&mut calls, &mut prog).unwrap();
+        ElfExecutable::fixup_relative_calls(&mut bpf_functions, &mut prog).unwrap();
         let key = ebpf::hash_symbol_name(&[5]);
         let insn = ebpf::Insn {
             opc: 0x85,
@@ -911,7 +918,7 @@ mod test {
             ..ebpf::Insn::default()
         };
         assert_eq!(insn.to_array(), prog[40..]);
-        assert_eq!(*calls.get(&key).unwrap(), 4);
+        assert_eq!(*bpf_functions.get(&key).unwrap(), (4, "".to_string()));
     }
 
     #[test]

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1058,7 +1058,7 @@ impl JitCompiler {
                     } else {
                         match executable.lookup_bpf_function(insn.imm as u32) {
                             Some(target_pc) => {
-                                emit_bpf_call(self, Value::Constant64(*target_pc as i64), self.result.pc_section.len() - 1)?;
+                                emit_bpf_call(self, Value::Constant64(target_pc as i64), self.result.pc_section.len() - 1)?;
                             },
                             None => {
                                 // executable.report_unresolved_symbol(self.pc)?;

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -98,8 +98,8 @@ pub struct Analysis<'a, E: UserDefinedError, I: InstructionMeter> {
     pub instructions: Vec<ebpf::Insn>,
     /// Syscalls used by the executable (available if debug symbols are not stripped)
     pub syscalls: BTreeMap<u32, String>,
-    /// Functions in the executable (available if debug symbols are not stripped)
-    pub functions: BTreeMap<usize, String>,
+    /// Functions in the executable
+    pub functions: BTreeMap<usize, (u32, String)>,
     /// Nodes of the control-flow graph
     pub cfg_nodes: BTreeMap<usize, CfgNode>,
     /// Topological order of cfg_nodes
@@ -176,12 +176,10 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
     ///
     /// Also links the control-flow graph edges between the basic blocks.
     pub fn split_into_basic_blocks(&mut self, flatten_call_graph: bool) {
-        {
-            self.functions
-                .entry(self.entrypoint)
-                .or_insert_with(|| "entrypoint".to_string());
-            for pc in self.functions.keys() {
-                self.cfg_nodes.entry(*pc).or_insert_with(CfgNode::default);
+        for (pc, (_hash, name)) in self.functions.iter_mut() {
+            self.cfg_nodes.entry(*pc).or_insert_with(CfgNode::default);
+            if name.is_empty() {
+                *name = format!("function_{}", *pc);
             }
         }
         let mut cfg_edges = BTreeMap::new();
@@ -199,21 +197,18 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
                     } else if let Some(target_pc) =
                         self.executable.lookup_bpf_function(insn.imm as u32)
                     {
-                        self.functions
-                            .entry(*target_pc)
-                            .or_insert(format!("function_{}", *target_pc));
                         self.cfg_nodes
                             .entry(insn.ptr + 1)
                             .or_insert_with(CfgNode::default);
                         self.cfg_nodes
-                            .entry(*target_pc)
+                            .entry(target_pc)
                             .or_insert_with(CfgNode::default);
                         cfg_edges.insert(
                             insn.ptr,
                             (
                                 insn.opc,
                                 if flatten_call_graph {
-                                    vec![insn.ptr + 1, *target_pc]
+                                    vec![insn.ptr + 1, target_pc]
                                 } else {
                                     vec![insn.ptr + 1]
                                 },
@@ -301,9 +296,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
             std::mem::swap(&mut self.functions, &mut functions);
             let mut functions = functions
                 .into_iter()
-                .filter(|(function_start, _function_body)| {
-                    self.cfg_nodes.contains_key(function_start)
-                })
+                .filter(|(function_start, _)| self.cfg_nodes.contains_key(function_start))
                 .collect();
             std::mem::swap(&mut self.functions, &mut functions);
         }
@@ -375,8 +368,8 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
     /// Gives the basic blocks names
     pub fn label_basic_blocks(&mut self) {
         for (pc, cfg_node) in self.cfg_nodes.iter_mut() {
-            cfg_node.label = if let Some(name) = self.functions.get(&pc) {
-                demangle(&name).to_string()
+            cfg_node.label = if let Some(function) = self.functions.get(&pc) {
+                demangle(&function.1).to_string()
             } else {
                 format!("lbb_{}", pc)
             };
@@ -507,7 +500,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
         )?;
         const MAX_CELL_CONTENT_LENGTH: usize = 15;
         let mut function_iter = self.functions.iter().peekable();
-        while let Some((function_start, name)) = function_iter.next() {
+        while let Some((function_start, (_hash, name))) = function_iter.next() {
             let function_end = if let Some(next_function) = function_iter.peek() {
                 *next_function.0
             } else {

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -176,11 +176,8 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
     ///
     /// Also links the control-flow graph edges between the basic blocks.
     pub fn split_into_basic_blocks(&mut self, flatten_call_graph: bool) {
-        for (pc, (_hash, name)) in self.functions.iter_mut() {
+        for pc in self.functions.keys() {
             self.cfg_nodes.entry(*pc).or_insert_with(CfgNode::default);
-            if name.is_empty() {
-                *name = format!("function_{}", *pc);
-            }
         }
         let mut cfg_edges = BTreeMap::new();
         for insn in self.instructions.iter() {

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2410,7 +2410,9 @@ fn test_err_call_lddw() {
             config,
         )
         .unwrap();
-        executable.register_bpf_function(2, 2);
+        executable
+            .register_bpf_function(2, 2, "in_the_middle_of_lddw")
+            .unwrap();
         test_interpreter_and_jit!(
             executable,
             [],
@@ -3255,7 +3257,9 @@ fn test_large_program() {
             config,
         )
         .unwrap();
-        executable.register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0);
+        executable
+            .register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint")
+            .unwrap();
         test_interpreter_and_jit!(
             executable,
             [],
@@ -3302,7 +3306,9 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     } else {
         return false;
     };
-    executable.register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0);
+    executable
+        .register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint")
+        .unwrap();
     executable.set_syscall_registry(SyscallRegistry::default());
     if executable.jit_compile().is_err() {
         return false;


### PR DESCRIPTION
* Unifies get_symbols() and .calls in Executable.
* Preserves the name of bpf_functions so that assembler / disassembler can go full cycle.
* Less function aliasing by matching the dst PC instead of the src PC of relative calls.
* Let relative call resolution also label the functions.
