### PR TITLE
Simplify syscall register and bind

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1032,7 +1032,7 @@ mod test {
         ebpf,
         elf::scroll::Pwrite,
         fuzz::fuzz,
-        syscalls::{BpfSyscallString, BpfSyscallU64},
+        syscalls::{BpfSyscallContext, BpfSyscallString, BpfSyscallU64},
         user_error::UserError,
         vm::{SyscallObject, TestInstructionMeter},
     };
@@ -1043,10 +1043,18 @@ mod test {
     fn syscall_registry() -> SyscallRegistry {
         let mut syscall_registry = SyscallRegistry::default();
         syscall_registry
-            .register_syscall_by_name(b"log", BpfSyscallString::call)
+            .register_syscall_by_name(
+                b"log",
+                BpfSyscallString::init::<BpfSyscallContext, UserError>,
+                BpfSyscallString::call,
+            )
             .unwrap();
         syscall_registry
-            .register_syscall_by_name(b"log_64", BpfSyscallU64::call)
+            .register_syscall_by_name(
+                b"log_64",
+                BpfSyscallU64::init::<BpfSyscallContext, UserError>,
+                BpfSyscallU64::call,
+            )
             .unwrap();
         syscall_registry
     }
@@ -1802,6 +1810,6 @@ mod test {
             Executable::jit_compile(&mut executable).unwrap();
         }
 
-        assert_eq!(18616, executable.mem_size());
+        assert_eq!(18640, executable.mem_size());
     }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -32,6 +32,9 @@ use crate::{
 use libc::c_char;
 use std::{slice::from_raw_parts, str::from_utf8, u64};
 
+/// Test syscall context
+pub type BpfSyscallContext = u64;
+
 /// Return type of syscalls
 pub type Result = std::result::Result<u64, EbpfError<UserError>>;
 
@@ -83,6 +86,12 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 /// This would equally print the three numbers in `/sys/kernel/debug/tracing` file each time the
 /// program is run.
 pub struct BpfTracePrintf {}
+impl BpfTracePrintf {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfTracePrintf {
     fn call(
         &mut self,
@@ -131,6 +140,12 @@ impl SyscallObject<UserError> for BpfTracePrintf {
 /// assert_eq!(result.unwrap(), 0x1122334455);
 /// ```
 pub struct BpfGatherBytes {}
+impl BpfGatherBytes {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfGatherBytes {
     fn call(
         &mut self,
@@ -176,6 +191,12 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 /// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub struct BpfMemFrob {}
+impl BpfMemFrob {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfMemFrob {
     fn call(
         &mut self,
@@ -216,6 +237,12 @@ impl SyscallObject<UserError> for BpfMemFrob {
 /// assert_eq!(result.unwrap(), 3);
 /// ```
 pub struct BpfSqrtI {}
+impl BpfSqrtI {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfSqrtI {
     fn call(
         &mut self,
@@ -257,6 +284,12 @@ impl SyscallObject<UserError> for BpfSqrtI {
 /// assert!(result.unwrap() != 0);
 /// ```
 pub struct BpfStrCmp {}
+impl BpfStrCmp {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfStrCmp {
     fn call(
         &mut self,
@@ -320,6 +353,12 @@ impl SyscallObject<UserError> for BpfStrCmp {
 /// assert!(3 <= n && n <= 6);
 /// ```
 pub struct BpfRand {}
+impl BpfRand {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfRand {
     fn call(
         &mut self,
@@ -341,6 +380,12 @@ impl SyscallObject<UserError> for BpfRand {
 
 /// Prints a NULL-terminated UTF-8 string.
 pub struct BpfSyscallString {}
+impl BpfSyscallString {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfSyscallString {
     fn call(
         &mut self,
@@ -371,6 +416,12 @@ impl SyscallObject<UserError> for BpfSyscallString {
 
 /// Prints the five arguments formated as u64 in decimal.
 pub struct BpfSyscallU64 {}
+impl BpfSyscallU64 {
+    /// new
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for BpfSyscallU64 {
     fn call(
         &mut self,
@@ -390,10 +441,16 @@ impl SyscallObject<UserError> for BpfSyscallU64 {
     }
 }
 
-/// Excample of a syscall with internal state.
+/// Example of a syscall with internal state.
 pub struct SyscallWithContext {
     /// Mutable state
-    pub context: u64,
+    pub context: BpfSyscallContext,
+}
+impl SyscallWithContext {
+    /// new
+    pub fn init<C, E>(context: BpfSyscallContext) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self { context })
+    }
 }
 impl SyscallObject<UserError> for SyscallWithContext {
     fn call(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -61,6 +61,9 @@ macro_rules! question_mark {
     }};
 }
 
+/// Syscall initialization function
+pub type SyscallInit<'a, C, E> = fn(C) -> Box<(dyn SyscallObject<E> + 'a)>;
+
 /// Syscall function without context
 pub type SyscallFunction<E, O> =
     fn(O, u64, u64, u64, u64, u64, &MemoryMapping, &mut ProgramResult<E>);
@@ -84,6 +87,8 @@ pub trait SyscallObject<E: UserDefinedError> {
 /// Syscall function and binding slot for a context object
 #[derive(Debug, PartialEq)]
 pub struct Syscall {
+    /// Syscall init
+    pub init: u64,
     /// Call the syscall function
     pub function: u64,
     /// Slot of context object
@@ -123,11 +128,13 @@ pub struct SyscallRegistry {
 
 impl SyscallRegistry {
     /// Register a syscall function by its symbol hash
-    pub fn register_syscall_by_hash<E: UserDefinedError, O: SyscallObject<E>>(
+    pub fn register_syscall_by_hash<'a, C, E: UserDefinedError, O: SyscallObject<E>>(
         &mut self,
         hash: u32,
+        init: SyscallInit<'a, C, E>,
         function: SyscallFunction<E, &mut O>,
     ) -> Result<(), EbpfError<E>> {
+        let init = init as *const u8 as u64;
         let function = function as *const u8 as u64;
         let context_object_slot = self.entries.len();
         if self
@@ -135,6 +142,7 @@ impl SyscallRegistry {
             .insert(
                 hash,
                 Syscall {
+                    init,
                     function,
                     context_object_slot,
                 },
@@ -152,12 +160,13 @@ impl SyscallRegistry {
     }
 
     /// Register a syscall function by its symbol name
-    pub fn register_syscall_by_name<E: UserDefinedError, O: SyscallObject<E>>(
+    pub fn register_syscall_by_name<'a, C, E: UserDefinedError, O: SyscallObject<E>>(
         &mut self,
         name: &[u8],
+        init: SyscallInit<'a, C, E>,
         function: SyscallFunction<E, &mut O>,
     ) -> Result<(), EbpfError<E>> {
-        self.register_syscall_by_hash(ebpf::hash_symbol_name(name), function)
+        self.register_syscall_by_hash::<C, E, O>(ebpf::hash_symbol_name(name), init, function)
     }
 
     /// Get a symbol's function pointer and context object slot
@@ -565,7 +574,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         &self.tracer
     }
 
-    /// Bind a context object instance to a previously registered syscall
+    /// Bind a context objects instance to a previously registered syscalls
     ///
     /// # Examples
     ///
@@ -591,7 +600,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// // On running the program this syscall will print the content of registers r3, r4 and r5 to
     /// // standard output.
     /// let mut syscall_registry = SyscallRegistry::default();
-    /// syscall_registry.register_syscall_by_hash(6, BpfTracePrintf::call).unwrap();
+    /// syscall_registry.register_syscall_by_hash(6, BpfTracePrintf::init::<u64, UserError>, BpfTracePrintf::call).unwrap();
     /// // Instantiate an Executable and VM
     /// let config = Config::default();
     /// let mut bpf_functions = std::collections::BTreeMap::new();
@@ -599,37 +608,47 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
     /// // Bind a context object instance to the previously registered syscall
-    /// vm.bind_syscall_context_object(Box::new(BpfTracePrintf {}), None);
+    /// vm.bind_syscall_context_objects(0, None);
     /// ```
-    pub fn bind_syscall_context_object(
+    pub fn bind_syscall_context_objects<C: Clone>(
         &mut self,
-        syscall_context_object: Box<dyn SyscallObject<E> + 'a>,
+        syscall_context: C,
         hash: Option<u32>,
     ) -> Result<(), EbpfError<E>> {
-        let fat_ptr: DynTraitFatPointer = unsafe { std::mem::transmute(&*syscall_context_object) };
         let syscall_registry = self.executable.get_syscall_registry();
-        let slot = match hash {
-            Some(hash) => {
-                syscall_registry
-                    .lookup_syscall(hash)
-                    .ok_or(EbpfError::SyscallNotRegistered(hash as usize))?
-                    .context_object_slot
+
+        for (_hash, syscall) in syscall_registry.entries.iter() {
+            let syscall_object_init_fn: SyscallInit<C, E> =
+                unsafe { std::mem::transmute(syscall.init) };
+            let syscall_context_object: Box<dyn SyscallObject<E> + 'a> =
+                syscall_object_init_fn(syscall_context.clone());
+            let fat_ptr: DynTraitFatPointer =
+                unsafe { std::mem::transmute(&*syscall_context_object) };
+
+            let slot = match hash {
+                Some(hash) => {
+                    syscall_registry
+                        .lookup_syscall(hash)
+                        .ok_or(EbpfError::SyscallNotRegistered(hash as usize))?
+                        .context_object_slot
+                }
+                None => syscall_registry
+                    .lookup_context_object_slot(fat_ptr.vtable.methods[0] as u64)
+                    .ok_or(EbpfError::SyscallNotRegistered(
+                        fat_ptr.vtable.methods[0] as usize,
+                    ))?,
+            };
+            if !self.syscall_context_objects[SYSCALL_CONTEXT_OBJECTS_OFFSET + slot].is_null() {
+                return Err(EbpfError::SyscallAlreadyBound(slot));
+            } else {
+                self.syscall_context_objects[SYSCALL_CONTEXT_OBJECTS_OFFSET + slot] = fat_ptr.data;
+                // Keep the dyn trait objects so that they can be dropped properly later
+                self.syscall_context_object_pool
+                    .push(syscall_context_object);
             }
-            None => syscall_registry
-                .lookup_context_object_slot(fat_ptr.vtable.methods[0] as u64)
-                .ok_or(EbpfError::SyscallNotRegistered(
-                    fat_ptr.vtable.methods[0] as usize,
-                ))?,
-        };
-        if !self.syscall_context_objects[SYSCALL_CONTEXT_OBJECTS_OFFSET + slot].is_null() {
-            Err(EbpfError::SyscallAlreadyBound(slot))
-        } else {
-            self.syscall_context_objects[SYSCALL_CONTEXT_OBJECTS_OFFSET + slot] = fat_ptr.data;
-            // Keep the dyn trait objects so that they can be dropped properly later
-            self.syscall_context_object_pool
-                .push(syscall_context_object);
-            Ok(())
         }
+
+        Ok(())
     }
 
     /// Lookup a syscall context object by its function pointer. Used for testing and validation.

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -21,7 +21,7 @@ use solana_rbpf::{
     error::EbpfError,
     memory_region::AccessType,
     memory_region::MemoryMapping,
-    syscalls::{self, Result},
+    syscalls::{self, BpfSyscallContext, Result},
     user_error::UserError,
     vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
@@ -29,20 +29,25 @@ use std::{collections::BTreeMap, fs::File, io::Read};
 use test_utils::{PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH};
 
 macro_rules! test_interpreter_and_jit {
-    (register, $syscall_registry:expr, $location:expr => $syscall_function:expr; $syscall_context_object:expr) => {
-        $syscall_registry.register_syscall_by_name::<UserError, _>($location, $syscall_function).unwrap();
+    (register, $syscall_registry:expr, $location:expr => $syscall_init:expr; $syscall_function:expr) => {
+        $syscall_registry
+            .register_syscall_by_name($location, $syscall_init, $syscall_function)
+            .unwrap();
     };
-    (bind, $vm:expr, $location:expr => $syscall_function:expr; $syscall_context_object:expr) => {
-        $vm.bind_syscall_context_object(Box::new($syscall_context_object), None).unwrap();
+    (bind, $vm:expr, $syscall_context:expr) => {
+        $vm.bind_syscall_context_objects($syscall_context, None)
+            .unwrap();
     };
-    ($executable:expr, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr) => {
+    ($executable:expr, $mem:tt, $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         #[allow(unused_mut)]
         let mut check_closure = $check;
         let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
             let mut vm = EbpfVm::new(&$executable, &mut [], &mut mem).unwrap();
-            $(test_interpreter_and_jit!(bind, vm, $location => $syscall_function; $syscall_context_object);)*
-            let result = vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: $expected_instruction_count });
+            test_interpreter_and_jit!(bind, vm, $syscall_context);
+            let result = vm.execute_program_interpreted(&mut TestInstructionMeter {
+                remaining: $expected_instruction_count,
+            });
             assert!(check_closure(&vm, result));
             (vm.get_total_instruction_count(), vm.get_tracer().clone())
         };
@@ -50,19 +55,27 @@ macro_rules! test_interpreter_and_jit {
         {
             #[allow(unused_mut)]
             let mut check_closure = $check;
-            let compilation_result = Executable::<UserError, TestInstructionMeter>::jit_compile(&mut $executable);
+            let compilation_result =
+                Executable::<UserError, TestInstructionMeter>::jit_compile(&mut $executable);
             let mut mem = $mem;
             let mut vm = EbpfVm::new(&$executable, &mut [], &mut mem).unwrap();
             match compilation_result {
                 Err(err) => assert!(check_closure(&vm, Err(err))),
                 Ok(()) => {
-                    $(test_interpreter_and_jit!(bind, vm, $location => $syscall_function; $syscall_context_object);)*
-                    let result = vm.execute_program_jit(&mut TestInstructionMeter { remaining: $expected_instruction_count });
+                    test_interpreter_and_jit!(bind, vm, $syscall_context);
+                    let result = vm.execute_program_jit(&mut TestInstructionMeter {
+                        remaining: $expected_instruction_count,
+                    });
                     let tracer_jit = vm.get_tracer();
-                    if !check_closure(&vm, result) || !solana_rbpf::vm::Tracer::compare(&_tracer_interpreter, tracer_jit) {
-                        let analysis = solana_rbpf::static_analysis::Analysis::from_executable(&$executable);
+                    if !check_closure(&vm, result)
+                        || !solana_rbpf::vm::Tracer::compare(&_tracer_interpreter, tracer_jit)
+                    {
+                        let analysis =
+                            solana_rbpf::static_analysis::Analysis::from_executable(&$executable);
                         let stdout = std::io::stdout();
-                        _tracer_interpreter.write(&mut stdout.lock(), &analysis).unwrap();
+                        _tracer_interpreter
+                            .write(&mut stdout.lock(), &analysis)
+                            .unwrap();
                         tracer_jit.write(&mut stdout.lock(), &analysis).unwrap();
                         panic!();
                     }
@@ -70,7 +83,7 @@ macro_rules! test_interpreter_and_jit {
                         let instruction_count_jit = vm.get_total_instruction_count();
                         assert_eq!(instruction_count_interpreter, instruction_count_jit);
                     }
-                },
+                }
             }
         }
         if $executable.get_config().enable_instruction_meter {
@@ -80,46 +93,46 @@ macro_rules! test_interpreter_and_jit {
 }
 
 macro_rules! test_interpreter_and_jit_asm {
-    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_init:expr; $syscall_function:expr),* $(,)?), $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         #[allow(unused_mut)]
         {
             let mut syscall_registry = SyscallRegistry::default();
-            $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_function; $syscall_context_object);)*
+            $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_init; $syscall_function);)*
             let mut executable = assemble($source, None, $config, syscall_registry).unwrap();
-            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
+            test_interpreter_and_jit!(executable, $mem, $syscall_context, $check, $expected_instruction_count);
         }
     };
-    ($source:tt, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $mem:tt, ($($location:expr => $syscall_init:expr; $syscall_function:expr),* $(,)?), $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         #[allow(unused_mut)]
         {
             let config = Config {
                 enable_instruction_tracing: true,
                 ..Config::default()
             };
-            test_interpreter_and_jit_asm!($source, config, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
+            test_interpreter_and_jit_asm!($source, config, $mem, ($($location => $syscall_init; $syscall_function),*), $syscall_context, $check, $expected_instruction_count);
         }
     };
 }
 
 macro_rules! test_interpreter_and_jit_elf {
-    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_init:expr; $syscall_function:expr),* $(,)?), $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         let mut file = File::open($source).unwrap();
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
         #[allow(unused_mut)]
         {
             let mut syscall_registry = SyscallRegistry::default();
-            $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_function; $syscall_context_object);)*
+            $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_init; $syscall_function);)*
             let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, None, $config, syscall_registry).unwrap();
-            test_interpreter_and_jit!(executable, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
+            test_interpreter_and_jit!(executable, $mem, $syscall_context, $check, $expected_instruction_count);
         }
     };
-    ($source:tt, $mem:tt, ($($location:expr => $syscall_function:expr; $syscall_context_object:expr),* $(,)?), $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $mem:tt, ($($location:expr => $syscall_init:expr; $syscall_function:expr),* $(,)?), $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         let config = Config {
             enable_instruction_tracing: true,
             ..Config::default()
         };
-        test_interpreter_and_jit_elf!($source, config, $mem, ($($location => $syscall_function; $syscall_context_object),*), $check, $expected_instruction_count);
+        test_interpreter_and_jit_elf!($source, config, $mem, ($($location => $syscall_init; $syscall_function),*), $syscall_context, $check, $expected_instruction_count);
     };
 }
 
@@ -134,6 +147,7 @@ fn test_mov() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         3
     );
@@ -147,6 +161,7 @@ fn test_mov32_imm_large() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xffffffff } },
         2
     );
@@ -161,6 +176,7 @@ fn test_mov_large() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xffffffff } },
         3
     );
@@ -179,6 +195,7 @@ fn test_bounce() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -195,6 +212,7 @@ fn test_add32() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         5
     );
@@ -209,6 +227,7 @@ fn test_neg32() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xfffffffe } },
         3
     );
@@ -223,6 +242,7 @@ fn test_neg64() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xfffffffffffffffe } },
         3
     );
@@ -253,6 +273,7 @@ fn test_alu32_arithmetic() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2a } },
         19
     );
@@ -283,6 +304,7 @@ fn test_alu64_arithmetic() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2a } },
         19
     );
@@ -336,6 +358,7 @@ fn test_mul128() {
         exit",
         [0; 16],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 600 } },
         42
     );
@@ -368,6 +391,7 @@ fn test_alu32_logic() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11 } },
         21
     );
@@ -402,6 +426,7 @@ fn test_alu64_logic() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11 } },
         23
     );
