### PR TITLE
Fix and Refactor BPF function symbol hashing

### DIFF
--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -10,6 +10,7 @@ use solana_rbpf::{
     user_error::UserError,
     vm::{Config, DefaultInstructionMeter, Executable},
 };
+use std::collections::BTreeMap;
 
 // Simply disassemble a program into human-readable instructions.
 fn main() {
@@ -31,6 +32,7 @@ fn main() {
     ];
     let executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         &program,
+        BTreeMap::new(),
         None,
         Config::default(),
     )

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -17,6 +17,7 @@ use solana_rbpf::{
     user_error::UserError,
     vm::{Config, DefaultInstructionMeter, Executable},
 };
+use std::collections::BTreeMap;
 // Turn a program into a JSON string.
 //
 // Relies on `json` crate.
@@ -29,6 +30,7 @@ use solana_rbpf::{
 fn to_json(program: &[u8]) -> String {
     let executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         &program,
+        BTreeMap::new(),
         None,
         Config::default(),
     )

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -10,6 +10,7 @@ use solana_rbpf::{
     user_error::UserError,
     vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject, SyscallRegistry},
 };
+use std::collections::BTreeMap;
 
 // The main objectives of this example is to show:
 //
@@ -44,6 +45,7 @@ fn main() {
     // Create a VM: this one takes no data. Load prog1 in it.
     let executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         prog1,
+        BTreeMap::new(),
         None,
         Config::default(),
     )
@@ -67,6 +69,7 @@ fn main() {
 
     let mut executable = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         prog2,
+        BTreeMap::new(),
         None,
         Config::default(),
     )

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -17,11 +17,11 @@ use crate::{
         Statement,
     },
     ebpf::{self, Insn},
+    elf::register_bpf_function,
     error::UserDefinedError,
     vm::{Config, Executable, InstructionMeter, Verifier},
 };
-
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum InstructionType {
@@ -173,17 +173,6 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
     })
 }
 
-fn resolve_label(
-    insn_ptr: usize,
-    labels: &HashMap<&str, usize>,
-    label: &str,
-) -> Result<i64, String> {
-    labels
-        .get(label)
-        .map(|target_pc| *target_pc as i64 - insn_ptr as i64 - 1)
-        .ok_or_else(|| format!("Label not found {}", label))
-}
-
 /// Parse assembly source and translate to binary.
 ///
 /// # Examples
@@ -226,6 +215,35 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     verifier: Option<Verifier<E>>,
     config: Config,
 ) -> Result<Box<dyn Executable<E, I>>, String> {
+    fn resolve_label(
+        insn_ptr: usize,
+        labels: &HashMap<&str, usize>,
+        label: &str,
+    ) -> Result<i64, String> {
+        labels
+            .get(label)
+            .map(|target_pc| *target_pc as i64 - insn_ptr as i64 - 1)
+            .ok_or_else(|| format!("Label not found {}", label))
+    }
+
+    fn resolve_call(
+        bpf_functions: &mut BTreeMap<u32, (usize, String)>,
+        labels: &HashMap<&str, usize>,
+        label: &str,
+        target_pc: Option<usize>,
+    ) -> Result<i64, String> {
+        let target_pc = if let Some(target_pc) = target_pc {
+            target_pc
+        } else {
+            *labels
+                .get(label)
+                .ok_or_else(|| format!("Label not found {}", label))?
+        };
+        let hash = register_bpf_function(bpf_functions, target_pc, label)
+            .map_err(|_| format!("Label hash collision {}", label))?;
+        Ok(hash as i32 as i64)
+    }
+
     let statements = parse(src)?;
     let instruction_map = make_instruction_map();
     let mut insn_ptr = 0;
@@ -242,7 +260,8 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
         }
     }
     insn_ptr = 0;
