### PR TITLE
Format callx operand as register

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -309,7 +309,7 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
                                 resolve_call(&mut bpf_functions, &labels, &label, Some(target_pc))?;
                             insn(opc, 0, 0, 0, hash as i32 as i64)
                         }
-                        (CallReg, [Integer(imm)]) => insn(opc, 0, 0, 0, *imm),
+                        (CallReg, [Register(dst)]) => insn(opc, 0, 0, 0, *dst),
                         (JumpConditional, [Register(dst), Register(src), Label(label)]) => insn(
                             opc | ebpf::BPF_X,
                             *dst,

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -267,7 +267,7 @@ pub fn disassemble_instruction<E: UserDefinedError, I: InstructionMeter>(insn: &
                 }
             };
         },
-        ebpf::CALL_REG   => { name = "callx"; desc = format!("{} {}", name, insn.imm); },
+        ebpf::CALL_REG   => { name = "callx"; desc = format!("{} r{}", name, insn.imm); },
         ebpf::EXIT       => { name = "exit"; desc = name.to_string(); },
 
         _                => { name = "unknown"; desc = format!("{} opcode={:#x}", name, insn.opc); },

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -120,7 +120,7 @@ fn test_jeq() {
 #[test]
 fn test_call_reg() {
     assert_eq!(
-        asm("callx 3"),
+        asm("callx r3"),
         Ok(vec![insn(0, ebpf::CALL_REG, 0, 0, 0, 3)])
     );
 }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2384,7 +2384,7 @@ fn test_call_reg() {
         mov64 r8, 0x1
         lsh64 r8, 0x20
         or64 r8, 0x30
-        callx 0x8
+        callx r8
         exit
         mov64 r0, 0x2A
         exit",
@@ -2400,7 +2400,7 @@ fn test_err_callx_oob_low() {
     test_interpreter_and_jit_asm!(
         "
         mov64 r0, 0x3
-        callx 0x0
+        callx r0
         exit",
         [],
         (),
@@ -2423,7 +2423,7 @@ fn test_err_callx_oob_high() {
         mov64 r0, -0x1
         lsh64 r0, 0x20
         or64 r0, 0x3
-        callx 0x0
+        callx r0
         exit",
         [],
         (),
@@ -2519,7 +2519,7 @@ fn test_err_dynamic_jmp_lddw() {
         mov64 r8, 0x1
         lsh64 r8, 0x20
         or64 r8, 40
-        callx 0x8
+        callx r8
         lddw r0, 0x1122334455667788
         exit",
         [],
@@ -2579,7 +2579,7 @@ fn test_err_reg_stack_depth() {
         "
         mov64 r0, 0x1
         lsh64 r0, 0x20
-        callx 0x0
+        callx r0
         exit",
         [],
         (),
@@ -2957,7 +2957,7 @@ fn test_tight_infinite_recursion_callx() {
         lsh64 r8, 0x20
         or64 r8, 0x18
         mov64 r3, 0x41414141
-        callx 8
+        callx r8
         exit",
         [],
         (),


### PR DESCRIPTION
The callx instruction takes a register as an operand. The current assembly syntax makes the operand appear as an immediate however. This patch updates the assembly syntax for callx to be in line with other instructions with register operands.