### PR TITLE
Performance: JIT syscall

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1329,6 +1329,7 @@ impl JitCompiler {
 
         // Routine for syscall
         set_anchor(self, TARGET_PC_SYSCALL);
+        X86Instruction::push(R11, None).emit(self)?; // Padding for stack alignment
         if self.config.enable_instruction_meter {
             // RDI = *PrevInsnMeter - RDI;
             emit_alu(self, OperandSize::S64, 0x2B, ARGUMENT_REGISTERS[0], RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::PrevInsnMeter))))?; // RDI -= *PrevInsnMeter;
@@ -1354,6 +1355,7 @@ impl JitCompiler {
             ], Some(ARGUMENT_REGISTERS[0]), false)?;
             X86Instruction::store(OperandSize::S64, ARGUMENT_REGISTERS[0], RBP, X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::PrevInsnMeter))).emit(self)?;
         }
+        X86Instruction::pop(R11).emit(self)?;
         // Store Ok value in result register
         X86Instruction::load(OperandSize::S64, RBP, R11, X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::OptRetValPtr))).emit(self)?;
         X86Instruction::load(OperandSize::S64, R11, REGISTER_MAP[0], X86IndirectAccess::Offset(8)).emit(self)?;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -930,7 +930,7 @@ impl JitCompiler {
             };
         }
 
-        let mut code_length_estimate = pc * 256 + 4096;
+        let mut code_length_estimate = pc * 110 + 4096;
         code_length_estimate += (code_length_estimate as f64 * _config.noop_instruction_ratio) as usize;
         let mut diversification_rng = SmallRng::from_rng(rand::thread_rng()).unwrap();
         let (environment_stack_key, program_argument_key) = 


### PR DESCRIPTION
Similar to #252 but for `syscall`, instead of `call imm` and `call reg`.

- Makes the `dst` parameter of `emit_rust_call()` more similar to `emit_bpf_call()`.
- Removes support for user_provided values in `emit_rust_call()` as that is never used.
- Change `Argument::emit_pass()` to work without using `R11` (for arguments on the stack).
- Separate the PC specific code in syscall and factors out the instruction meter, rust call and result retrieval code.
- Optimize instruction meter around syscall.
- Reduce `code_length_estimate` from 256 bytes per instruction to 110.