-    let mut functions: HashSet<&str> = HashSet::new();
+    let mut bpf_functions: BTreeMap<u32, (usize, String)> = BTreeMap::new();
+    resolve_call(&mut bpf_functions, &labels, "entrypoint", None)?;
     let mut instructions: Vec<Insn> = Vec::new();
     for statement in statements.iter() {
         if let Statement::Instruction { name, operands } = statement {
@@ -277,7 +296,13 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
                         (JumpUnconditional, [Label(label)]) => {
                             insn(opc, 0, 0, resolve_label(insn_ptr, &labels, label)?, 0)
                         }
-                        (CallImm, [Integer(imm)]) => insn(opc, 0, 0, 0, *imm),
+                        (CallImm, [Integer(imm)]) => {
+                            let target_pc = (*imm + insn_ptr as i64 + 1) as usize;
+                            let label = format!("function_{}", target_pc);
+                            let hash =
+                                resolve_call(&mut bpf_functions, &labels, &label, Some(target_pc))?;
+                            insn(opc, 0, 0, 0, hash as i32 as i64)
+                        }
                         (CallReg, [Integer(imm)]) => insn(opc, 0, 0, 0, *imm),
                         (JumpConditional, [Register(dst), Register(src), Label(label)]) => insn(
                             opc | ebpf::BPF_X,
@@ -298,17 +323,11 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
                             0,
                             0,
                             0,
-                            ebpf::hash_symbol_name(label.as_bytes()) as i64,
+                            ebpf::hash_symbol_name(label.as_bytes()) as i32 as i64,
                         ),
                         (CallImm, [Label(label)]) => {
-                            functions.insert(label);
-                            insn(
-                                opc,
-                                0,
-                                0,
-                                0,
-                                ebpf::hash_symbol_name(label.as_bytes()) as i32 as i64,
-                            )
+                            let hash = resolve_call(&mut bpf_functions, &labels, label, None)?;
+                            insn(opc, 0, 0, 0, hash as i32 as i64)
                         }
                         (Endian(size), [Register(dst)]) => insn(opc, *dst, 0, 0, size),
                         (LoadImm, [Register(dst), Integer(imm)]) => {
@@ -339,18 +358,6 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
         .map(|insn| insn.to_vec())
         .flatten()
         .collect::<Vec<_>>();
-    let mut executable =
-        <dyn Executable<E, I>>::from_text_bytes(&program, verifier, config).unwrap();
-    functions.insert("entrypoint");
-    for label in functions {
-        executable
-            .register_bpf_function(
-                *labels
-                    .get(label)
-                    .ok_or_else(|| format!("Label not found {}", label))?,
-                label,
-            )
-            .map_err(|_| format!("Label hash collision {}", label))?;
-    }
-    Ok(executable)
+    <dyn Executable<E, I>>::from_text_bytes(&program, bpf_functions, verifier, config)
+        .map_err(|err| format!("Executable constructor {:?}", err))
 }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -345,7 +345,6 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     for label in functions {
         executable
             .register_bpf_function(
-                ebpf::hash_symbol_name(label.as_bytes()),
                 *labels
                     .get(label)
                     .ok_or_else(|| format!("Label not found {}", label))?,

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -230,13 +230,13 @@ pub fn disassemble_instruction<E: UserDefinedError, I: InstructionMeter>(insn: &
                 format!("{} {}", name, syscall_name)
             } else {
                 name = "call";
-                format!("{} {}", name,
-                    resolve_label(analysis,
-                        analysis
-                        .executable
-                        .lookup_bpf_function(insn.imm as u32)
-                        .unwrap()),
-                )
+                if let Some(target_pc) = analysis
+                    .executable
+                    .lookup_bpf_function(insn.imm as u32) {
+                    format!("{} {}", name, resolve_label(analysis, target_pc))
+                } else {
+                    format!("{} [invalid]", name)
+                }
             };
         },
         ebpf::CALL_REG   => { name = "callx"; desc = format!("{} {}", name, insn.imm); },

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1064,7 +1064,7 @@ impl JitCompiler {
                                 // executable.report_unresolved_symbol(self.pc)?;
                                 // Workaround for unresolved symbols in ELF: Report error at runtime instead of compiletime
                                 let fat_ptr: DynTraitFatPointer = unsafe { std::mem::transmute(executable) };
-                                emit_rust_call(self, fat_ptr.vtable.methods[10], &[
+                                emit_rust_call(self, fat_ptr.vtable.methods[9], &[
                                     Argument { index: 0, value: Value::RegisterIndirect(RBP, -8 * (CALLEE_SAVED_REGISTERS.len() + 1) as i32) }, // Pointer to optional typed return value
                                     Argument { index: 1, value: Value::Constant64(fat_ptr.data as i64) },
                                     Argument { index: 2, value: Value::Constant64(self.pc as i64) },

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -496,16 +496,20 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
   ];"
         )?;
         const MAX_CELL_CONTENT_LENGTH: usize = 15;
-        let mut function_iter = self.functions.iter().peekable();
-        while let Some((function_start, (_hash, name))) = function_iter.next() {
+        let mut function_iter = self.functions.keys().peekable();
+        while let Some(function_start) = function_iter.next() {
             let function_end = if let Some(next_function) = function_iter.peek() {
-                *next_function.0
+                **next_function
             } else {
                 self.instructions.last().unwrap().ptr + 1
             };
             let mut alias_nodes = HashSet::new();
             writeln!(output, "  subgraph cluster_{} {{", *function_start)?;
-            writeln!(output, "    label={:?};", html_escape(name))?;
+            writeln!(
+                output,
+                "    label={:?};",
+                html_escape(&self.cfg_nodes[&function_start].label)
+            )?;
             writeln!(output, "    tooltip=lbb_{};", *function_start)?;
             emit_cfg_node(
                 output,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -204,8 +204,6 @@ pub trait Executable<E: UserDefinedError, I: InstructionMeter>: Send + Sync {
     fn get_ro_sections(&self) -> Result<Vec<(u64, &[u8])>, EbpfError<E>>;
     /// Get the entry point offset into the text section
     fn get_entrypoint_instruction_offset(&self) -> Result<usize, EbpfError<E>>;
-    /// Set a symbol's instruction offset
-    fn register_bpf_function(&mut self, pc: usize, name: &str) -> Result<u32, EbpfError<E>>;
     /// Get a symbol's instruction offset
     fn lookup_bpf_function(&self, hash: u32) -> Option<usize>;
     /// Get the syscall registry
@@ -240,13 +238,18 @@ impl<E: UserDefinedError, I: 'static + InstructionMeter> dyn Executable<E, I> {
     /// Creates a post relocaiton/fixup executable from machine code
     pub fn from_text_bytes(
         text_bytes: &[u8],
+        bpf_functions: BTreeMap<u32, (usize, String)>,
         verifier: Option<Verifier<E>>,
         config: Config,
     ) -> Result<Box<Self>, EbpfError<E>> {
         if let Some(verifier) = verifier {
             verifier(text_bytes)?;
         }
-        Ok(Box::new(EBpfElf::new_from_text_bytes(config, text_bytes)))
+        Ok(Box::new(EBpfElf::new_from_text_bytes(
+            config,
+            text_bytes,
+            bpf_functions,
+        )))
     }
 }
 
@@ -405,7 +408,7 @@ pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 6;
 /// # Examples
 ///
 /// ```
-/// use solana_rbpf::{ebpf, vm::{Config, Executable, EbpfVm, DefaultInstructionMeter}, user_error::UserError};
+/// use solana_rbpf::{ebpf, elf::register_bpf_function, vm::{Config, Executable, EbpfVm, DefaultInstructionMeter}, user_error::UserError};
 ///
 /// let prog = &[
 ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -415,8 +418,9 @@ pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 6;
 /// ];
 ///
 /// // Instantiate a VM.
-/// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-/// executable.register_bpf_function(0, "entrypoint").unwrap();
+/// let mut bpf_functions = std::collections::BTreeMap::new();
+/// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+/// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, bpf_functions, None, Config::default()).unwrap();
 /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), mem, &[]).unwrap();
 ///
 /// // Provide a reference to the packet data.
@@ -443,15 +447,16 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, vm::{Config, Executable, EbpfVm, DefaultInstructionMeter}, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::register_bpf_function, vm::{Config, Executable, EbpfVm, DefaultInstructionMeter}, user_error::UserError};
     ///
     /// let prog = &[
     ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
     /// ];
     ///
     /// // Instantiate a VM.
-    /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-    /// executable.register_bpf_function(0, "entrypoint").unwrap();
+    /// let mut bpf_functions = std::collections::BTreeMap::new();
+    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, bpf_functions, None, Config::default()).unwrap();
     /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
     /// ```
     pub fn new(
@@ -534,7 +539,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, vm::{Config, Executable, EbpfVm, SyscallObject, SyscallRegistry, DefaultInstructionMeter}, syscalls::BpfTracePrintf, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::register_bpf_function, vm::{Config, Executable, EbpfVm, SyscallObject, SyscallRegistry, DefaultInstructionMeter}, syscalls::BpfTracePrintf, user_error::UserError};
     ///
     /// // This program was compiled with clang, from a C program containing the following single
     /// // instruction: `return bpf_trace_printk("foo %c %c %c\n", 10, 1, 2, 3);`
@@ -557,8 +562,9 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let mut syscall_registry = SyscallRegistry::default();
     /// syscall_registry.register_syscall_by_hash(6, BpfTracePrintf::call).unwrap();
     /// // Instantiate an Executable and VM
-    /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-    /// executable.register_bpf_function(0, "entrypoint").unwrap();
+    /// let mut bpf_functions = std::collections::BTreeMap::new();
+    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, bpf_functions, None, Config::default()).unwrap();
     /// executable.set_syscall_registry(syscall_registry);
     /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
     /// // Bind a context object instance to the previously registered syscall
@@ -611,7 +617,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, vm::{Config, Executable, EbpfVm, DefaultInstructionMeter}, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::register_bpf_function, vm::{Config, Executable, EbpfVm, DefaultInstructionMeter}, user_error::UserError};
     ///
     /// let prog = &[
     ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -621,8 +627,9 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// ];
     ///
     /// // Instantiate a VM.
-    /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-    /// executable.register_bpf_function(0, "entrypoint").unwrap();
+    /// let mut bpf_functions = std::collections::BTreeMap::new();
+    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, bpf_functions, None, Config::default()).unwrap();
     /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), mem, &[]).unwrap();
     ///
     /// // Provide a reference to the packet data.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -205,12 +205,7 @@ pub trait Executable<E: UserDefinedError, I: InstructionMeter>: Send + Sync {
     /// Get the entry point offset into the text section
     fn get_entrypoint_instruction_offset(&self) -> Result<usize, EbpfError<E>>;
     /// Set a symbol's instruction offset
