### PR TITLE
Remove disabled infinite loop check

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -121,9 +121,6 @@ fn check_load_dw(prog: &[u8], insn_ptr: usize) -> Result<(), VerifierError> {
 
 fn check_jmp_offset(prog: &[u8], insn_ptr: usize) -> Result<(), VerifierError> {
     let insn = ebpf::get_insn(prog, insn_ptr);
-    // if insn.off == -1 {
-    //     return Err(VerifierError::InfiniteLoop(adj_insn_ptr(insn_ptr)).into());
-    // }
 
     let dst_insn_ptr = insn_ptr as isize + 1 + insn.off as isize;
     if dst_insn_ptr < 0 || dst_insn_ptr as usize >= (prog.len() / ebpf::INSN_SIZE) {


### PR DESCRIPTION
The infinite loop check in the BPF verifier just checked for a tight infinite loop (jump to same current PC) which doesn't actually protect execution from malicious behavior be any infinite loop will have the same effect.  And, keeping the check in would reject any new or existing program from containing a jump to present PC even if it is in dead code.

Remove the remnants of this check because the compute meter protects against infinite programs and adding this check could break existing programs.