@@ -417,6 +442,7 @@ fn test_arsh32_high_shift() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x4 } },
         4
     );
@@ -432,6 +458,7 @@ fn test_arsh32_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xffff8000 } },
         4
     );
@@ -448,6 +475,7 @@ fn test_arsh32_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xffff8000 } },
         5
     );
@@ -465,6 +493,7 @@ fn test_arsh64() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xfffffffffffffff8 } },
         6
     );
@@ -480,6 +509,7 @@ fn test_lsh64_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x10 } },
         4
     );
@@ -495,6 +525,7 @@ fn test_rhs32_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x00ffffff } },
         4
     );
@@ -510,6 +541,7 @@ fn test_rsh64_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         4
     );
@@ -524,6 +556,7 @@ fn test_be16() {
         exit",
         [0x11, 0x22],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1122 } },
         3
     );
@@ -538,6 +571,7 @@ fn test_be16_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1122 } },
         3
     );
@@ -552,6 +586,7 @@ fn test_be32() {
         exit",
         [0x11, 0x22, 0x33, 0x44],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11223344 } },
         3
     );
@@ -566,6 +601,7 @@ fn test_be32_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11223344 } },
         3
     );
@@ -580,6 +616,7 @@ fn test_be64() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1122334455667788 } },
         3
     );
