### PR TITLE
Adds vm::Config::reject_section_virtual_address_file_offset_mismatch

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -374,7 +374,10 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
             vaddr: text_section.sh_addr.saturating_add(ebpf::MM_PROGRAM_START),
             offset_range: text_section.file_range().unwrap_or_default(),
         };
-        if text_section_info.vaddr > ebpf::MM_STACK_START {
+        if (config.reject_section_virtual_address_file_offset_mismatch
+            && text_section.sh_addr != text_section.sh_offset)
+            || text_section_info.vaddr > ebpf::MM_STACK_START
+        {
             return Err(ElfError::ValueOutOfBounds);
         }
 
@@ -414,7 +417,10 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
                 let vaddr = section_header
                     .sh_addr
                     .saturating_add(ebpf::MM_PROGRAM_START);
-                if vaddr > ebpf::MM_STACK_START {
+                if (config.reject_section_virtual_address_file_offset_mismatch
+                    && section_header.sh_addr != section_header.sh_offset)
+                    || vaddr > ebpf::MM_STACK_START
+                {
                     return Err(ElfError::ValueOutOfBounds);
                 }
                 let slice = elf_bytes

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -189,6 +189,8 @@ pub struct Config {
     pub enable_instruction_tracing: bool,
     /// Reject ELF files containing syscalls which are not in the SyscallRegistry
     pub reject_unresolved_syscalls: bool,
+    /// Reject ELF files containing section headers where sh_addr != sh_offset
+    pub reject_section_virtual_address_file_offset_mismatch: bool,
     /// Ratio of random no-ops per instruction in JIT (0.0 = OFF)
     pub noop_instruction_ratio: f64,
     /// Enable disinfection of immediate values and offsets provided by the user in JIT
@@ -210,6 +212,7 @@ impl Default for Config {
             enable_instruction_meter: true,
             enable_instruction_tracing: false,
             reject_unresolved_syscalls: false,
+            reject_section_virtual_address_file_offset_mismatch: false,
             noop_instruction_ratio: 1.0 / 256.0,
             sanitize_user_provided_values: true,
             encrypt_environment_registers: true,


### PR DESCRIPTION
To enforce a direct mapping of file offset and virtual address space.