### PR TITLE
Fix verifier shift instruction overflows imm value

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -70,8 +70,8 @@ pub enum VerifierError {
     #[error("unknown eBPF opcode {0:#2x} (insn #{1:?})")]
     UnknownOpCode(u8, usize),
     /// Shift with overflow
-    #[error("Shift with overflow at instruction {0}")]
-    ShiftWithOverflow(usize),
+    #[error("Shift with overflow of {0}-bit value by {1} (insn #{2:?})")]
+    ShiftWithOverflow(u64, u64, usize),
     /// Invalid register specified
     #[error("Invalid register specified at instruction {0}")]
     InvalidRegister(usize),
@@ -156,9 +156,10 @@ fn check_registers(insn: &ebpf::Insn, store: bool, insn_ptr: usize) -> Result<()
 }
 
 /// Check that the imm is a valid shift operand
-fn check_imm_shift(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierError> {
-    if insn.imm < 0 || insn.imm as u64 >= 64 {
-        return Err(VerifierError::ShiftWithOverflow(adj_insn_ptr(insn_ptr)));
+fn check_imm_shift(insn: &ebpf::Insn, insn_ptr: usize, imm_bits: u64) -> Result<(), VerifierError> {
+    let shift_by = insn.imm as u64;
+    if insn.imm < 0 || shift_by >= imm_bits {
+        return Err(VerifierError::ShiftWithOverflow(shift_by, imm_bits, adj_insn_ptr(insn_ptr)));
     }
     Ok(())
 }
@@ -229,9 +230,9 @@ pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
             ebpf::OR32_REG   => {},
             ebpf::AND32_IMM  => {},
             ebpf::AND32_REG  => {},
-            ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
             ebpf::LSH32_REG  => {},
-            ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
             ebpf::RSH32_REG  => {},
             ebpf::NEG32      => {},
             ebpf::MOD32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
@@ -240,7 +241,7 @@ pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
             ebpf::XOR32_REG  => {},
             ebpf::MOV32_IMM  => {},
             ebpf::MOV32_REG  => {},
-            ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr, 32)?; },
             ebpf::ARSH32_REG => {},
             ebpf::LE         => { check_imm_endian(&insn, insn_ptr)?; },
             ebpf::BE         => { check_imm_endian(&insn, insn_ptr)?; },
@@ -262,9 +263,9 @@ pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
             ebpf::OR64_REG   => {},
             ebpf::AND64_IMM  => {},
             ebpf::AND64_REG  => {},
-            ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
             ebpf::LSH64_REG  => {},
-            ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
             ebpf::RSH64_REG  => {},
             ebpf::NEG64      => {},
             ebpf::MOD64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
@@ -273,7 +274,7 @@ pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
             ebpf::XOR64_REG  => {},
             ebpf::MOV64_IMM  => {},
             ebpf::MOV64_REG  => {},
-            ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr, 64)?; },
             ebpf::ARSH64_REG => {},
 
             // BPF_JMP class

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -159,7 +159,11 @@ fn check_registers(insn: &ebpf::Insn, store: bool, insn_ptr: usize) -> Result<()
 fn check_imm_shift(insn: &ebpf::Insn, insn_ptr: usize, imm_bits: u64) -> Result<(), VerifierError> {
     let shift_by = insn.imm as u64;
     if insn.imm < 0 || shift_by >= imm_bits {
-        return Err(VerifierError::ShiftWithOverflow(shift_by, imm_bits, adj_insn_ptr(insn_ptr)));
+        return Err(VerifierError::ShiftWithOverflow(
+            shift_by,
+            imm_bits,
+            adj_insn_ptr(insn_ptr),
+        ));
     }
     Ok(())
 }

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -210,3 +210,50 @@ fn test_verifier_err_write_r10() {
     )
     .unwrap();
 }