@@ -594,6 +631,7 @@ fn test_le16() {
         exit",
         [0x22, 0x11],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1122 } },
         3
     );
@@ -608,6 +646,7 @@ fn test_le16_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2211 } },
         3
     );
@@ -622,6 +661,7 @@ fn test_le32() {
         exit",
         [0x44, 0x33, 0x22, 0x11],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11223344 } },
         3
     );
@@ -636,6 +676,7 @@ fn test_le32_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x44332211 } },
         3
     );
@@ -650,6 +691,7 @@ fn test_le64() {
         exit",
         [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1122334455667788 } },
         3
     );
@@ -664,6 +706,7 @@ fn test_mul32_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xc } },
         3
     );
@@ -679,6 +722,7 @@ fn test_mul32_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xc } },
         4
     );
@@ -694,6 +738,7 @@ fn test_mul32_reg_overflow() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x4 } },
         4
     );
@@ -708,6 +753,7 @@ fn test_mul64_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x100000004 } },
         3
     );
@@ -723,6 +769,7 @@ fn test_mul64_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x100000004 } },
         4
     );
@@ -738,6 +785,7 @@ fn test_div32_high_divisor() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         4
     );
@@ -752,6 +800,7 @@ fn test_div32_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         3
     );
@@ -767,6 +816,7 @@ fn test_div32_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         4
     );