-    fn register_bpf_function(
-        &mut self,
-        hash: u32,
-        pc: usize,
-        name: &str,
-    ) -> Result<(), EbpfError<E>>;
+    fn register_bpf_function(&mut self, pc: usize, name: &str) -> Result<u32, EbpfError<E>>;
     /// Get a symbol's instruction offset
     fn lookup_bpf_function(&self, hash: u32) -> Option<usize>;
     /// Get the syscall registry
@@ -421,7 +416,7 @@ pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 6;
 ///
 /// // Instantiate a VM.
 /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-/// executable.register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint").unwrap();
+/// executable.register_bpf_function(0, "entrypoint").unwrap();
 /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), mem, &[]).unwrap();
 ///
 /// // Provide a reference to the packet data.
@@ -456,7 +451,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     ///
     /// // Instantiate a VM.
     /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-    /// executable.register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint").unwrap();
+    /// executable.register_bpf_function(0, "entrypoint").unwrap();
     /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
     /// ```
     pub fn new(
@@ -563,7 +558,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// syscall_registry.register_syscall_by_hash(6, BpfTracePrintf::call).unwrap();
     /// // Instantiate an Executable and VM
     /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-    /// executable.register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint").unwrap();
+    /// executable.register_bpf_function(0, "entrypoint").unwrap();
     /// executable.set_syscall_registry(syscall_registry);
     /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
     /// // Bind a context object instance to the previously registered syscall
@@ -627,7 +622,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     ///
     /// // Instantiate a VM.
     /// let mut executable = Executable::<UserError, DefaultInstructionMeter>::from_text_bytes(prog, None, Config::default()).unwrap();
-    /// executable.register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint").unwrap();
+    /// executable.register_bpf_function(0, "entrypoint").unwrap();
     /// let mut vm = EbpfVm::<UserError, DefaultInstructionMeter>::new(executable.as_ref(), mem, &[]).unwrap();
     ///
     /// // Provide a reference to the packet data.

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -119,7 +119,7 @@ fn test_call_reg() {
 fn test_call_imm() {
     assert_eq!(
         asm("call 300"),
-        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 0, 0, 300)])
+        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 0, 0, -1090069135)])
     );
 }
 

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -14,8 +14,8 @@ extern crate thiserror;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use solana_rbpf::{
     assembler::assemble,
-    ebpf::{self, hash_symbol_name},
-    elf::ElfError,
+    ebpf,
+    elf::{register_bpf_function, ElfError},
     error::EbpfError,
     memory_region::AccessType,
     syscalls,
@@ -23,7 +23,7 @@ use solana_rbpf::{
     verifier::check,
     vm::{Config, DefaultInstructionMeter, EbpfVm, Executable, SyscallObject, SyscallRegistry},
 };
-use std::{fs::File, io::Read};
+use std::{collections::BTreeMap, fs::File, io::Read};
 use test_utils::{
     BpfSyscallString, BpfSyscallU64, BpfTracePrintf, Result, SyscallWithContext,
     TestInstructionMeter, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
@@ -31,7 +31,7 @@ use test_utils::{
 
 macro_rules! test_interpreter_and_jit {
     (register, $executable:expr, $syscall_registry:expr, $location:expr => $syscall_function:expr; $syscall_context_object:expr) => {
-        $syscall_registry.register_syscall_by_hash::<UserError, _>($location, $syscall_function).unwrap();
+        $syscall_registry.register_syscall_by_name::<UserError, _>($location, $syscall_function).unwrap();
     };
     (bind, $vm:expr, $location:expr => $syscall_function:expr; $syscall_context_object:expr) => {
         $vm.bind_syscall_context_object(Box::new($syscall_context_object), None).unwrap();
@@ -2192,19 +2192,19 @@ fn test_stack2() {
         mov r1, r10
         mov r2, 0x4
         sub r1, r2
-        call 1
+        syscall BpfMemFrob
         mov r1, 0
         ldxb r2, [r10-4]
         ldxb r3, [r10-3]
         ldxb r4, [r10-2]
         ldxb r5, [r10-1]
-        call 0
+        syscall BpfGatherBytes
         xor r0, 0x2a2a2a2a
         exit",
         [],
         (
-            0 => syscalls::BpfGatherBytes::call; syscalls::BpfGatherBytes {},
-            1 => syscalls::BpfMemFrob::call; syscalls::BpfMemFrob {},
+            b"BpfMemFrob" => syscalls::BpfMemFrob::call; syscalls::BpfMemFrob {},
+            b"BpfGatherBytes" => syscalls::BpfGatherBytes::call; syscalls::BpfGatherBytes {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0x01020304 } },
         16
@@ -2225,7 +2225,7 @@ fn test_string_stack() {
         mov r1, r10
         add r1, -8
         mov r2, r1
-        call 0
+        syscall BpfStrCmp
         mov r1, r0
         mov r0, 0x1
         lsh r1, 0x20
@@ -2235,7 +2235,7 @@ fn test_string_stack() {
         add r1, -8
         mov r2, r10
         add r2, -16
-        call 0
+        syscall BpfStrCmp
         mov r1, r0
         lsh r1, 0x20
         rsh r1, 0x20
@@ -2245,7 +2245,7 @@ fn test_string_stack() {
         exit",
         [],
         (
-            0 => syscalls::BpfStrCmp::call; syscalls::BpfStrCmp {},
+            b"BpfStrCmp" => syscalls::BpfStrCmp::call; syscalls::BpfStrCmp {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         28
@@ -2280,7 +2280,7 @@ fn test_relative_call() {
         "tests/elfs/relative_call.so",
         [1],
         (
-            hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
+            b"log" => BpfSyscallString::call; BpfSyscallString {},
         ),
         { |_vm, res: Result| { res.unwrap() == 2 } },
         14
@@ -2293,7 +2293,7 @@ fn test_bpf_to_bpf_scratch_registers() {
         "tests/elfs/scratch_registers.so",
         [1],
         (
-            hash_symbol_name(b"log_64") => BpfSyscallU64::call; BpfSyscallU64 {},
+            b"log_64" => BpfSyscallU64::call; BpfSyscallU64 {},
         ),
         { |_vm, res: Result| { res.unwrap() == 112 } },
         41
@@ -2318,12 +2318,12 @@ fn test_syscall_parameter_on_stack() {
         mov64 r1, r10
         add64 r1, -0x100
         mov64 r2, 0x1
-        call 0
+        syscall BpfSyscallString
         mov64 r0, 0x0
         exit",
         [],
         (
-            0 => BpfSyscallString::call; BpfSyscallString {},
+            b"BpfSyscallString" => BpfSyscallString::call; BpfSyscallString {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         6
@@ -2403,16 +2403,13 @@ fn test_err_call_lddw() {
         };
         let mut executable = assemble(
             "
-            call 0x63210A6D
+            call 1
             lddw r0, 0x1122334455667788
             exit",
             None,
             config,
         )
         .unwrap();
-        executable
-            .register_bpf_function(2, "in_the_middle_of_lddw")
-            .unwrap();
         test_interpreter_and_jit!(
             executable,
             [],
@@ -2460,7 +2457,7 @@ fn test_bpf_to_bpf_depth() {
             "tests/elfs/multiple_file.so",
             [i as u8],
             (
-                hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
+                b"log" => BpfSyscallString::call; BpfSyscallString {},
             ),
             { |_vm, res: Result| { res.unwrap() == 0 } },
             if i == 0 { 4 } else { 3 + 10 * i as u64 }
@@ -2475,7 +2472,7 @@ fn test_err_bpf_to_bpf_too_deep() {
         "tests/elfs/multiple_file.so",
         [config.max_call_depth as u8],
         (
-            hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
+            b"log" => BpfSyscallString::call; BpfSyscallString {},
         ),
         {
             |_vm, res: Result| {
@@ -2544,12 +2541,12 @@ fn test_err_syscall_string() {
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, 0x0
-        call 0
+        syscall BpfSyscallString
         mov64 r0, 0x0
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => BpfSyscallString::call; BpfSyscallString {},
+            b"BpfSyscallString" => BpfSyscallString::call; BpfSyscallString {},
         ),
         {
             |_vm, res: Result| {
@@ -2568,12 +2565,12 @@ fn test_syscall_string() {
     test_interpreter_and_jit_asm!(
         "
         mov64 r2, 0x5
-        call 0
+        syscall BpfSyscallString
         mov64 r0, 0x0
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => BpfSyscallString::call; BpfSyscallString {},
+            b"BpfSyscallString" => BpfSyscallString::call; BpfSyscallString {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         4
@@ -2589,12 +2586,12 @@ fn test_syscall() {
         mov64 r3, 0xCC
         mov64 r4, 0xDD
         mov64 r5, 0xEE
-        call 0
+        syscall BpfSyscallU64
         mov64 r0, 0x0
         exit",
         [],
         (
-            0 => BpfSyscallU64::call; BpfSyscallU64 {},
+            b"BpfSyscallU64" => BpfSyscallU64::call; BpfSyscallU64 {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         8
@@ -2610,11 +2607,11 @@ fn test_call_gather_bytes() {
         mov r3, 3
         mov r4, 4
         mov r5, 5
-        call 0
+        syscall BpfGatherBytes
         exit",
         [],
         (
-            0 => syscalls::BpfGatherBytes::call; syscalls::BpfGatherBytes {},
+            b"BpfGatherBytes" => syscalls::BpfGatherBytes::call; syscalls::BpfGatherBytes {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0x0102030405 } },
         7
@@ -2628,7 +2625,7 @@ fn test_call_memfrob() {
         mov r6, r1
         add r1, 2
         mov r2, 4
-        call 0
+        syscall BpfMemFrob
         ldxdw r0, [r6]
         be64 r0
         exit",
@@ -2636,7 +2633,7 @@ fn test_call_memfrob() {
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
         ],
         (
-            0 => syscalls::BpfMemFrob::call; syscalls::BpfMemFrob {},
+            b"BpfMemFrob" => syscalls::BpfMemFrob::call; syscalls::BpfMemFrob {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0x102292e2f2c0708 } },
         7
@@ -2652,12 +2649,12 @@ fn test_syscall_with_context() {
         mov64 r3, 0xCC
         mov64 r4, 0xDD
         mov64 r5, 0xEE
-        call 0
+        syscall SyscallWithContext
         mov64 r0, 0x0
         exit",
         [],
         (
-            0 => SyscallWithContext::call; SyscallWithContext { context: 42 },
+            b"SyscallWithContext" => SyscallWithContext::call; SyscallWithContext { context: 42 },
         ),
         { |vm: &EbpfVm<UserError, TestInstructionMeter>, res: Result| {
             let syscall_context_object = unsafe { &*(vm.get_syscall_context_object(SyscallWithContext::call as usize).unwrap() as *const SyscallWithContext) };
@@ -2676,8 +2673,8 @@ fn test_load_elf() {
         "tests/elfs/noop.so",
         [],
         (
-            hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
-            hash_symbol_name(b"log_64") => BpfSyscallU64::call; BpfSyscallU64 {},
+            b"log" => BpfSyscallString::call; BpfSyscallString {},
+            b"log_64" => BpfSyscallU64::call; BpfSyscallU64 {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         11
@@ -2690,7 +2687,7 @@ fn test_load_elf_empty_noro() {
         "tests/elfs/noro.so",
         [],
         (
-            hash_symbol_name(b"log_64") => BpfSyscallU64::call; BpfSyscallU64 {},
+            b"log_64" => BpfSyscallU64::call; BpfSyscallU64 {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         8
@@ -2703,7 +2700,7 @@ fn test_load_elf_empty_rodata() {
         "tests/elfs/empty_rodata.so",
         [],
         (
-            hash_symbol_name(b"log_64") => BpfSyscallU64::call; BpfSyscallU64 {},
+            b"log_64" => BpfSyscallU64::call; BpfSyscallU64 {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         8
@@ -2723,8 +2720,8 @@ fn test_custom_entrypoint() {
         executable,
         [],
         (
-            hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
-            hash_symbol_name(b"log_64") => BpfSyscallU64::call; BpfSyscallU64 {},
+            b"log" => BpfSyscallString::call; BpfSyscallString {},
+            b"log_64" => BpfSyscallU64::call; BpfSyscallU64 {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         2
@@ -2824,12 +2821,12 @@ fn test_instruction_count_syscall() {
     test_interpreter_and_jit_asm!(
         "
         mov64 r2, 0x5
-        call 0
+        syscall BpfSyscallString
         mov64 r0, 0x0
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => BpfSyscallString::call; BpfSyscallString {},
+            b"BpfSyscallString" => BpfSyscallString::call; BpfSyscallString {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         4
@@ -2846,7 +2843,7 @@ fn test_err_instruction_count_syscall_capped() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => BpfSyscallString::call; BpfSyscallString {},
+            b"BpfSyscallString" => BpfSyscallString::call; BpfSyscallString {},
         ),
         {
             |_vm, res: Result| {
@@ -2870,7 +2867,7 @@ fn test_non_terminate_early() {
         mov64 r3, 0x0
         mov64 r4, 0x0
         mov64 r5, r6
-        call 0x6
+        syscall Unresolved
         add64 r6, 0x1
         ja -0x8
         exit",
@@ -2898,13 +2895,13 @@ fn test_err_non_terminate_capped() {
         mov64 r3, 0x0
         mov64 r4, 0x0
         mov64 r5, r6
-        call 0x0
+        syscall BpfTracePrintf
         add64 r6, 0x1
         ja -0x8
         exit",
         [],
         (
-            0 => BpfTracePrintf::call; BpfTracePrintf {},
+            b"BpfTracePrintf" => BpfTracePrintf::call; BpfTracePrintf {},
         ),
         {
             |_vm, res: Result| {
@@ -2928,13 +2925,13 @@ fn test_err_non_terminating_capped() {
         mov64 r3, 0x0
         mov64 r4, 0x0
         mov64 r5, r6
-        call 0x0
+        syscall BpfTracePrintf
         add64 r6, 0x1
         ja -0x8
         exit",
         [],
         (
-            0 => BpfTracePrintf::call; BpfTracePrintf {},
+            b"BpfTracePrintf" => BpfTracePrintf::call; BpfTracePrintf {},
         ),
         {
             |_vm, res: Result| {
@@ -2957,12 +2954,12 @@ fn test_symbol_relocation() {
         mov64 r1, r10
         sub64 r1, 0x1
         mov64 r2, 0x1
-        call 0
+        syscall BpfSyscallString
         mov64 r0, 0x0
         exit",
         [72, 101, 108, 108, 111],
         (
-            0 => BpfSyscallString::call; BpfSyscallString {},
+            b"BpfSyscallString" => BpfSyscallString::call; BpfSyscallString {},
         ),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         6
@@ -2973,7 +2970,7 @@ fn test_symbol_relocation() {
 fn test_err_symbol_unresolved() {
     test_interpreter_and_jit_asm!(
         "
-        call 0
+        syscall Unresolved
         mov64 r0, 0x0
         exit",
         [],
@@ -2994,7 +2991,7 @@ fn test_err_call_unresolved() {
         mov r3, 3
         mov r4, 4
         mov r5, 5
-        call 63
+        syscall Unresolved
         exit",
         [],
         (),
@@ -3011,7 +3008,7 @@ fn test_err_unresolved_elf() {
         "tests/elfs/unresolved_syscall.so",
         [],
         (
-            hash_symbol_name(b"log") => BpfSyscallString::call; BpfSyscallString {},
+            b"log" => BpfSyscallString::call; BpfSyscallString {},
         ),
         {
             |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset)) if symbol == "log_64" && pc == 550 && offset == 4168)
@@ -3251,13 +3248,15 @@ fn test_large_program() {
         .collect::<Vec<_>>();
     #[allow(unused_mut)]
     {
+        let mut bpf_functions = BTreeMap::new();
+        register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
         let mut executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
             program.as_slice(),
+            bpf_functions,
             None,
             config,
         )
         .unwrap();
-        executable.register_bpf_function(0, "entrypoint").unwrap();
         test_interpreter_and_jit!(
             executable,
             [],
@@ -3277,6 +3276,7 @@ fn test_large_program() {
         assert!(
             <dyn Executable::<UserError, DefaultInstructionMeter>>::from_text_bytes(
                 program.as_slice(),
+                BTreeMap::new(),
                 Some(check),
                 config,
             )
@@ -3291,8 +3291,11 @@ fn test_large_program() {
 fn execute_generated_program(prog: &[u8]) -> bool {
     let max_instruction_count = 1024;
     let mem_size = 1024 * 1024;
+    let mut bpf_functions = BTreeMap::new();
+    register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
     let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
         &prog,
+        bpf_functions,
         Some(check),
         Config {
             enable_instruction_tracing: true,
@@ -3304,7 +3307,6 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     } else {
         return false;
     };
-    executable.register_bpf_function(0, "entrypoint").unwrap();
     executable.set_syscall_registry(SyscallRegistry::default());
     if executable.jit_compile().is_err() {
         return false;

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2403,7 +2403,7 @@ fn test_err_call_lddw() {
         };
         let mut executable = assemble(
             "
-            call 2
+            call 0x63210A6D
             lddw r0, 0x1122334455667788
             exit",
             None,
@@ -2411,7 +2411,7 @@ fn test_err_call_lddw() {
         )
         .unwrap();
         executable
-            .register_bpf_function(2, 2, "in_the_middle_of_lddw")
+            .register_bpf_function(2, "in_the_middle_of_lddw")
             .unwrap();
         test_interpreter_and_jit!(
             executable,
@@ -2777,9 +2777,9 @@ fn test_tight_infinite_loop_unconditional() {
 fn test_tight_infinite_recursion() {
     test_interpreter_and_jit_asm!(
         "
-        loop:
+        entrypoint:
         mov64 r3, 0x41414141
-        call loop
+        call entrypoint
         exit",
         [],
         (),
@@ -3257,9 +3257,7 @@ fn test_large_program() {
             config,
         )
         .unwrap();
-        executable
-            .register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint")
-            .unwrap();
+        executable.register_bpf_function(0, "entrypoint").unwrap();
         test_interpreter_and_jit!(
             executable,
             [],
@@ -3306,9 +3304,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     } else {
         return false;
     };
-    executable
-        .register_bpf_function(ebpf::hash_symbol_name(b"entrypoint"), 0, "entrypoint")
-        .unwrap();
+    executable.register_bpf_function(0, "entrypoint").unwrap();
     executable.set_syscall_registry(SyscallRegistry::default());
     if executable.jit_compile().is_err() {
         return false;

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -30,6 +30,7 @@ use solana_rbpf::{
     verifier::check,
     vm::{Config, DefaultInstructionMeter, EbpfVm, Executable},
 };
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 /// Error definitions
@@ -98,6 +99,7 @@ fn test_verifier_err_endian_size() {
     ];
     let _ = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         prog,
+        BTreeMap::new(),
         Some(check),
         Config::default(),
     )
@@ -114,6 +116,7 @@ fn test_verifier_err_incomplete_lddw() {
     ];
     let _ = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         prog,
+        BTreeMap::new(),
         Some(check),
         Config::default(),
     )
@@ -212,6 +215,7 @@ fn test_verifier_err_too_many_instructions() {
 
     let _ = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         &prog,
+        BTreeMap::new(),
         Some(check),
         Config::default(),
     )
@@ -227,6 +231,7 @@ fn test_verifier_err_unknown_opcode() {
     ];
     let _ = <dyn Executable<UserError, DefaultInstructionMeter>>::from_text_bytes(
         prog,
+        BTreeMap::new(),
         Some(check),
         Config::default(),
     )


### PR DESCRIPTION
Unifies all inserts into `bpf_functions` in assembler and elf into `register_bpf_function()`.
Moves `register_bpf_function()` out of Executable and into `from_text_bytes()`.
Also, let `register_bpf_function()` decide the symbol hash.
Changes all test cases to use the `syscall` mnemonic.