+
+#[test]
+fn test_verifier_err_all_shift_overflows() {
+    let testcases = [
+        // lsh32_imm
+        ("lsh32 r0, 32", "ShiftWithOverflow(32, 32, 29)"),
+        ("lsh32 r0, 42", "ShiftWithOverflow(42, 32, 29)"),
+
+        // rsh32_imm
+        ("rsh32 r0, 32", "ShiftWithOverflow(32, 32, 29)"),
+        ("rsh32 r0, 42", "ShiftWithOverflow(42, 32, 29)"),
+
+        // arsh32_imm
+        ("arsh32 r0, 32", "ShiftWithOverflow(32, 32, 29)"),
+        ("arsh32 r0, 42", "ShiftWithOverflow(42, 32, 29)"),
+
+        // lsh64_imm
+        ("lsh64 r0, 64", "ShiftWithOverflow(64, 64, 29)"),
+        ("lsh64 r0, 250", "ShiftWithOverflow(250, 64, 29)"),
+
+        // rsh64_imm
+        ("rsh64 r0, 64", "ShiftWithOverflow(64, 64, 29)"),
+        ("rsh64 r0, 250", "ShiftWithOverflow(250, 64, 29)"),
+
+        // arsh64_imm
+        ("arsh64 r0, 64", "ShiftWithOverflow(64, 64, 29)"),
+        ("arsh64 r0, 250", "ShiftWithOverflow(250, 64, 29)"),
+    ];
+
+    for (overflowing_instruction, overflow_msg) in testcases {
+        let code = format!("\n{}\nexit", overflowing_instruction);
+        let expected_err = format!("Executable constructor VerifierError({})", overflow_msg);
+
+        let result = assemble::<UserError, TestInstructionMeter>(
+            &code,
+            Some(check),
+            Config::default(),
+            SyscallRegistry::default(),
+        );
+
+        match result {
+            Err(err) => { assert_eq!(err, expected_err); }
+            _ => { panic!("Incorrect test result"); }
+        }
+    }
+}
+

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -217,23 +217,18 @@ fn test_verifier_err_all_shift_overflows() {
         // lsh32_imm
         ("lsh32 r0, 32", "ShiftWithOverflow(32, 32, 29)"),
         ("lsh32 r0, 42", "ShiftWithOverflow(42, 32, 29)"),
-
         // rsh32_imm
         ("rsh32 r0, 32", "ShiftWithOverflow(32, 32, 29)"),
         ("rsh32 r0, 42", "ShiftWithOverflow(42, 32, 29)"),
-
         // arsh32_imm
         ("arsh32 r0, 32", "ShiftWithOverflow(32, 32, 29)"),
         ("arsh32 r0, 42", "ShiftWithOverflow(42, 32, 29)"),
-
         // lsh64_imm
         ("lsh64 r0, 64", "ShiftWithOverflow(64, 64, 29)"),
         ("lsh64 r0, 250", "ShiftWithOverflow(250, 64, 29)"),
-
         // rsh64_imm
         ("rsh64 r0, 64", "ShiftWithOverflow(64, 64, 29)"),
         ("rsh64 r0, 250", "ShiftWithOverflow(250, 64, 29)"),
-
         // arsh64_imm
         ("arsh64 r0, 64", "ShiftWithOverflow(64, 64, 29)"),
         ("arsh64 r0, 250", "ShiftWithOverflow(250, 64, 29)"),
@@ -251,9 +246,12 @@ fn test_verifier_err_all_shift_overflows() {
         );
 
         match result {
-            Err(err) => { assert_eq!(err, expected_err); }
-            _ => { panic!("Incorrect test result"); }
+            Err(err) => {
+                assert_eq!(err, expected_err);
+            }
+            _ => {
+                panic!("Incorrect test result");
+            }
         }
     }
 }
-


### PR DESCRIPTION
Before this commit, the verifier didn't properly check against shift overflows in instructions that operate on 32-bit registers. Those instructions are: `lsh32_imm`, `rsh32_imm` and `arsh32_imm`.

For those instructions, the verifier used the same check for shift overflow as for instructions that operate on 64-bit registers: it called the `check_imm_shift(&insn, insn_ptr)` function, which was implemented in the following way:
```rust
/// Check that the imm is a valid shift operand
fn check_imm_shift(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierError> {
    if insn.imm < 0 || insn.imm as u64 >= 64 {
        return Err(VerifierError::ShiftWithOverflow(adj_insn_ptr(insn_ptr)));
    }
    Ok(())
}
```

Note that here, we ensure the argument is not below 0 (`insn.imm < 0`) and that it is not greater or equal than 64 (`insn.imm as u64 >= 64`).

This check is incorrect for 32-bit versions of shift instructions which won't be marked with shift overflow for arguments in range [32, 63].

This can be problematic as shifting by more bits than the register size can lead to UB.

Please note that this bug can't be triggered with current Solana examples (https://github.com/solana-labs/example-helloworld/tree/52b0f1afb90ccb1af28c1c25030366e27a1e9834). This is because:
1) The Rust compiler won't allow for such shift overflow
2) The C compiler warns about it and the C example is compiled with the `-Werror` flag which makes the overflowing shift an error

However, this of course doesn't prevent the bytecode itself from having such invalid and overflowing shift value and so this commit fixes it making the verifier to check against those cases.