### PR TITLE
Fix: Don't munmap nothing

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -361,8 +361,7 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     }
     let program = instructions
         .iter()
-        .map(|insn| insn.to_vec())
-        .flatten()
+        .flat_map(|insn| insn.to_vec())
         .collect::<Vec<_>>();
     Executable::<E, I>::from_text_bytes(&program, verifier, config, syscall_registry, bpf_functions)
         .map_err(|err| format!("Executable constructor {:?}", err))

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -505,32 +505,31 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
     pub fn mem_size(&self) -> usize {
         let total = mem::size_of::<Self>()
             // elf bytres
-            .saturating_add(self.elf_bytes.mem_size()
+            .saturating_add(self.elf_bytes.mem_size())
             // ro section
-            .saturating_add(self.ro_section.capacity()
+            .saturating_add(self.ro_section.capacity())
             // text section info
-            .saturating_add(self.text_section_info.mem_size()
+            .saturating_add(self.text_section_info.mem_size())
             // bpf functions
-            .saturating_add(mem::size_of_val(&self.bpf_functions)
+            .saturating_add(mem::size_of_val(&self.bpf_functions))
             .saturating_add(self.bpf_functions
             .iter()
             .fold(0, |state: usize, (_, (val, name))| state
                 .saturating_add(mem::size_of_val(&val)
                 .saturating_add(mem::size_of_val(&name)
-                .saturating_add(name.capacity()))))
+                .saturating_add(name.capacity())))))
             // syscall symbols
-            .saturating_add(mem::size_of_val(&self.syscall_symbols)
+            .saturating_add(mem::size_of_val(&self.syscall_symbols))
             .saturating_add(self.syscall_symbols
             .iter()
             .fold(0, |state: usize, (val, name)| state
                 .saturating_add(mem::size_of_val(&val)
                 .saturating_add(mem::size_of_val(&name)
-                .saturating_add(name.capacity()))))
+                .saturating_add(name.capacity())))))
             // syscall registry
-            .saturating_add(self.syscall_registry.mem_size()
+            .saturating_add(self.syscall_registry.mem_size())
             // compiled programs
-            .saturating_add(self.compiled_program.as_ref().map_or(0, |program| program.mem_size()
-        ))))))))));
+            .saturating_add(self.compiled_program.as_ref().map_or(0, |program| program.mem_size()));
 
         total as usize
     }

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -35,24 +35,28 @@ pub trait Instruction: Sized {
     }
 
     /// sets destination register
+    #[must_use]
     fn set_dst(mut self, dst: u8) -> Self {
         self.get_insn_mut().dst = dst;
         self
     }
 
     /// sets source register
+    #[must_use]
     fn set_src(mut self, src: u8) -> Self {
         self.get_insn_mut().src = src;
         self
     }
 
     /// sets offset bytes
+    #[must_use]
     fn set_off(mut self, offset: i16) -> Self {
         self.get_insn_mut().off = offset;
         self
     }
 
     /// sets immediate value
+    #[must_use]
     fn set_imm(mut self, imm: i64) -> Self {
         self.get_insn_mut().imm = imm;
         self

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -147,7 +147,7 @@ impl Drop for JitProgramSections {
 /// eBPF JIT-compiled program
 pub struct JitProgram<E: UserDefinedError, I: InstructionMeter> {
     /// Holds and manages the protected memory
-    _sections: JitProgramSections,
+    sections: JitProgramSections,
     /// Call this with JitProgramArgument to execute the compiled code
     pub main: unsafe fn(&ProgramResult<E>, u64, &JitProgramArgument, &mut I) -> i64,
 }
@@ -171,14 +171,14 @@ impl<E: UserDefinedError, I: InstructionMeter> JitProgram<E, I> {
         jit.compile::<E, I>(executable)?;
         let main = unsafe { mem::transmute(jit.result.text_section.as_ptr()) };
         Ok(Self {
-            _sections: jit.result,
+            sections: jit.result,
             main,
         })
     }
 
     pub fn mem_size(&self) ->usize{
         mem::size_of::<Self>() +
-        self._sections.mem_size()
+        self.sections.mem_size()
     }
 }
 

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -461,10 +461,10 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> Analysis<'a, E, I> {
     ) -> std::io::Result<()> {
         fn html_escape(string: &str) -> String {
             string
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('\"', "&quot;")
         }
         fn emit_cfg_node<W: std::io::Write, E: UserDefinedError, I: InstructionMeter>(
             output: &mut W,


### PR DESCRIPTION
Don't call `munpam` if the size estimate was correct.