### PR TITLE
fix generates Control Flow generation

### DIFF
--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -607,8 +607,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
                         .collect::<Vec<String>>()
                         .join(" ")
                 )?;
-            } else {
-                let dynamic_analysis = dynamic_analysis.unwrap();
+            } else if let Some(dynamic_analysis) = dynamic_analysis {
                 for (destination, counter) in edges {
                     write!(output, "  lbb_{} -> ", cfg_node_start)?;
                     if function_range.contains(&destination) {


### PR DESCRIPTION
dynamic_analysis is already unwrapped, 

currently that code produces:
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', solana_rbpf-0.2.14/src/static_analysis.rs:611:57
```