@@ -781,6 +831,7 @@ fn test_sdiv32_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         3
     );
@@ -796,6 +847,7 @@ fn test_sdiv32_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         4
     );
@@ -811,6 +863,7 @@ fn test_div64_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x300000000 } },
         4
     );
@@ -827,6 +880,7 @@ fn test_div64_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x300000000 } },
         5
     );
@@ -842,6 +896,7 @@ fn test_sdiv64_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x300000000 } },
         4
     );
@@ -858,6 +913,7 @@ fn test_sdiv64_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x300000000 } },
         5
     );
@@ -873,6 +929,7 @@ fn test_err_div64_by_zero_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
@@ -888,6 +945,7 @@ fn test_err_div32_by_zero_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
@@ -903,6 +961,7 @@ fn test_err_sdiv64_by_zero_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
@@ -918,6 +977,7 @@ fn test_err_sdiv32_by_zero_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
@@ -933,6 +993,7 @@ fn test_err_sdiv64_overflow_imm() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 31)
         },
@@ -951,6 +1012,7 @@ fn test_err_sdiv64_overflow_reg() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 32)
         },
@@ -968,6 +1030,7 @@ fn test_err_sdiv32_overflow_imm() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 31)
         },
@@ -986,6 +1049,7 @@ fn test_err_sdiv32_overflow_reg() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 32)
         },
@@ -1004,6 +1068,7 @@ fn test_mod32() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x5 } },
         5
     );
