### PR TITLE
Wrapes Executable in a Pin Box

### DIFF
--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -47,5 +47,7 @@ fn bench_jit_compile(bencher: &mut Bencher) {
         SyscallRegistry::default(),
     )
     .unwrap();
-    bencher.iter(|| executable.jit_compile().unwrap());
+    bencher.iter(|| {
+        Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap()
+    });
 }

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -50,7 +50,7 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
         SyscallRegistry::default(),
     )
     .unwrap();
-    executable.jit_compile().unwrap();
+    Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     let mut vm =
         EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
     bencher.iter(|| {
@@ -73,7 +73,7 @@ fn bench_jit_vs_interpreter(
         SyscallRegistry::default(),
     )
     .unwrap();
-    executable.jit_compile().unwrap();
+    Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     let mut vm = EbpfVm::new(&executable, &mut [], mem).unwrap();
     let interpreter_summary = bencher
         .bench(|bencher| {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
         }
     }
     .unwrap();
-    executable.jit_compile().unwrap();
+    Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     let analysis = Analysis::from_executable(&executable);
 
     match matches.value_of("use") {

--- a/examples/uptime.rs
+++ b/examples/uptime.rs
@@ -86,7 +86,7 @@ fn main() {
     .unwrap();
     #[cfg(not(windows))]
     {
-        executable.jit_compile().unwrap();
+        Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     }
     let mut vm =
         EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -22,7 +22,10 @@ use crate::{
     error::UserDefinedError,
     vm::{Config, InstructionMeter, SyscallRegistry, Verifier},
 };
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    pin::Pin,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum InstructionType {
@@ -217,7 +220,7 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     verifier: Option<Verifier>,
     config: Config,
     syscall_registry: SyscallRegistry,
-) -> Result<Executable<E, I>, String> {
+) -> Result<Pin<Box<Executable<E, I>>>, String> {
     fn resolve_label(
         insn_ptr: usize,
         labels: &HashMap<&str, usize>,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -21,7 +21,7 @@ use goblin::{
     elf::{header::*, reloc::*, section_header::*, Elf},
     error::Error as GoblinError,
 };
-use std::{collections::BTreeMap, fmt::Debug, mem, ops::Range, str};
+use std::{collections::BTreeMap, fmt::Debug, mem, ops::Range, pin::Pin, str};
 
 /// Error definitions
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -285,8 +285,9 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
     }
 
     /// JIT compile the executable
-    pub fn jit_compile(&mut self) -> Result<(), EbpfError<E>> {
-        self.compiled_program = Some(JitProgram::<E, I>::new(self)?);
+    pub fn jit_compile(executable: &mut Pin<Box<Self>>) -> Result<(), EbpfError<E>> {
+        // TODO: Turn back to `executable: &mut self` once Self::report_unresolved_symbol() is gone
+        executable.compiled_program = Some(JitProgram::<E, I>::new(executable)?);
         Ok(())
     }
 

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -46,7 +46,7 @@ macro_rules! test_interpreter_and_jit {
         #[cfg(all(not(windows), target_arch = "x86_64"))]
         {
             let check_closure = $check;
-            let compilation_result = $executable.jit_compile();
+            let compilation_result = Executable::<UserError, TestInstructionMeter>::jit_compile(&mut $executable);
             let mut mem = $mem;
             let mut vm = EbpfVm::new(&$executable, &mut [], &mut mem).unwrap();
             match compilation_result {
@@ -2737,7 +2737,8 @@ impl SyscallObject<UserError> for NestedVmSyscall {
             .unwrap();
             #[cfg(all(not(windows), target_arch = "x86_64"))]
             {
-                executable.jit_compile().unwrap();
+                Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable)
+                    .unwrap();
             }
             let mut vm = EbpfVm::new(&executable, &mut [], mem).unwrap();
             vm.bind_syscall_context_object(Box::new(NestedVmSyscall {}), None)
@@ -3412,7 +3413,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     } else {
         return false;
     };
-    if executable.jit_compile().is_err() {
+    if Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).is_err() {
         return false;
     }
     let (instruction_count_interpreter, tracer_interpreter, result_interpreter) = {


### PR DESCRIPTION
#231 removed the fat-ptr and its instance pointer which had a stable location.

So this PR prevents the pointer of the `Executable` struct changing after loading and compilation by always heap allocating it.