### PR TITLE
Removes the Executable dyn Trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,6 @@ dependencies = [
  "test_utils",
  "thiserror",
  "time",
- "version_check",
 ]
 
 [[package]]
@@ -303,12 +302,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,3 @@ rustc-demangle = "0.1"
 elf = "0.0.10"
 json = "0.11"
 test_utils = { path = "test_utils/" }
-
-[build-dependencies]
-version_check = "0.9"

--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -11,9 +11,10 @@ extern crate test;
 extern crate test_utils;
 
 use solana_rbpf::{
+    elf::Executable,
     syscalls::BpfSyscallU64,
     user_error::UserError,
-    vm::{Config, Executable, SyscallObject, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -32,7 +33,7 @@ fn bench_load_elf(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        <dyn Executable<UserError, TestInstructionMeter>>::from_elf(
+        Executable::<UserError, TestInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -48,7 +49,7 @@ fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_elf(
+        let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -65,7 +66,7 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_elf(
+        let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -10,8 +10,9 @@ extern crate solana_rbpf;
 extern crate test;
 
 use solana_rbpf::{
+    elf::Executable,
     user_error::UserError,
-    vm::{Config, EbpfVm, Executable, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -21,7 +22,7 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_elf(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
         None,
         Config::default(),
@@ -29,8 +30,7 @@ fn bench_init_vm(bencher: &mut Bencher) {
     )
     .unwrap();
     bencher.iter(|| {
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
-            .unwrap()
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap()
     });
 }
 
@@ -40,7 +40,7 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let mut executable = <dyn Executable<UserError, TestInstructionMeter>>::from_elf(
+    let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
         None,
         Config::default(),

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-extern crate version_check as rustc;
-
-fn main() {
-    if rustc::is_min_version("1.56.0").unwrap_or(false) {
-        println!("cargo:rustc-cfg=vtable_send_sync_plus_one");
-    }
-}

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -6,9 +6,10 @@
 
 extern crate solana_rbpf;
 use solana_rbpf::{
+    elf::Executable,
     static_analysis::Analysis,
     user_error::UserError,
-    vm::{Config, Executable, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
 
@@ -30,7 +31,7 @@ fn main() {
         0x00, 0x00, 0x00, 0x00, 0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x95, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00,
     ];
-    let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         &program,
         None,
         Config::default(),
@@ -38,7 +39,7 @@ fn main() {
         BTreeMap::default(),
     )
     .unwrap();
-    let analysis = Analysis::from_executable(executable.as_ref());
+    let analysis = Analysis::from_executable(&executable);
     let stdout = std::io::stdout();
     analysis.disassemble(&mut stdout.lock()).unwrap();
 }

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -13,9 +13,10 @@ use std::path::PathBuf;
 extern crate solana_rbpf;
 use solana_rbpf::{
     disassembler::disassemble_instruction,
+    elf::Executable,
     static_analysis::Analysis,
     user_error::UserError,
-    vm::{Config, Executable, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
 // Turn a program into a JSON string.
@@ -28,7 +29,7 @@ use std::collections::BTreeMap;
 // * Print integers as integers, and not as strings containing their hexadecimal representation
 //   (just replace the relevant `format!()` calls by the commented values.
 fn to_json(program: &[u8]) -> String {
-    let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         &program,
         None,
         Config::default(),
@@ -36,7 +37,7 @@ fn to_json(program: &[u8]) -> String {
         BTreeMap::default(),
     )
     .unwrap();
-    let analysis = Analysis::from_executable(executable.as_ref());
+    let analysis = Analysis::from_executable(&executable);
 
     let mut json_insns = vec![];
     for insn in analysis.instructions.iter() {

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -6,9 +6,10 @@
 
 extern crate solana_rbpf;
 use solana_rbpf::{
+    elf::Executable,
     syscalls,
     user_error::UserError,
-    vm::{Config, EbpfVm, Executable, SyscallObject, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
 
@@ -43,7 +44,7 @@ fn main() {
     ];
 
     // Create a VM: this one takes no data. Load prog1 in it.
-    let executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog1,
         None,
         Config::default(),
@@ -52,8 +53,7 @@ fn main() {
     )
     .unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
-            .unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
     // Execute prog1.
     assert_eq!(
         vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 5 })
@@ -76,7 +76,7 @@ fn main() {
         )
         .unwrap();
     #[allow(unused_mut)]
-    let mut executable = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog2,
         None,
         Config::default(),
@@ -89,8 +89,7 @@ fn main() {
         executable.jit_compile().unwrap();
     }
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
-            .unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
     vm.bind_syscall_context_object(Box::new(syscalls::BpfTimeGetNs {}), None)
         .unwrap();
 

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -17,9 +17,9 @@ use crate::{
         Statement,
     },
     ebpf::{self, Insn},
-    elf::register_bpf_function,
+    elf::{register_bpf_function, Executable},
     error::UserDefinedError,
-    vm::{Config, Executable, InstructionMeter, SyscallRegistry, Verifier},
+    vm::{Config, InstructionMeter, SyscallRegistry, Verifier},
 };
 use std::collections::{BTreeMap, HashMap};
 
@@ -216,7 +216,7 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     verifier: Option<Verifier>,
     config: Config,
     syscall_registry: SyscallRegistry,
-) -> Result<Box<dyn Executable<E, I>>, String> {
+) -> Result<Executable<E, I>, String> {
     fn resolve_label(
         insn_ptr: usize,
         labels: &HashMap<&str, usize>,
@@ -360,12 +360,6 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
         .map(|insn| insn.to_vec())
         .flatten()
         .collect::<Vec<_>>();
-    <dyn Executable<E, I>>::from_text_bytes(
-        &program,
-        verifier,
-        config,
-        syscall_registry,
-        bpf_functions,
-    )
-    .map_err(|err| format!("Executable constructor {:?}", err))
+    Executable::<E, I>::from_text_bytes(&program, verifier, config, syscall_registry, bpf_functions)
+        .map_err(|err| format!("Executable constructor {:?}", err))
 }

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -2,10 +2,10 @@
 
 use crate::disassembler::disassemble_instruction;
 use crate::{
-    ebpf, elf,
+    ebpf,
+    elf::{self, Executable},
     error::UserDefinedError,
-    vm::InstructionMeter,
-    vm::{DynamicAnalysis, Executable},
+    vm::{DynamicAnalysis, InstructionMeter},
 };
 use rustc_demangle::demangle;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -93,7 +93,7 @@ impl Default for CfgNode {
 /// Result of the executable analysis
 pub struct Analysis<'a, E: UserDefinedError, I: InstructionMeter> {
     /// The program which is analyzed
-    pub executable: &'a dyn Executable<E, I>,
+    pub executable: &'a Executable<E, I>,
     /// Plain list of instructions as they occur in the executable
     pub instructions: Vec<ebpf::Insn>,
     /// Functions in the executable
@@ -112,7 +112,7 @@ pub struct Analysis<'a, E: UserDefinedError, I: InstructionMeter> {
 
 impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
     /// Analyze an executable statically
-    pub fn from_executable(executable: &'a dyn Executable<E, I>) -> Self {
+    pub fn from_executable(executable: &'a Executable<E, I>) -> Self {
         let (_program_vm_addr, program) = executable.get_text_bytes();
         let functions = executable.get_function_symbols();
         debug_assert!(

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -25,7 +25,7 @@ macro_rules! disasm {
             SyscallRegistry::default(),
         )
         .unwrap();
-        let analysis = Analysis::from_executable(executable.as_ref());
+        let analysis = Analysis::from_executable(&executable);
         let mut reasm = Vec::new();
         analysis.disassemble(&mut reasm).unwrap();
         assert_eq!(src, String::from_utf8(reasm).unwrap());

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -24,10 +24,11 @@ extern crate thiserror;
 
 use solana_rbpf::{
     assembler::assemble,
+    elf::Executable,
     error::UserDefinedError,
     user_error::UserError,
     verifier::{check, VerifierError},
-    vm::{Config, EbpfVm, Executable, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -51,8 +52,8 @@ fn test_verifier_success() {
         SyscallRegistry::default(),
     )
     .unwrap();
-    let _vm = EbpfVm::<UserError, TestInstructionMeter>::new(executable.as_ref(), &mut [], &mut [])
-        .unwrap();
+    let _vm =
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
 }
 
 #[test]
@@ -95,7 +96,7 @@ fn test_verifier_err_endian_size() {
         0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let _ = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
         Some(check),
         Config::default(),
@@ -113,7 +114,7 @@ fn test_verifier_err_incomplete_lddw() {
         0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let _ = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
         Some(check),
         Config::default(),
@@ -187,7 +188,7 @@ fn test_verifier_err_unknown_opcode() {
         0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = <dyn Executable<UserError, TestInstructionMeter>>::from_text_bytes(
+    let _ = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
         Some(check),
         Config::default(),


### PR DESCRIPTION
in order to remove the workaround hacks (`vtable_send_sync_plus_one` and `REPORT_UNRESOLVED_SYMBOL_INDEX`) related to it.