### PR TITLE
Feature/address translation cleanup

### DIFF
--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -29,7 +29,8 @@ fn bench_init_vm(bencher: &mut Bencher) {
     )
     .unwrap();
     bencher.iter(|| {
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap()
+        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
+            .unwrap()
     });
 }
 

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -24,7 +24,7 @@ fn generate_memory_regions(
     mut prng: Option<&mut SmallRng>,
 ) -> (Vec<MemoryRegion>, u64) {
     let mut memory_regions = Vec::with_capacity(entries);
-    let mut offset = 0;
+    let mut offset = 0x100000000;
     for _ in 0..entries {
         let length = match &mut prng {
             Some(prng) => (*prng).gen::<u8>() as u64 + 4,
@@ -37,7 +37,7 @@ fn generate_memory_regions(
             0,
             is_writable,
         ));
-        offset += length;
+        offset += 0x100000000;
     }
     (memory_regions, offset)
 }
@@ -61,7 +61,7 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
     let content = vec![0; (frame_size * frame_count * 2) as usize];
     let memory_regions = vec![MemoryRegion::new_from_slice(
         &content[..],
-        0,
+        0x100000000,
         frame_size,
         false,
     )];
@@ -72,7 +72,7 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
         assert!(memory_mapping
             .map::<UserError>(
                 AccessType::Load,
-                prng.gen::<u64>() % frame_count * (frame_size * 2),
+                0x100000000 + (prng.gen::<u64>() % frame_count * (frame_size * 2)),
                 1
             )
             .is_ok());
@@ -82,18 +82,21 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
 #[bench]
 fn bench_randomized_access_with_0001_entry(bencher: &mut Bencher) {
     let content = vec![0; 1024 * 2];
-    let memory_regions = vec![MemoryRegion::new_from_slice(&content[..], 0, 0, false)];
+    let memory_regions = vec![MemoryRegion::new_from_slice(
+        &content[..],
+        0x100000000,
+        0,
+        false,
+    )];
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     let mut prng = new_prng!();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(
-                AccessType::Load,
-                prng.gen::<u64>() % content.len() as u64,
-                1
-            )
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % content.len() as u64),
+            1,
+        );
     });
 }
 
@@ -104,9 +107,11 @@ fn bench_randomized_mapping_access_with_0004_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % end_address),
+            1,
+        );
     });
 }
 
@@ -117,9 +122,11 @@ fn bench_randomized_mapping_access_with_0016_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % end_address),
+            1,
+        );
     });
 }
 
@@ -130,9 +137,11 @@ fn bench_randomized_mapping_access_with_0064_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % end_address),
+            1,
+        );
     });
 }
 
@@ -143,9 +152,11 @@ fn bench_randomized_mapping_access_with_0256_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % end_address),
+            1,
+        );
     });
 }
 
@@ -156,9 +167,11 @@ fn bench_randomized_mapping_access_with_1024_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % end_address),
+            1,
+        );
     });
 }
 
@@ -169,9 +182,11 @@ fn bench_randomized_access_with_1024_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, prng.gen::<u64>() % end_address, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(
+            AccessType::Load,
+            0x100000000 + (prng.gen::<u64>() % end_address),
+            1,
+        );
     });
 }
 
@@ -182,9 +197,7 @@ fn bench_randomized_mapping_with_1024_entries(bencher: &mut Bencher) {
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
-        assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, 0, 1)
-            .is_ok());
+        let _ = memory_mapping.map::<UserError>(AccessType::Load, 0x100000000, 1);
     });
 }
 
