### PR TITLE
jit/x86: add emit_indirect_branch_target

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -866,6 +866,12 @@ fn emit_set_exception_kind<E: UserDefinedError>(jit: &mut JitCompiler, err: Ebpf
     X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(8), err_kind as i64).emit(jit)
 }
 
+#[inline]
+#[allow(unused)]
+fn emit_indirect_branch_target<E: UserDefinedError>(jit: &mut JitCompiler) -> Result<(), EbpfError<E>> {
+    X86Instruction::end_branch().emit(jit)
+}
+
 #[derive(Debug)]
 struct Jump {
     location: usize,
@@ -978,6 +984,22 @@ impl JitCompiler {
             environment_stack_key,
             program_argument_key,
         })
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn new_mock() -> Self {
+        let res = Self::new::<UserError>(&[], &Config {
+            noop_instruction_ratio: 0.0,
+            ..Config::default()
+        });
+        res.expect("failed to create mock JitCompiler")
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn get_text_result(&self) -> &[u8] {
+        self.result.text_section
     }
 
     fn compile<E: UserDefinedError, I: InstructionMeter>(&mut self,


### PR DESCRIPTION
This PR adds the ability to emit the `endbr64` instruction to begin the work on Indirect Branch Tracking (IBT).
This does not introduce any functional changes to the JIT compiler.

The bulk of the work to enable IBT, which involves adding `endbr64`s to code translated from SBF, is not implemented in this PR.

Relates to #287 

Changes

- Adds test-only `JitCompiler::new_mock()` and `JitCompiler::get_text_result()` methods to allow test case assertions on x86-compiled code.
- Add `emit_indirect_branch_target` function to emit `endbr64` per Intel CET.