@@ -1018,6 +1083,7 @@ fn test_mod32_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         3
     );
@@ -1038,6 +1104,7 @@ fn test_mod64() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x30ba5a04 } },
         9
     );
@@ -1053,6 +1120,7 @@ fn test_err_mod64_by_zero_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
@@ -1068,6 +1136,7 @@ fn test_err_mod_by_zero_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31) },
         3
     );
@@ -1086,6 +1155,7 @@ fn test_ldabsb() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x33 } },
         2
     );
@@ -1102,6 +1172,7 @@ fn test_ldabsh() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x4433 } },
         2
     );
@@ -1118,6 +1189,7 @@ fn test_ldabsw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x66554433 } },
         2
     );
@@ -1134,6 +1206,7 @@ fn test_ldabsdw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xaa99887766554433 } },
         2
     );
@@ -1150,6 +1223,7 @@ fn test_err_ldabsb_oob() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -1170,6 +1244,7 @@ fn test_err_ldabsb_nomem() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -1194,6 +1269,7 @@ fn test_ldindb() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x88 } },
         3
     );
@@ -1211,6 +1287,7 @@ fn test_ldindh() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x9988 } },
         3
     );
@@ -1228,6 +1305,7 @@ fn test_ldindw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x88776655 } },
         3
     );
@@ -1245,6 +1323,7 @@ fn test_ldinddw() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xccbbaa9988776655 } },
         3
     );
@@ -1262,6 +1341,7 @@ fn test_err_ldindb_oob() {
             0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, //
         ],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -1283,6 +1363,7 @@ fn test_err_ldindb_nomem() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -1303,6 +1384,7 @@ fn test_ldxb() {
         exit",
         [0xaa, 0xbb, 0x11, 0xcc, 0xdd],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11 } },
         2
     );
@@ -1316,6 +1398,7 @@ fn test_ldxh() {
         exit",
         [0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2211 } },
         2
     );
@@ -1331,6 +1414,7 @@ fn test_ldxw() {
             0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x44332211 } },
         2
     );
@@ -1346,6 +1430,7 @@ fn test_ldxh_same_reg() {
         exit",
         [0xff, 0xff],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1234 } },
         4
     );
@@ -1362,6 +1447,7 @@ fn test_lldxdw() {
             0x77, 0x88, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x8877665544332211 } },
         2
     );
@@ -1378,6 +1464,7 @@ fn test_err_ldxdw_oob() {
             0x77, 0x88, 0xcc, 0xdd, //
         ],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -1430,6 +1517,7 @@ fn test_ldxb_all() {
             0x08, 0x09, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x9876543210 } },
         31
     );
@@ -1486,6 +1574,7 @@ fn test_ldxh_all() {
             0x00, 0x08, 0x00, 0x09, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x9876543210 } },
         41
     );
@@ -1532,6 +1621,7 @@ fn test_ldxh_all2() {
             0x01, 0x00, 0x02, 0x00, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3ff } },
         31
     );
@@ -1580,6 +1670,7 @@ fn test_ldxw_all() {
             0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x030f0f } },
         31
     );
@@ -1593,6 +1684,7 @@ fn test_lddw() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1122334455667788 } },
         2
     );
@@ -1602,6 +1694,7 @@ fn test_lddw() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x80000000 } },
         2
     );
@@ -1616,6 +1709,7 @@ fn test_stb() {
         exit",
         [0xaa, 0xbb, 0xff, 0xcc, 0xdd],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11 } },
         3
     );
@@ -1632,6 +1726,7 @@ fn test_sth() {
             0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2211 } },
         3
     );
@@ -1648,6 +1743,7 @@ fn test_stw() {
             0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x44332211 } },
         3
     );
@@ -1665,6 +1761,7 @@ fn test_stdw() {
             0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x44332211 } },
         3
     );
@@ -1682,6 +1779,7 @@ fn test_stxb() {
             0xaa, 0xbb, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x11 } },
         4
     );
@@ -1699,6 +1797,7 @@ fn test_stxh() {
             0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2211 } },
         4
     );
@@ -1716,6 +1815,7 @@ fn test_stxw() {
             0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x44332211 } },
         4
     );
@@ -1736,6 +1836,7 @@ fn test_stxdw() {
             0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x8877665544332211 } },
         6
     );
@@ -1768,6 +1869,7 @@ fn test_stxb_all() {
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xf0f2f3f4f5f6f7f8 } },
         19
     );
@@ -1787,6 +1889,7 @@ fn test_stxb_all2() {
         exit",
         [0xff, 0xff],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xf1f9 } },
         8
     );
@@ -1822,6 +1925,7 @@ fn test_stxb_chain() {
             0x00, 0x00, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2a } },
         21
     );
@@ -1836,6 +1940,7 @@ fn test_exit_without_value() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         1
     );
@@ -1849,6 +1954,7 @@ fn test_exit() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         2
     );
@@ -1864,6 +1970,7 @@ fn test_early_exit() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x3 } },
         2
     );
@@ -1879,6 +1986,7 @@ fn test_ja() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         3
     );
@@ -1898,6 +2006,7 @@ fn test_jeq_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -1918,6 +2027,7 @@ fn test_jeq_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         8
     );
@@ -1937,6 +2047,7 @@ fn test_jge_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -1957,6 +2068,7 @@ fn test_jge_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         8
     );
@@ -1977,6 +2089,7 @@ fn test_jle_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -1999,6 +2112,7 @@ fn test_jle_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         9
     );
@@ -2018,6 +2132,7 @@ fn test_jgt_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2039,6 +2154,7 @@ fn test_jgt_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         9
     );
@@ -2058,6 +2174,7 @@ fn test_jlt_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2079,6 +2196,7 @@ fn test_jlt_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         9
     );
@@ -2098,6 +2216,7 @@ fn test_jne_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2118,6 +2237,7 @@ fn test_jne_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         8
     );
