### PR TITLE
CI: Deny clippy::integer_arithmetic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Lint
       run: |
         cargo fmt --all -- --check
-        cargo clippy --all --tests -- --deny=warnings
+        cargo clippy --all --tests -- --deny=warnings --deny=clippy::integer_arithmetic
       shell: bash
     - name: Build and test
       run: |

--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Aligned memory
 
 /// Provides u8 slices at a specified alignment

--- a/src/asm_parser.rs
+++ b/src/asm_parser.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Call frame handler
 
 use crate::{

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2017 6WIND S.A. <quentin.monnet@6wind.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! This module relocates a BPF ELF
 
 // Note: Typically ELF shared objects are loaded using the program headers and

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2017 Alex Dukhno <alex.dukhno@icloud.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: JIT algorithm, originally in C)

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! This module defines memory regions
 
 use crate::{

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Static Byte Code Analysis
 
 use crate::disassembler::disassemble_instruction;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2015 Big Switch Networks, Inc
 //      (Algorithms for uBPF syscalls, originally in C)
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: safety checks, originally in C)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: VM architecture, parts of the interpreter, originally in C)

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use crate::{
     error::{EbpfError, UserDefinedError},
     jit::{emit, emit_variable_length, JitCompiler, OperandSize},

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Copyright 2020 Solana Maintainers <maintainers@solana.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or


### PR DESCRIPTION
But explicitly allow it in each source file so that we can eliminate unchecked integer arithmetic step by step.