### PR TITLE
Reject `callx r10`

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -213,6 +213,8 @@ pub struct Config {
     pub disable_deprecated_load_instructions: bool,
     /// Throw ElfError::SymbolHashCollision when a BPF function collides with a registered syscall
     pub syscall_bpf_function_hash_collision: bool,
+    /// Have the verifier reject "callx r10"
+    pub reject_callx_r10: bool,
 }
 
 impl Default for Config {
@@ -232,6 +234,7 @@ impl Default for Config {
             encrypt_environment_registers: true,
             disable_deprecated_load_instructions: true,
             syscall_bpf_function_hash_collision: true,
+            reject_callx_r10: true,
         }
     }
 }


### PR DESCRIPTION
`r10` is the stack pointer and generally points in the stack memory region.
`callx` can only jump to addresses in the program memory region.
The two memory regions don't overlap so there is no point in using `callx r10`.