@@ -2137,6 +2257,7 @@ fn test_jset_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2157,6 +2278,7 @@ fn test_jset_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         8
     );
@@ -2177,6 +2299,7 @@ fn test_jsge_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         8
     );
@@ -2199,6 +2322,7 @@ fn test_jsge_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         10
     );
@@ -2219,6 +2343,7 @@ fn test_jsle_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2242,6 +2367,7 @@ fn test_jsle_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         10
     );
@@ -2261,6 +2387,7 @@ fn test_jsgt_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2281,6 +2408,7 @@ fn test_jsgt_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         8
     );
@@ -2300,6 +2428,7 @@ fn test_jslt_imm() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         7
     );
@@ -2321,6 +2450,7 @@ fn test_jslt_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         9
     );
@@ -2343,6 +2473,7 @@ fn test_stack1() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0xcd } },
         9
     );
@@ -2370,9 +2501,10 @@ fn test_stack2() {
         exit",
         [],
         (
-            b"BpfMemFrob" => syscalls::BpfMemFrob::call; syscalls::BpfMemFrob {},
-            b"BpfGatherBytes" => syscalls::BpfGatherBytes::call; syscalls::BpfGatherBytes {},
+            b"BpfMemFrob" => syscalls::BpfMemFrob::init::<BpfSyscallContext, UserError>; syscalls::BpfMemFrob::call,
+            b"BpfGatherBytes" => syscalls::BpfGatherBytes::init::<BpfSyscallContext, UserError>; syscalls::BpfGatherBytes::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x01020304 } },
         16
     );
