### PR TITLE
Fix: Bytes at end of instruction stream

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -943,8 +943,8 @@ impl JitCompiler {
 
         // Scan through program to find actual number of instructions
         let mut pc = 0;
-        while pc * ebpf::INSN_SIZE < _program.len() {
-            let insn = ebpf::get_insn(_program, pc);
+        while (pc + 1) * ebpf::INSN_SIZE <= _program.len() {
+            let insn = ebpf::get_insn_unchecked(_program, pc);
             pc += match insn.opc {
                 ebpf::LD_DW_IMM => 2,
                 _ => 1,
@@ -996,7 +996,7 @@ impl JitCompiler {
         self.generate_exception_handlers::<E>()?;
 
         while self.pc * ebpf::INSN_SIZE < program.len() {
-            let mut insn = ebpf::get_insn(program, self.pc);
+            let mut insn = ebpf::get_insn_unchecked(program, self.pc);
 
             self.result.pc_section[self.pc] = self.offset_in_text_section as u64;
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -108,7 +108,7 @@ fn check_imm_endian(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierEr
 }
 
 fn check_load_dw(prog: &[u8], insn_ptr: usize) -> Result<(), VerifierError> {
-    if insn_ptr + 1 >= (prog.len() / ebpf::INSN_SIZE) {
+    if (insn_ptr + 1) * ebpf::INSN_SIZE >= prog.len() {
         // Last instruction cannot be LD_DW because there would be no 2nd DW
         return Err(VerifierError::LDDWCannotBeLast);
     }
@@ -123,7 +123,7 @@ fn check_jmp_offset(prog: &[u8], insn_ptr: usize) -> Result<(), VerifierError> {
     let insn = ebpf::get_insn(prog, insn_ptr);
 
     let dst_insn_ptr = insn_ptr as isize + 1 + insn.off as isize;
-    if dst_insn_ptr < 0 || dst_insn_ptr as usize >= (prog.len() / ebpf::INSN_SIZE) {
+    if dst_insn_ptr < 0 || dst_insn_ptr as usize * ebpf::INSN_SIZE >= prog.len() {
         return Err(VerifierError::JumpOutOfCode(
             dst_insn_ptr as usize,
             adj_insn_ptr(insn_ptr),
@@ -179,7 +179,7 @@ pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
     check_prog_len(prog)?;
 
     let mut insn_ptr: usize = 0;
-    while insn_ptr * ebpf::INSN_SIZE < prog.len() {
+    while (insn_ptr + 1) * ebpf::INSN_SIZE <= prog.len() {
         let insn = ebpf::get_insn(prog, insn_ptr);
         let mut store = false;
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -701,7 +701,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         let initial_insn_count = remaining_insn_count;
         self.last_insn_count = 0;
         let mut total_insn_count = 0;
-        while next_pc * ebpf::INSN_SIZE + ebpf::INSN_SIZE <= self.program.len() {
+        while (next_pc + 1) * ebpf::INSN_SIZE <= self.program.len() {
             let pc = next_pc;
             next_pc += 1;
             let mut insn = ebpf::get_insn_unchecked(self.program, pc);


### PR DESCRIPTION
Makes the handling of superfluous bytes (modulo rest of program length divided by instruction size) consistent.