### PR TITLE
Fix JIT instruction meter limit reached before exception

### DIFF
--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2995,6 +2995,31 @@ fn test_err_non_terminating_capped() {
     );
 }
 
+#[test]
+fn test_err_capped_before_exception() {
+    test_interpreter_and_jit_asm!(
+        "
+        mov64 r1, 0x0
+        mov64 r2, 0x0
+        add64 r0, 0x0
+        add64 r0, 0x0
+        div64 r1, r2
+        add64 r0, 0x0
+        exit",
+        [],
+        (),
+        {
+            |_vm, res: Result| {
+                matches!(res.unwrap_err(),
+                    EbpfError::ExceededMaxInstructions(pc, initial_insn_count)
+                    if pc == 31 && initial_insn_count == 2
+                )
+            }
+        },
+        2
+    );
+}
+
 // Symbols and Relocation
 
 #[test]


### PR DESCRIPTION
> There's actually a separate issue involved, which is that if the program throws an error or panics after it was supposed to have run out of budget, then it may return a different return type. I guess this wouldn't be a problem if every error or branch into an error also first checks the compute meter (perhaps already subsumed under the conditions for returning)

_Originally posted by @jon-chuang in https://github.com/solana-labs/rbpf/issues/185#issuecomment-871833662_