@@ -195,7 +208,7 @@ fn bench_mapping_with_1024_entries(bencher: &mut Bencher) {
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     bencher.iter(|| {
         assert!(memory_mapping
-            .map::<UserError>(AccessType::Load, 0, 1)
+            .map::<UserError>(AccessType::Load, 0x100000000, 1)
             .is_ok());
     });
 }

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -23,7 +23,8 @@ fn generate_memory_regions(
     is_writable: bool,
     mut prng: Option<&mut SmallRng>,
 ) -> (Vec<MemoryRegion>, u64) {
-    let mut memory_regions = Vec::with_capacity(entries);
+    let mut memory_regions = Vec::with_capacity(entries + 1);
+    memory_regions.push(MemoryRegion::default());
     let mut offset = 0x100000000;
     for _ in 0..entries {
         let length = match &mut prng {
@@ -59,12 +60,10 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
     let frame_size: u64 = 2;
     let frame_count: u64 = 1024;
     let content = vec![0; (frame_size * frame_count * 2) as usize];
-    let memory_regions = vec![MemoryRegion::new_from_slice(
-        &content[..],
-        0x100000000,
-        frame_size,
-        false,
-    )];
+    let memory_regions = vec![
+        MemoryRegion::default(),
+        MemoryRegion::new_from_slice(&content[..], 0x100000000, frame_size, false),
+    ];
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     let mut prng = new_prng!();
@@ -82,12 +81,10 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
 #[bench]
 fn bench_randomized_access_with_0001_entry(bencher: &mut Bencher) {
     let content = vec![0; 1024 * 2];
-    let memory_regions = vec![MemoryRegion::new_from_slice(
-        &content[..],
-        0x100000000,
-        0,
-        false,
-    )];
+    let memory_regions = vec![
+        MemoryRegion::default(),
+        MemoryRegion::new_from_slice(&content[..], 0x100000000, 0, false),
+    ];
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
     let mut prng = new_prng!();

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -29,7 +29,8 @@ fn bench_init_interpreter_execution(bencher: &mut Bencher) {
     )
     .unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
+            .unwrap();
     bencher.iter(|| {
         vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 29 })
             .unwrap()
@@ -51,7 +52,8 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     .unwrap();
     executable.jit_compile().unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
+            .unwrap();
     bencher.iter(|| {
         vm.execute_program_jit(&mut TestInstructionMeter { remaining: 29 })
             .unwrap()
@@ -73,7 +75,7 @@ fn bench_jit_vs_interpreter(
     )
     .unwrap();
     executable.jit_compile().unwrap();
-    let mut vm = EbpfVm::new(executable.as_ref(), mem, &[]).unwrap();
+    let mut vm = EbpfVm::new(executable.as_ref(), &mut [], mem).unwrap();
     let interpreter_summary = bencher
         .bench(|bencher| {
             bencher.iter(|| {

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -52,7 +52,8 @@ fn main() {
     )
     .unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
+            .unwrap();
     // Execute prog1.
     assert_eq!(
         vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 5 })
@@ -88,7 +89,8 @@ fn main() {
         executable.jit_compile().unwrap();
     }
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
+            .unwrap();
     vm.bind_syscall_context_object(Box::new(syscalls::BpfTimeGetNs {}), None)
         .unwrap();
 

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -190,7 +190,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 ///     Config::default(),
 ///     SyscallRegistry::default(),
 /// ).unwrap();
-/// let program = executable.get_text_bytes().unwrap().1;
+/// let program = executable.get_text_bytes().1;
 /// println!("{:?}", program);
 /// # assert_eq!(program,
 /// #            &[0x07, 0x01, 0x00, 0x00, 0x05, 0x06, 0x00, 0x00,

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -5,6 +5,7 @@ use crate::{
     ebpf::{ELF_INSN_DUMP_OFFSET, HOST_ALIGN, MM_STACK_START, SCRATCH_REGS},
     error::{EbpfError, UserDefinedError},
     memory_region::MemoryRegion,
+    vm::Config,
 };
 
 /// One call frame
@@ -19,21 +20,24 @@ struct CallFrame {
 /// function to be called in its own frame.  CallFrames manages
 /// call frames
 #[derive(Clone, Debug)]
-pub struct CallFrames {
+pub struct CallFrames<'a> {
+    config: &'a Config,
     stack: AlignedMemory,
-    frame_size: usize,
     frame_index: usize,
     frame_index_max: usize,
     frames: Vec<CallFrame>,
 }
-impl CallFrames {
+impl<'a> CallFrames<'a> {
     /// New call frame, depth indicates maximum call depth
-    pub fn new(depth: usize, frame_size: usize) -> Self {
-        let mut stack = AlignedMemory::new(depth * frame_size, HOST_ALIGN);
-        stack.resize(depth * frame_size, 0).unwrap();
+    pub fn new(config: &'a Config) -> Self {
+        let mut stack =
+            AlignedMemory::new(config.max_call_depth * config.stack_frame_size, HOST_ALIGN);
+        stack
+            .resize(config.max_call_depth * config.stack_frame_size, 0)
+            .unwrap();
         let mut frames = CallFrames {
+            config,
             stack,
-            frame_size,
             frame_index: 0,
             frame_index_max: 0,
             frames: vec![
@@ -42,12 +46,14 @@ impl CallFrames {
                     saved_reg: [0u64; SCRATCH_REGS],
                     return_ptr: 0
                 };
-                depth
+                config.max_call_depth
             ],
         };
-        for i in 0..depth {
-            // Seperate each stack frame's virtual address so that stack over/under-run is caught explicitly
-            frames.frames[i].vm_addr = MM_STACK_START + (i * 2 * frame_size) as u64;
+        // Seperate each stack frame's virtual address so that stack over/under-run is caught explicitly
+        let gap_factor = if config.enable_stack_frame_gaps { 2 } else { 1 };
+        for i in 0..config.max_call_depth {
+            frames.frames[i].vm_addr =
+                MM_STACK_START + (i * gap_factor * config.stack_frame_size) as u64;
         }
         frames
     }
@@ -57,7 +63,11 @@ impl CallFrames {
         MemoryRegion::new_from_slice(
             self.stack.as_slice(),
             MM_STACK_START,
-            self.frame_size as u64,
+            if self.config.enable_stack_frame_gaps {
+                self.config.stack_frame_size as u64
+            } else {
+                0
+            },
             true,
         )
     }
@@ -69,7 +79,7 @@ impl CallFrames {
 
     /// Get the address of a frame's top of stack
     pub fn get_stack_top(&self) -> u64 {
-        self.frames[self.frame_index].vm_addr + self.frame_size as u64
+        self.frames[self.frame_index].vm_addr + self.config.stack_frame_size as u64
     }
 
     /// Get current call frame index, 0 is the root frame
@@ -124,32 +134,41 @@ mod tests {
 
     #[test]
     fn test_frames() {
-        const DEPTH: usize = 10;
-        const FRAME_SIZE: u64 = 8;
-        let mut frames = CallFrames::new(DEPTH, FRAME_SIZE as usize);
+        let config = Config {
+            max_call_depth: 10,
+            stack_frame_size: 8,
+            enable_stack_frame_gaps: true,
+            ..Config::default()
+        };
+        let mut frames = CallFrames::new(&config);
         let mut ptrs: Vec<u64> = Vec::new();
-        for i in 0..DEPTH - 1 {
-            let registers = vec![i as u64; FRAME_SIZE as usize];
+        for i in 0..config.max_call_depth - 1 {
+            let registers = vec![i as u64; config.stack_frame_size];
             assert_eq!(frames.get_frame_index(), i);
             ptrs.push(frames.get_frame_pointers()[i]);
 
             let top = frames.push::<UserError>(&registers[0..4], i).unwrap();
             let new_ptrs = frames.get_frame_pointers();
-            assert_eq!(top, new_ptrs[i + 1] + FRAME_SIZE);
-            assert_ne!(top, ptrs[i] + FRAME_SIZE - 1);
-            assert!(!(ptrs[i] <= new_ptrs[i + 1] && new_ptrs[i + 1] < ptrs[i] + FRAME_SIZE));
+            assert_eq!(top, new_ptrs[i + 1] + config.stack_frame_size as u64);
+            assert_ne!(top, ptrs[i] + config.stack_frame_size as u64 - 1);
+            assert!(
+                !(ptrs[i] <= new_ptrs[i + 1]
+                    && new_ptrs[i + 1] < ptrs[i] + config.stack_frame_size as u64)
+            );
         }
-        let i = DEPTH - 1;
-        let registers = vec![i as u64; FRAME_SIZE as usize];
+        let i = config.max_call_depth - 1;
+        let registers = vec![i as u64; config.stack_frame_size];
         assert_eq!(frames.get_frame_index(), i);
         ptrs.push(frames.get_frame_pointers()[i]);
 
-        assert!(frames.push::<UserError>(&registers, DEPTH - 1).is_err());
+        assert!(frames
+            .push::<UserError>(&registers, config.max_call_depth - 1)
+            .is_err());
 
-        for i in (0..DEPTH - 1).rev() {
+        for i in (0..config.max_call_depth - 1).rev() {
             let (saved_reg, stack_ptr, return_ptr) = frames.pop::<UserError>().unwrap();
             assert_eq!(saved_reg, [i as u64, i as u64, i as u64, i as u64]);
-            assert_eq!(ptrs[i] + FRAME_SIZE, stack_ptr);
+            assert_eq!(ptrs[i] + config.stack_frame_size as u64, stack_ptr);
             assert_eq!(i, return_ptr);
         }
 

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -35,21 +35,13 @@ pub const SCRATCH_REGS: usize = 4;
 /// Instruction numbers typically start at 29 in the ELF dump, use this offset
 /// when reporting so that trace aligns with the dump.
 pub const ELF_INSN_DUMP_OFFSET: usize = 29;
+/// Alignment of the memory regions in host address space in bytes
+pub const HOST_ALIGN: usize = 16;
+/// Upper half of a pointer is the region index, lower half the virtual address inside that region.
+pub const VIRTUAL_ADDRESS_BITS: usize = 32;
 
-// Memory map
-// +-----------------+
-// | Program         |
-// +-----------------+
-// | Stack           |
-// +-----------------+
-// | Heap            |
-// +-----------------+
-// | Input           |
-// +-----------------+
-// The values below providesufficient separations between the map areas. Avoid using
-// 0x0 to distinguish virtual addresses from null pointers.
-// Note: Compiled programs themselves have no direct dependency on these values so
-// they may be modified based on new requirements.
+// Memory map regions virtual addresses need to be (1 << VIRTUAL_ADDRESS_BITS) bytes apart.
+// Also the region at index 0 should be skipped to catch NULL ptr accesses.
 
 /// Start of the program bits (text and ro segments) in the memory map
 pub const MM_PROGRAM_START: u64 = 0x100000000;
@@ -59,9 +51,6 @@ pub const MM_STACK_START: u64 = 0x200000000;
 pub const MM_HEAP_START: u64 = 0x300000000;
 /// Start of the input buffers in the memory map
 pub const MM_INPUT_START: u64 = 0x400000000;
-
-/// Alignment of the memory regions in host address space in bytes
-pub const HOST_ALIGN: usize = 16;
 
 // eBPF op codes.
 // See also https://www.kernel.org/doc/Documentation/networking/filter.txt

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,9 +66,9 @@ pub enum EbpfError<E: UserDefinedError> {
     /// Invalid virtual address
     #[error("invalid virtual address {0:x?}")]
     InvalidVirtualAddress(u64),
-    /// Virtual address overlap
-    #[error("virtual address overlap {0:x?}")]
-    VirtualAddressOverlap(u64),
+    /// Memory region index or virtual address space is invalid
+    #[error("Invalid memory region at index {0}")]
+    InvalidMemoryRegion(usize),
     /// Access violation (general)
     #[error("Access violation in {4} section at address {2:#x} of size {3:?} by instruction #{0}")]
     AccessViolation(usize, AccessType, u64, u64, &'static str),

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -146,7 +146,7 @@ impl<E: UserDefinedError, I: InstructionMeter> PartialEq for JitProgram<E, I> {
 
 impl<E: UserDefinedError, I: InstructionMeter> JitProgram<E, I> {
     pub fn new(executable: &dyn Executable<E, I>) -> Result<Self, EbpfError<E>> {
-        let program = executable.get_text_bytes()?.1;
+        let program = executable.get_text_bytes().1;
         let mut jit = JitCompiler::new::<E>(program, executable.get_config())?;
         jit.compile::<E, I>(executable)?;
         let main = unsafe { mem::transmute(jit.result.text_section.as_ptr()) };
@@ -982,7 +982,7 @@ impl JitCompiler {
 
     fn compile<E: UserDefinedError, I: InstructionMeter>(&mut self,
             executable: &dyn Executable<E, I>) -> Result<(), EbpfError<E>> {
-        let (program_vm_addr, program) = executable.get_text_bytes()?;
+        let (program_vm_addr, program) = executable.get_text_bytes();
         self.program_vm_addr = program_vm_addr;
 
         self.generate_prologue::<E, I>()?;

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -23,7 +23,7 @@ pub struct MemoryRegion {
 }
 impl MemoryRegion {
     /// Creates a new MemoryRegion structure from a slice
-    pub fn new_from_slice(v: &[u8], vm_addr: u64, vm_gap_size: u64, is_writable: bool) -> Self {
+    pub fn new_from_slice(slice: &[u8], vm_addr: u64, vm_gap_size: u64, is_writable: bool) -> Self {
         let vm_gap_shift = if vm_gap_size > 0 {
             let vm_gap_shift =
                 std::mem::size_of::<u64>() as u8 * 8 - vm_gap_size.leading_zeros() as u8 - 1;
@@ -33,9 +33,9 @@ impl MemoryRegion {
             std::mem::size_of::<u64>() as u8 * 8 - 1
         };
         MemoryRegion {
-            host_addr: v.as_ptr() as u64,
+            host_addr: slice.as_ptr() as u64,
             vm_addr,
-            len: v.len() as u64,
+            len: slice.len() as u64,
             vm_gap_shift,
             is_writable,
         }

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -108,10 +108,10 @@ impl<'a> MemoryMapping<'a> {
     ) -> Result<Self, EbpfError<E>> {
         regions.sort();
         for (index, region) in regions.iter().enumerate() {
-            if region.vm_addr != (index as u64 + 1) << ebpf::VIRTUAL_ADDRESS_BITS
+            if region.vm_addr != (index as u64) << ebpf::VIRTUAL_ADDRESS_BITS
                 || (region.len > 0
                     && ((region.vm_addr + region.len - 1) >> ebpf::VIRTUAL_ADDRESS_BITS) as usize
-                        != index + 1)
+                        != index)
             {
                 return Err(EbpfError::InvalidMemoryRegion(index));
             }
@@ -130,8 +130,8 @@ impl<'a> MemoryMapping<'a> {
         len: u64,
     ) -> Result<u64, EbpfError<E>> {
         let index = (vm_addr >> ebpf::VIRTUAL_ADDRESS_BITS) as usize;
-        if (1..self.regions.len() + 1).contains(&index) {
-            let region = &self.regions[index - 1];
+        if index > 0 && index < self.regions.len() {
+            let region = &self.regions[index];
             if access_type == AccessType::Load || region.is_writable {
                 if let Ok(host_addr) = region.vm_to_host::<E>(vm_addr, len as u64) {
                     return Ok(host_addr);
@@ -186,7 +186,7 @@ impl<'a> MemoryMapping<'a> {
             || (new_len > 0
                 && ((self.regions[index].vm_addr + new_len - 1) >> ebpf::VIRTUAL_ADDRESS_BITS)
                     as usize
-                    != index + 1)
+                    != index)
         {
             return Err(EbpfError::InvalidMemoryRegion(index));
         }

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -113,7 +113,7 @@ pub struct Analysis<'a, E: UserDefinedError, I: InstructionMeter> {
 impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
     /// Analyze an executable statically
     pub fn from_executable(executable: &'a dyn Executable<E, I>) -> Self {
-        let (_program_vm_addr, program) = executable.get_text_bytes().unwrap();
+        let (_program_vm_addr, program) = executable.get_text_bytes();
         let functions = executable.get_function_symbols();
         debug_assert!(
             program.len() % ebpf::INSN_SIZE == 0,

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -55,7 +55,7 @@ pub const BPF_KTIME_GETNS_IDX: u32 = 5;
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
 /// BpfTimeGetNs::call(&mut BpfTimeGetNs {}, 0, 0, 0, 0, 0, &memory_mapping, &mut result);
 /// let t = result.unwrap();
 /// let d =  t / 10u64.pow(9)  / 60   / 60  / 24;
@@ -103,7 +103,7 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
 /// BpfTracePrintf::call(&mut BpfTracePrintf {}, 0, 0, 1, 15, 32, &memory_mapping, &mut result);
 /// assert_eq!(result.unwrap() as usize, "BpfTracePrintf: 0x1, 0xf, 0x20\n".len());
 /// ```
@@ -172,7 +172,7 @@ impl SyscallObject<UserError> for BpfTracePrintf {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
 /// BpfGatherBytes::call(&mut BpfGatherBytes {}, 0x11, 0x22, 0x33, 0x44, 0x55, &memory_mapping, &mut result);
 /// assert_eq!(result.unwrap(), 0x1122334455);
 /// ```
@@ -211,7 +211,7 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 /// use solana_rbpf::user_error::UserError;
 ///
 /// let val = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33];
-/// let val_va = 0x1000;
+/// let val_va = 0x100000000;
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
@@ -257,7 +257,7 @@ impl SyscallObject<UserError> for BpfMemFrob {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
 /// BpfSqrtI::call(&mut BpfSqrtI {}, 9, 0, 0, 0, 0, &memory_mapping, &mut result);
 /// assert_eq!(result.unwrap(), 3);
 /// ```
@@ -288,8 +288,8 @@ impl SyscallObject<UserError> for BpfSqrtI {
 ///
 /// let foo = "This is a string.";
 /// let bar = "This is another sting.";
-/// let va_foo = 0x1000;
-/// let va_bar = 0x2000;
+/// let va_foo = 0x100000000;
+/// let va_bar = 0x200000000;
 /// use solana_rbpf::user_error::UserError;
 ///
 /// let mut result: Result = Ok(0);
@@ -365,7 +365,7 @@ impl SyscallObject<UserError> for BpfStrCmp {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default()], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
 /// BpfRand::call(&mut BpfRand {}, 3, 6, 0, 0, 0, &memory_mapping, &mut result);
 /// let n = result.unwrap();
 /// assert!(3 <= n && n <= 6);

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -215,7 +215,7 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::new_from_slice(&val, val_va, 0, true)], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_from_slice(&val, val_va, 0, true)], &config).unwrap();
 /// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
 /// assert_eq!(val, vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
 /// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
@@ -294,11 +294,11 @@ impl SyscallObject<UserError> for BpfSqrtI {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false)], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false)], &config).unwrap();
 /// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &memory_mapping, &mut result);
 /// assert!(result.unwrap() == 0);
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, 0, false)], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, 0, false)], &config).unwrap();
 /// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &memory_mapping, &mut result);
 /// assert!(result.unwrap() != 0);
 /// ```

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -501,6 +501,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         let ro_region = executable.get_ro_section();
         let stack = CallFrames::new(config.max_call_depth, config.stack_frame_size);
         let regions: Vec<MemoryRegion> = vec![
+            MemoryRegion::new_from_slice(&[], 0, 0, false),
             MemoryRegion::new_from_slice(ro_region, ebpf::MM_PROGRAM_START, 0, false),
             stack.get_memory_region(),
             MemoryRegion::new_from_slice(heap_region, ebpf::MM_HEAP_START, 0, true),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -243,7 +243,7 @@ pub trait Executable<E: UserDefinedError, I: InstructionMeter>: Send + Sync {
 pub const REPORT_UNRESOLVED_SYMBOL_INDEX: usize = 8;
 
 /// The syscall_context_objects field stores some metadata in the front, thus the entries are shifted
-pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 6;
+pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 4;
 
 /// Static constructors for Executable
 impl<E: UserDefinedError, I: 'static + InstructionMeter> dyn Executable<E, I> {

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -22,7 +22,7 @@ fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
         Config::default(),
         SyscallRegistry::default(),
     )?;
-    let (_program_vm_addr, program) = executable.get_text_bytes().unwrap();
+    let (_program_vm_addr, program) = executable.get_text_bytes();
     Ok((0..program.len() / ebpf::INSN_SIZE)
         .map(|insn_ptr| ebpf::get_insn(program, insn_ptr))
         .collect())
@@ -581,7 +581,7 @@ fn test_tcp_sack() {
         SyscallRegistry::default(),
     )
     .unwrap();
-    let (_program_vm_addr, program) = executable.get_text_bytes().unwrap();
+    let (_program_vm_addr, program) = executable.get_text_bytes();
     assert_eq!(program, TCP_SACK_BIN.to_vec());
 }
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -127,7 +127,7 @@ fn test_fuzz_execute() {
                 let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(
                     executable.as_ref(),
                     &mut [],
-                    &[],
+                    &mut [],
                 )
                 .unwrap();
                 vm.bind_syscall_context_object(Box::new(BpfSyscallString {}), None)

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -36,7 +36,7 @@ macro_rules! test_interpreter_and_jit {
         let check_closure = $check;
         let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
-            let mut vm = EbpfVm::new($executable.as_ref(), &mut mem, &[]).unwrap();
+            let mut vm = EbpfVm::new($executable.as_ref(), &mut [], &mut mem).unwrap();
             $(test_interpreter_and_jit!(bind, vm, $location => $syscall_function; $syscall_context_object);)*
             let result = vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: $expected_instruction_count });
             assert!(check_closure(&vm, result));
@@ -47,7 +47,7 @@ macro_rules! test_interpreter_and_jit {
             let check_closure = $check;
             let compilation_result = $executable.jit_compile();
             let mut mem = $mem;
-            let mut vm = EbpfVm::new($executable.as_ref(), &mut mem, &[]).unwrap();
+            let mut vm = EbpfVm::new($executable.as_ref(), &mut [], &mut mem).unwrap();
             match compilation_result {
                 Err(err) => assert!(check_closure(&vm, Err(err))),
                 Ok(()) => {
@@ -2738,7 +2738,7 @@ impl SyscallObject<UserError> for NestedVmSyscall {
             {
                 executable.jit_compile().unwrap();
             }
-            let mut vm = EbpfVm::new(executable.as_ref(), mem, &[]).unwrap();
+            let mut vm = EbpfVm::new(executable.as_ref(), &mut [], mem).unwrap();
             vm.bind_syscall_context_object(Box::new(NestedVmSyscall {}), None)
                 .unwrap();
             let mut instruction_meter = TestInstructionMeter { remaining: 6 };
@@ -3416,7 +3416,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     }
     let (instruction_count_interpreter, tracer_interpreter, result_interpreter) = {
         let mut mem = vec![0u8; mem_size];
-        let mut vm = EbpfVm::new(executable.as_ref(), &mut mem, &[]).unwrap();
+        let mut vm = EbpfVm::new(executable.as_ref(), &mut [], &mut mem).unwrap();
         let result_interpreter = vm.execute_program_interpreted(&mut TestInstructionMeter {
             remaining: max_instruction_count,
         });
@@ -3428,7 +3428,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         )
     };
     let mut mem = vec![0u8; mem_size];
-    let mut vm = EbpfVm::new(executable.as_ref(), &mut mem, &[]).unwrap();
+    let mut vm = EbpfVm::new(executable.as_ref(), &mut [], &mut mem).unwrap();
     let result_jit = vm.execute_program_jit(&mut TestInstructionMeter {
         remaining: max_instruction_count,
     });

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -3170,7 +3170,7 @@ fn test_err_unresolved_elf() {
     file.read_to_end(&mut elf).unwrap();
     let config = Config {
         reject_unresolved_syscalls: true,
-        ..Default::default()
+        ..Config::default()
     };
     assert!(
         matches!(<dyn Executable::<UserError, TestInstructionMeter>>::from_elf(&elf, None, config, syscall_registry), Err(EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset))) if symbol == "log_64" && pc == 550 && offset == 4168)

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -51,8 +51,8 @@ fn test_verifier_success() {
         SyscallRegistry::default(),
     )
     .unwrap();
-    let _vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &[]).unwrap();
+    let _vm = EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
+        .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
* Concatenates all read only sections (including the text section) into one
* Requires exactly one heap section
* This way there are always exactly 5 memory regions:
  - **0**: NULL
  - **1**: Program & Constants (read only)
  - **2**: Stack
  - **3**: Heap
  - **4**: Input
* Enforces the memory regions virtual address to be aligned.
* Makes address translation constant time complexity by interpreting the upper half of a pointer as region index.
* Replaces rust call in JIT by x86 native implementation.
* Makes stack frame gaps in VM address space optional / configurable.