### PR TITLE
Unify BPF verifiers

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -212,7 +212,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 /// ```
 pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     src: &str,
-    verifier: Option<Verifier<E>>,
+    verifier: Option<Verifier>,
     config: Config,
 ) -> Result<Box<dyn Executable<E, I>>, String> {
     fn resolve_label(

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -25,8 +25,6 @@ use std::fmt;
 pub const PROG_MAX_INSNS: usize = 65_536;
 /// Size of an eBPF instructions, in bytes.
 pub const INSN_SIZE: usize = 8;
-/// Maximum size of an eBPF program, in bytes.
-pub const PROG_MAX_SIZE: usize = PROG_MAX_INSNS * INSN_SIZE;
 /// Stack register
 pub const STACK_REG: usize = 10;
 /// First scratch register

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
-use crate::{elf::ElfError, memory_region::AccessType};
+use crate::{elf::ElfError, memory_region::AccessType, verifier::VerifierError};
 
 /// User defined errors must implement this trait
 pub trait UserDefinedError: 'static + std::error::Error {}
@@ -86,4 +86,7 @@ pub enum EbpfError<E: UserDefinedError> {
     /// Compilation is too big to fit
     #[error("Compilation exhaused text segment at instruction {0}")]
     ExhausedTextSegment(usize),
+    /// ELF error
+    #[error("Verifier error: {0}")]
+    VerifierError(#[from] VerifierError),
 }


### PR DESCRIPTION
There are currently two bpf verifiers, one in the rbpf crate and one in the bpf_loader crate in the Solana repo.  Only the one in the bpf_loader crate is used by the cluster but having two is confusing.

This PR pulls the verifier from the bpf_loader crate and makes the necessary changes in prep for the bpf_loader crate to switch over to the updated one in the rbpf create.