@@ -2412,8 +2544,9 @@ fn test_string_stack() {
         exit",
         [],
         (
-            b"BpfStrCmp" => syscalls::BpfStrCmp::call; syscalls::BpfStrCmp {},
+            b"BpfStrCmp" => syscalls::BpfStrCmp::init::<BpfSyscallContext, UserError>; syscalls::BpfStrCmp::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         28
     );
@@ -2427,6 +2560,7 @@ fn test_err_fixed_stack_out_of_bound() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2457,6 +2591,7 @@ fn test_err_dynamic_stack_out_of_bound() {
         config,
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2476,6 +2611,7 @@ fn test_err_dynamic_stack_out_of_bound() {
         config,
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2514,6 +2650,7 @@ fn test_err_dynamic_stack_ptr_overflow() {
         config,
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2544,6 +2681,7 @@ fn test_dynamic_stack_frames_empty() {
         config,
         [],
         (),
+        0,
         { |_vm, res: Result| res.unwrap() == ebpf::MM_STACK_START + config.stack_size() as u64 },
         4
     );
@@ -2569,6 +2707,7 @@ fn test_dynamic_frame_ptr() {
         config,
         [],
         (),
+        0,
         {
             |_vm, res: Result| res.unwrap() == ebpf::MM_STACK_START + config.stack_size() as u64 - 8
         },
@@ -2589,6 +2728,7 @@ fn test_dynamic_frame_ptr() {
         config,
         [],
         (),
+        0,
         { |_vm, res: Result| res.unwrap() == ebpf::MM_STACK_START + config.stack_size() as u64 },
         5
     );
@@ -2622,6 +2762,7 @@ fn test_entrypoint_exit() {
             config,
             [],
             (),
+            0,
             { |_vm, res: Result| { res.unwrap() == 42 } },
             5
         );
@@ -2652,6 +2793,7 @@ fn test_stack_call_depth_tracking() {
             config,
             [],
             (),
+            0,
             { |_vm, res: Result| { res.is_ok() } },
             5
         );
@@ -2671,6 +2813,7 @@ fn test_stack_call_depth_tracking() {
             config,
             [],
             (),
+            0,
             {
                 |_vm, res: Result| {
                     matches!(res.unwrap_err(),
@@ -2717,7 +2860,7 @@ fn test_err_mem_access_out_of_bound() {
         test_interpreter_and_jit!(
             executable,
             mem,
-            (),
+            0,
             {
                 |_vm, res: Result| {
                     matches!(res.unwrap_err(),
@@ -2739,8 +2882,9 @@ fn test_relative_call() {
         "tests/elfs/relative_call.so",
         [1],
         (
-            b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"log" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 2 } },
         14
     );
@@ -2752,8 +2896,9 @@ fn test_bpf_to_bpf_scratch_registers() {
         "tests/elfs/scratch_registers.so",
         [1],
         (
-            b"log_64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {},
+            b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 112 } },
         41
     );
@@ -2765,6 +2910,7 @@ fn test_bpf_to_bpf_pass_stack_reference() {
         "tests/elfs/pass_stack_reference.so",
         [],
         (),
+        0,
         { |_vm, res: Result| res.unwrap() == 42 },
         29
     );
@@ -2782,8 +2928,9 @@ fn test_syscall_parameter_on_stack() {
         exit",
         [],
         (
-            b"BpfSyscallString" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"BpfSyscallString" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         6
     );
@@ -2803,6 +2950,7 @@ fn test_call_reg() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 42 } },
         8
     );
@@ -2817,6 +2965,7 @@ fn test_err_callx_oob_low() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2840,6 +2989,7 @@ fn test_err_callx_oob_high() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2863,6 +3013,7 @@ fn test_err_static_jmp_lddw() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2887,6 +3038,7 @@ fn test_err_static_jmp_lddw() {
         ",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x2 } },
         9
     );
@@ -2898,6 +3050,7 @@ fn test_err_static_jmp_lddw() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2917,6 +3070,7 @@ fn test_err_static_jmp_lddw() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2940,6 +3094,7 @@ fn test_err_dynamic_jmp_lddw() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2962,6 +3117,7 @@ fn test_err_dynamic_jmp_lddw() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -2983,6 +3139,7 @@ fn test_err_dynamic_jmp_lddw() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3002,8 +3159,9 @@ fn test_bpf_to_bpf_depth() {
             "tests/elfs/multiple_file.so",
             [i as u8],
             (
-                b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+                b"log" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
             ),
+            0,
             { |_vm, res: Result| { res.unwrap() == 0 } },
             if i == 0 { 4 } else { 3 + 10 * i as u64 }
         );
@@ -3017,8 +3175,9 @@ fn test_err_bpf_to_bpf_too_deep() {
         "tests/elfs/multiple_file.so",
         [config.max_call_depth as u8],
         (
-            b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"log" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3042,6 +3201,7 @@ fn test_err_reg_stack_depth() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3091,8 +3251,9 @@ fn test_err_syscall_string() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"BpfSyscallString" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"BpfSyscallString" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3115,8 +3276,9 @@ fn test_syscall_string() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"BpfSyscallString" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"BpfSyscallString" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         4
     );
@@ -3136,8 +3298,9 @@ fn test_syscall() {
         exit",
         [],
         (
-            b"BpfSyscallU64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {},
+            b"BpfSyscallU64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         8
     );
@@ -3156,8 +3319,9 @@ fn test_call_gather_bytes() {
         exit",
         [],
         (
-            b"BpfGatherBytes" => syscalls::BpfGatherBytes::call; syscalls::BpfGatherBytes {},
+            b"BpfGatherBytes" => syscalls::BpfGatherBytes::init::<BpfSyscallContext, UserError>; syscalls::BpfGatherBytes::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0102030405 } },
         7
     );
@@ -3178,8 +3342,9 @@ fn test_call_memfrob() {
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
         ],
         (
-            b"BpfMemFrob" => syscalls::BpfMemFrob::call; syscalls::BpfMemFrob {},
+            b"BpfMemFrob" => syscalls::BpfMemFrob::init::<BpfSyscallContext, UserError>; syscalls::BpfMemFrob::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x102292e2f2c0708 } },
         7
     );
@@ -3199,8 +3364,9 @@ fn test_syscall_with_context() {
         exit",
         [],
         (
-            b"SyscallWithContext" => syscalls::SyscallWithContext::call; syscalls::SyscallWithContext { context: 42 },
+            b"SyscallWithContext" => syscalls::SyscallWithContext::init::< syscalls::BpfSyscallContext, UserError>; syscalls::SyscallWithContext::call
         ),
+        42,
         { |vm: &EbpfVm<UserError, TestInstructionMeter>, res: Result| {
             let syscall_context_object = unsafe { &*(vm.get_syscall_context_object(syscalls::SyscallWithContext::call as usize).unwrap() as *const syscalls::SyscallWithContext) };
             assert_eq!(syscall_context_object.context, 84);
@@ -3210,7 +3376,13 @@ fn test_syscall_with_context() {
     );
 }
 
+type UserContext = u64;
 pub struct NestedVmSyscall {}
+impl NestedVmSyscall {
+    pub fn init<C, E>(_unused: C) -> Box<dyn SyscallObject<UserError>> {
+        Box::new(Self {})
+    }
+}
 impl SyscallObject<UserError> for NestedVmSyscall {
     fn call(
         &mut self,
@@ -3226,7 +3398,11 @@ impl SyscallObject<UserError> for NestedVmSyscall {
         if depth > 0 {
             let mut syscall_registry = SyscallRegistry::default();
             syscall_registry
-                .register_syscall_by_name::<UserError, _>(b"NestedVmSyscall", NestedVmSyscall::call)
+                .register_syscall_by_name(
+                    b"NestedVmSyscall",
+                    NestedVmSyscall::init::<UserContext, UserError>,
+                    NestedVmSyscall::call,
+                )
                 .unwrap();
             let mem = [depth as u8 - 1, throw as u8];
             let mut executable = assemble::<UserError, TestInstructionMeter>(
@@ -3242,7 +3418,18 @@ impl SyscallObject<UserError> for NestedVmSyscall {
                 syscall_registry,
             )
             .unwrap();
-            test_interpreter_and_jit!(executable, mem, (b"NestedVmSyscall" => NestedVmSyscall::call; NestedVmSyscall {}), { |_vm, res: Result| { *result = res; true } }, if throw == 0 { 6 } else { 5 });
+            test_interpreter_and_jit!(
+                executable,
+                mem,
+                0,
+                {
+                    |_vm, res: Result| {
+                        *result = res;
+                        true
+                    }
+                },
+                if throw == 0 { 6 } else { 5 }
+            );
         } else {
             *result = if throw == 0 {
                 Ok(42)
@@ -3277,9 +3464,10 @@ fn test_load_elf() {
         "tests/elfs/noop.so",
         [],
         (
-            b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
-            b"log_64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {},
+            b"log" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
+            b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         11
     );
@@ -3291,8 +3479,9 @@ fn test_load_elf_empty_noro() {
         "tests/elfs/noro.so",
         [],
         (
-            b"log_64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {},
+            b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         8
     );
@@ -3304,8 +3493,9 @@ fn test_load_elf_empty_rodata() {
         "tests/elfs/empty_rodata.so",
         [],
         (
-            b"log_64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {},
+            b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         8
     );
@@ -3325,6 +3515,7 @@ fn test_load_elf_rodata() {
             config,
             [],
             (),
+            0,
             { |_vm, res: Result| { res.unwrap() == 42 } },
             3
         );
@@ -3342,8 +3533,9 @@ fn test_custom_entrypoint() {
         ..Config::default()
     };
     let mut syscall_registry = SyscallRegistry::default();
-    test_interpreter_and_jit!(register, syscall_registry, b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {});
-    test_interpreter_and_jit!(register, syscall_registry, b"log_64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {});
+    test_interpreter_and_jit!(register, syscall_registry, b"log" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call);
+    let mut syscall_registry = SyscallRegistry::default();
+    test_interpreter_and_jit!(register, syscall_registry, b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call);
     #[allow(unused_mut)]
     let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
@@ -3355,10 +3547,7 @@ fn test_custom_entrypoint() {
     test_interpreter_and_jit!(
         executable,
         [],
-        (
-            b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
-            b"log_64" => syscalls::BpfSyscallU64::call; syscalls::BpfSyscallU64 {},
-        ),
+        syscalls::BpfSyscallContext::default(),
         { |_vm, res: Result| { res.unwrap() == 0 } },
         2
     );
@@ -3374,6 +3563,7 @@ fn test_tight_infinite_loop_conditional() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3394,6 +3584,7 @@ fn test_tight_infinite_loop_unconditional() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3416,6 +3607,7 @@ fn test_tight_infinite_recursion() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3440,6 +3632,7 @@ fn test_tight_infinite_recursion_callx() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3462,8 +3655,9 @@ fn test_instruction_count_syscall() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"BpfSyscallString" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"BpfSyscallString" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         4
     );
@@ -3479,8 +3673,9 @@ fn test_err_instruction_count_syscall_capped() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"BpfSyscallString" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"BpfSyscallString" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call,
         ),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3504,6 +3699,7 @@ fn test_err_instruction_count_lddw_capped() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3532,6 +3728,7 @@ fn test_non_terminate_early() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3560,8 +3757,9 @@ fn test_err_non_terminate_capped() {
         exit",
         [],
         (
-            b"BpfTracePrintf" => syscalls::BpfTracePrintf::call; syscalls::BpfTracePrintf {},
+            b"BpfTracePrintf" => syscalls::BpfTracePrintf::init::<BpfSyscallContext, UserError>; syscalls::BpfTracePrintf::call,
         ),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3586,8 +3784,9 @@ fn test_err_non_terminate_capped() {
         exit",
         [],
         (
-            b"BpfTracePrintf" => syscalls::BpfTracePrintf::call; syscalls::BpfTracePrintf {},
+            b"BpfTracePrintf" => syscalls::BpfTracePrintf::init::<BpfSyscallContext, UserError>; syscalls::BpfTracePrintf::call,
         ),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3613,6 +3812,7 @@ fn test_err_capped_before_exception() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3634,6 +3834,7 @@ fn test_err_capped_before_exception() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3658,6 +3859,7 @@ fn test_err_exit_capped() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3678,6 +3880,7 @@ fn test_err_exit_capped() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3695,6 +3898,7 @@ fn test_err_exit_capped() {
         ",
         [],
         (),
+        0,
         {
             |_vm, res: Result| {
                 matches!(res.unwrap_err(),
@@ -3720,8 +3924,9 @@ fn test_symbol_relocation() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"BpfSyscallString" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {},
+            b"BpfSyscallString" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call
         ),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0 } },
         6
     );
@@ -3741,6 +3946,7 @@ fn test_err_call_unresolved() {
         exit",
         [],
         (),
+        0,
         {
             |_vm, res: Result| matches!(res.unwrap_err(), EbpfError::UnsupportedInstruction(pc) if pc == 34)
         },
@@ -3751,7 +3957,7 @@ fn test_err_call_unresolved() {
 #[test]
 fn test_err_unresolved_elf() {
     let mut syscall_registry = SyscallRegistry::default();
-    test_interpreter_and_jit!(register, syscall_registry, b"log" => syscalls::BpfSyscallString::call; syscalls::BpfSyscallString {});
+    test_interpreter_and_jit!(register, syscall_registry, b"log" => syscalls::BpfSyscallString::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallString::call);
     let mut file = File::open("tests/elfs/unresolved_syscall.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
@@ -3782,6 +3988,7 @@ fn test_mul_loop() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x75db9c97 } },
         37
     );
@@ -3809,6 +4016,7 @@ fn test_prime() {
         exit",
         [],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         655
     );
@@ -3845,6 +4053,7 @@ fn test_subnet() {
             0x03, 0x00, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         11
     );
@@ -3870,6 +4079,7 @@ fn test_tcp_port80_match() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x1 } },
         17
     );
@@ -3895,6 +4105,7 @@ fn test_tcp_port80_nomatch() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         18
     );
@@ -3920,6 +4131,7 @@ fn test_tcp_port80_nomatch_ethertype() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         7
     );
@@ -3945,6 +4157,7 @@ fn test_tcp_port80_nomatch_proto() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
+        0,
         { |_vm, res: Result| { res.unwrap() == 0x0 } },
         9
     );
@@ -3956,6 +4169,7 @@ fn test_tcp_sack_match() {
         TCP_SACK_ASM,
         TCP_SACK_MATCH,
         (),
+        0,
         { |_vm, res: Result| res.unwrap() == 0x1 },
         79
     );
@@ -3967,6 +4181,7 @@ fn test_tcp_sack_nomatch() {
         TCP_SACK_ASM,
         TCP_SACK_NOMATCH,
         (),
+        0,
         { |_vm, res: Result| res.unwrap() == 0x0 },
         55
     );


### PR DESCRIPTION
Syscall registration and binding are currently disjoint operations that require the callers to do both for each syscall explicitly.

This can lead to mismatch or missing registration/binds and complicates the code.  Another side effect is that it is difficult/impossible given the current API for callers to filter syscalls at the registration stage but allow them at the binding stage.  One example is the effort to deprecate/disallow syscalls by preventing new deployments of programs that rely on a disallowed syscall while continuing to support existing programs that already rely on them.

Now, all syscalls are registered once, and later the bind operation uses a common context to bind all the previously registered syscalls.  Thus, no longer requiring an explicit bind for each syscall and without the complications of keeping two identical lists of syscalls for registration and bind.

The meat of this PR is in src/vm.rs, the rest of the changes are test related