### PR TITLE
Make symbol and section labels optional

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -117,6 +117,7 @@ fn main() {
 
     let config = Config {
         enable_instruction_tracing: matches.is_present("trace") || matches.is_present("profile"),
+        enable_symbol_and_section_labels: true,
         ..Config::default()
     };
     let verifier: Option<for<'r> fn(&'r [u8], &Config) -> std::result::Result<_, _>> =
@@ -126,9 +127,6 @@ fn main() {
             None
         };
     let syscall_registry = SyscallRegistry::default();
-    /*for hash in syscalls.keys() {
-        let _ = syscall_registry.register_syscall_by_hash(*hash, MockSyscall::call);
-    }*/
     let mut executable = match matches.value_of("assembler") {
         Some(asm_file_name) => {
             let mut file = File::open(&Path::new(asm_file_name)).unwrap();

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -241,7 +241,7 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
                 .get(label)
                 .ok_or_else(|| format!("Label not found {}", label))?
         };
-        let hash = register_bpf_function(bpf_functions, target_pc, label)
+        let hash = register_bpf_function(bpf_functions, target_pc, label, true)
             .map_err(|_| format!("Label hash collision {}", label))?;
         Ok(hash as i32 as i64)
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -187,6 +187,8 @@ pub struct Config {
     pub enable_instruction_meter: bool,
     /// Enable instruction tracing
     pub enable_instruction_tracing: bool,
+    /// Enable dynamic string allocation for labels
+    pub enable_symbol_and_section_labels: bool,
     /// Reject ELF files containing syscalls which are not in the SyscallRegistry
     pub reject_unresolved_syscalls: bool,
     /// Reject ELF files containing section headers where sh_addr != sh_offset
@@ -211,6 +213,7 @@ impl Default for Config {
             instruction_meter_checkpoint_distance: 10000,
             enable_instruction_meter: true,
             enable_instruction_tracing: false,
+            enable_symbol_and_section_labels: false,
             reject_unresolved_syscalls: false,
             reject_section_virtual_address_file_offset_mismatch: false,
             noop_instruction_ratio: 1.0 / 256.0,
@@ -432,7 +435,7 @@ macro_rules! translate_memory_access {
 ///
 /// // Instantiate a VM.
 /// let mut bpf_functions = std::collections::BTreeMap::new();
-/// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+/// register_bpf_function(&mut bpf_functions, 0, "entrypoint", false).unwrap();
 /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, Config::default(), SyscallRegistry::default(), bpf_functions).unwrap();
 /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], mem).unwrap();
 ///
@@ -468,7 +471,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     ///
     /// // Instantiate a VM.
     /// let mut bpf_functions = std::collections::BTreeMap::new();
-    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint", false).unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, Config::default(), SyscallRegistry::default(), bpf_functions).unwrap();
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
     /// ```
@@ -558,7 +561,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// syscall_registry.register_syscall_by_hash(6, BpfTracePrintf::call).unwrap();
     /// // Instantiate an Executable and VM
     /// let mut bpf_functions = std::collections::BTreeMap::new();
-    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint", false).unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, Config::default(), syscall_registry, bpf_functions).unwrap();
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
     /// // Bind a context object instance to the previously registered syscall
@@ -622,7 +625,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     ///
     /// // Instantiate a VM.
     /// let mut bpf_functions = std::collections::BTreeMap::new();
-    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    /// register_bpf_function(&mut bpf_functions, 0, "entrypoint", false).unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, Config::default(), SyscallRegistry::default(), bpf_functions).unwrap();
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], mem).unwrap();
     ///

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -3395,7 +3395,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     let max_instruction_count = 1024;
     let mem_size = 1024 * 1024;
     let mut bpf_functions = BTreeMap::new();
-    register_bpf_function(&mut bpf_functions, 0, "entrypoint").unwrap();
+    register_bpf_function(&mut bpf_functions, 0, "entrypoint", false).unwrap();
     let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
         Some(check),


### PR DESCRIPTION
There is no need for having symbol and section labels outside of debugging and the CLI tool.