### PR TITLE
Bump to v0.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "byteorder 1.2.7",
  "combine",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "libc",
  "solana_rbpf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana_rbpf"
-version = "0.2.14"
+version = "0.2.15"
 description = "Virtual machine and JIT compiler for eBPF programs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/rbpf"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ so it should work out of the box by adding it as a dependency in your
 
 ```toml
 [dependencies]
-solana_rbpf = "0.2.14"
+solana_rbpf = "0.2.15"
 ```
 
 You can also use the development version from this GitHub repository. This

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf_cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "clap",
  "solana_rbpf",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "byteorder",
  "combine",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "libc",
  "solana_rbpf",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbpf_cli"
-version = "0.2.14"
+version = "0.2.15"
 description = "CLI to test and analyze eBPF programs"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/rbpf"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,7 +37,7 @@ impl SyscallObject<UserError> for MockSyscall {
 
 fn main() {
     let matches = App::new("Solana RBPF CLI")
-        .version("0.2.14")
+        .version("0.2.15")
         .author("Solana Maintainers <maintainers@solana.foundation>")
         .about("CLI to test and analyze eBPF programs")
         .arg(

--- a/test_utils/Cargo.lock
+++ b/test_utils/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "byteorder",
  "combine",
@@ -213,6 +213,7 @@ dependencies = [
  "scroll",
  "thiserror",
  "time",
+ "version_check",
 ]
 
 [[package]]
@@ -228,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "libc",
  "solana_rbpf",
@@ -279,6 +280,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_utils"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
- Fix R_BPF_64_64 relocation handling (#225)
- Fixes the build of the CLI tool. (#224)
- Clearify error message MultipleTextSections => NotOneTextSection. (#223)
- Remove disabled infinite loop check (#219)
- Fix tests to pass on non-X86_64 architectures (#218)
- Fix Beta CI Tests (#216)
- Make disassembler output more readable (#215)
- Makes #212 configurable for feature gate. (#213)
- Fix verifier shift instruction overflows imm value (#212)