### PR TITLE
Pass custom `MemoryRegion`s to VM constructor

### DIFF
--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -30,7 +30,7 @@ fn bench_init_vm(bencher: &mut Bencher) {
     )
     .unwrap();
     bencher.iter(|| {
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap()
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap()
     });
 }
 

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -32,7 +32,7 @@ fn generate_memory_regions(
             None => 4,
         };
         let content = vec![0; length as usize];
-        memory_regions.push(MemoryRegion::new_from_slice(
+        memory_regions.push(MemoryRegion::new_for_testing(
             &content[..],
             offset,
             0,
@@ -62,7 +62,7 @@ fn bench_gapped_randomized_access_with_1024_entries(bencher: &mut Bencher) {
     let content = vec![0; (frame_size * frame_count * 2) as usize];
     let memory_regions = vec![
         MemoryRegion::default(),
-        MemoryRegion::new_from_slice(&content[..], 0x100000000, frame_size, false),
+        MemoryRegion::new_for_testing(&content[..], 0x100000000, frame_size, false),
     ];
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();
@@ -83,7 +83,7 @@ fn bench_randomized_access_with_0001_entry(bencher: &mut Bencher) {
     let content = vec![0; 1024 * 2];
     let memory_regions = vec![
         MemoryRegion::default(),
-        MemoryRegion::new_from_slice(&content[..], 0x100000000, 0, false),
+        MemoryRegion::new_readonly(&content[..], 0x100000000),
     ];
     let config = Config::default();
     let memory_mapping = MemoryMapping::new::<UserError>(memory_regions, &config).unwrap();

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -30,7 +30,7 @@ fn bench_init_interpreter_execution(bencher: &mut Bencher) {
     )
     .unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
     bencher.iter(|| {
         vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 29 })
             .unwrap()
@@ -52,7 +52,7 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     .unwrap();
     Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
     bencher.iter(|| {
         vm.execute_program_jit(&mut TestInstructionMeter { remaining: 29 })
             .unwrap()
@@ -75,7 +75,8 @@ fn bench_jit_vs_interpreter(
     )
     .unwrap();
     Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
-    let mut vm = EbpfVm::new(&executable, &mut [], mem).unwrap();
+    let mem_region = MemoryRegion::new_from_slice(mem, ebpf::MM_INPUT_START, 0, true);
+    let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
     let interpreter_summary = bencher
         .bench(|bencher| {
             bencher.iter(|| {

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -10,7 +10,9 @@ extern crate solana_rbpf;
 extern crate test;
 
 use solana_rbpf::{
+    ebpf,
     elf::Executable,
+    memory_region::MemoryRegion,
     user_error::UserError,
     vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
 };
@@ -75,7 +77,7 @@ fn bench_jit_vs_interpreter(
     )
     .unwrap();
     Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
-    let mem_region = MemoryRegion::new_from_slice(mem, ebpf::MM_INPUT_START, 0, true);
+    let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
     let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
     let interpreter_summary = bencher
         .bench(|bencher| {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,9 @@
 use clap::{crate_version, App, Arg};
 use solana_rbpf::{
     assembler::assemble,
+    ebpf,
     elf::Executable,
-    memory_region::MemoryMapping,
+    memory_region::{MemoryMapping, MemoryRegion},
     static_analysis::Analysis,
     syscalls::Result,
     user_error::UserError,
@@ -179,7 +180,7 @@ fn main() {
     if matches.value_of("use") == Some("jit") {
         Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     }
-    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+    let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
     let mut vm = EbpfVm::new(&executable, &mut heap, vec![mem_region]).unwrap();
 
     let analysis = if matches.value_of("use") == Some("cfg")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -179,7 +179,8 @@ fn main() {
     if matches.value_of("use") == Some("jit") {
         Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
     }
-    let mut vm = EbpfVm::new(&executable, &mut mem, &mut heap).unwrap();
+    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+    let mut vm = EbpfVm::new(&executable, &mut heap, vec![mem_region]).unwrap();
 
     let analysis = if matches.value_of("use") == Some("cfg")
         || matches.value_of("use") == Some("disassembler")

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -44,7 +44,7 @@ fuzz_target!(|data: DumbFuzzData| {
         bpf_functions,
     )
     .unwrap();
-    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+    let mem_region = MemoryRegion::new_writable(&mem, ebpf::MM_INPUT_START);
     let mut vm =
         EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -8,6 +8,7 @@ use libfuzzer_sys::fuzz_target;
 
 use solana_rbpf::{
     elf::{register_bpf_function, Executable},
+    memory_region::MemoryRegion,
     user_error::UserError,
     verifier::check,
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
@@ -43,8 +44,9 @@ fuzz_target!(|data: DumbFuzzData| {
         bpf_functions,
     )
     .unwrap();
+    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut mem).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 
     drop(black_box(vm.execute_program_interpreted(
         &mut TestInstructionMeter { remaining: 1024 },

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -48,7 +48,7 @@ fuzz_target!(|data: FuzzData| {
         bpf_functions,
     )
     .unwrap();
-    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+    let mem_region = MemoryRegion::new_writable(&mem, ebpf::MM_INPUT_START);
     let mut vm =
         EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -10,6 +10,7 @@ use grammar_aware::*;
 use solana_rbpf::{
     elf::{register_bpf_function, Executable},
     insn_builder::{Arch, IntoBytes},
+    memory_region::MemoryRegion,
     user_error::UserError,
     verifier::check,
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
@@ -47,8 +48,9 @@ fuzz_target!(|data: FuzzData| {
         bpf_functions,
     )
     .unwrap();
+    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut mem).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 
     drop(black_box(vm.execute_program_interpreted(
         &mut TestInstructionMeter { remaining: 1 << 16 },

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -8,6 +8,7 @@ use grammar_aware::*;
 use solana_rbpf::{
     elf::{register_bpf_function, Executable},
     insn_builder::{Arch, Instruction, IntoBytes},
+    memory_region::MemoryRegion,
     user_error::UserError,
     verifier::check,
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
@@ -56,11 +57,13 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     if Executable::jit_compile(&mut executable).is_ok() {
+        let interp_mem_region = MemoryRegion::new_from_slice(&mut interp_mem, ebpf::MM_INPUT_START, 0, true);
         let mut interp_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut interp_mem)
+            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![interp_mem])
                 .unwrap();
+        let jit_mem_region = MemoryRegion::new_from_slice(&mut jit_mem, ebpf::MM_INPUT_START, 0, true);
         let mut jit_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut jit_mem)
+            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![jit_mem_region])
                 .unwrap();
 
         let mut interp_meter = TestInstructionMeter { remaining: 1 << 16 };

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -57,11 +57,11 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     if Executable::jit_compile(&mut executable).is_ok() {
-        let interp_mem_region = MemoryRegion::new_from_slice(&mut interp_mem, ebpf::MM_INPUT_START, 0, true);
+        let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
         let mut interp_vm =
             EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![interp_mem])
                 .unwrap();
-        let jit_mem_region = MemoryRegion::new_from_slice(&mut jit_mem, ebpf::MM_INPUT_START, 0, true);
+        let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
         let mut jit_vm =
             EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![jit_mem_region])
                 .unwrap();

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -9,6 +9,7 @@ use solana_rbpf::{
     elf::{register_bpf_function, Executable},
     error::{EbpfError, UserDefinedError},
     insn_builder::IntoBytes,
+    memory_region::MemoryRegion,
     static_analysis::Analysis,
     user_error::UserError,
     verifier::check,
@@ -54,11 +55,13 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     if Executable::jit_compile(&mut executable).is_ok() {
+        let interp_mem_region = MemoryRegion::new_from_slice(&mut interp_mem, ebpf::MM_INPUT_START, 0, true);
         let mut interp_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut interp_mem)
+            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![interp_mem])
                 .unwrap();
+        let jit_mem_region = MemoryRegion::new_from_slice(&mut jit_mem, ebpf::MM_INPUT_START, 0, true);
         let mut jit_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut jit_mem)
+            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![jit_mem_region])
                 .unwrap();
 
         let mut interp_meter = TestInstructionMeter { remaining: 1 << 16 };

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -55,11 +55,11 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     if Executable::jit_compile(&mut executable).is_ok() {
-        let interp_mem_region = MemoryRegion::new_from_slice(&mut interp_mem, ebpf::MM_INPUT_START, 0, true);
+        let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
         let mut interp_vm =
             EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![interp_mem])
                 .unwrap();
-        let jit_mem_region = MemoryRegion::new_from_slice(&mut jit_mem, ebpf::MM_INPUT_START, 0, true);
+        let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
         let mut jit_vm =
             EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![jit_mem_region])
                 .unwrap();

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -68,16 +68,15 @@ impl<'a> CallFrames<'a> {
     }
 
     /// Get stack memory region
-    pub fn get_memory_region(&self) -> MemoryRegion {
-        MemoryRegion::new_from_slice(
-            self.stack.as_slice(),
+    pub fn get_memory_region(&mut self) -> MemoryRegion {
+        MemoryRegion::new_writable_gapped(
+            self.stack.as_slice_mut(),
             MM_STACK_START,
             if !self.config.dynamic_stack_frames && self.config.enable_stack_frame_gaps {
                 self.config.stack_frame_size as u64
             } else {
                 0
             },
-            true,
         )
     }
 

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1017,11 +1017,9 @@ pub(crate) fn get_ro_region(ro_section: &Section, elf: &[u8]) -> MemoryRegion {
     // If offset > 0, the region will start at MM_PROGRAM_START + the offset of
     // the first read only byte. [MM_PROGRAM_START, MM_PROGRAM_START + offset)
     // will be unmappable, see MemoryRegion::vm_to_host.
-    MemoryRegion::new_from_slice(
+    MemoryRegion::new_readonly(
         ro_data,
         ebpf::MM_PROGRAM_START.saturating_add(offset as u64),
-        0,
-        false,
     )
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -182,7 +182,7 @@ pub fn gather_bytes<E: UserDefinedError> (
 ///
 /// let val = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33];
 /// let val_va = 0x1000;
-/// let regions = [MemoryRegion::new_from_slice(&val, val_va)];
+/// let regions = [MemoryRegion::new_readonly(&val, val_va, 0)];
 ///
 /// memfrob::<UserError>(val_va, 8, 0, 0, 0, &regions, &regions);
 /// assert_eq!(val, vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
@@ -271,10 +271,10 @@ pub fn sqrti<E: UserDefinedError> (
 /// let bar = "This is another sting.";
 /// let va_foo = 0x1000;
 /// let va_bar = 0x2000;
-/// let regions = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo)];
+/// let regions = [MemoryRegion::new_readonly(foo.as_bytes(), va_foo, 0)];
 /// assert!(strcmp::<UserError>(va_foo, va_foo, 0, 0, 0, &regions, &regions).unwrap() == 0);
-/// let regions = [MemoryRegion::new_from_slice(foo.as_bytes(), va_foo),
-///                MemoryRegion::new_from_slice(bar.as_bytes(), va_bar)];
+/// let regions = [MemoryRegion::new_readonly(foo.as_bytes(), va_foo, 0),
+///                MemoryRegion::new_readonly(bar.as_bytes(), va_bar, 0)];
 /// assert!(strcmp::<UserError>(va_foo, va_bar, 0, 0, 0, &regions, &regions).unwrap() != 0);
 /// ```
 #[allow(dead_code)]

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -50,8 +50,7 @@ impl MemoryRegion {
     pub(crate) const IS_WRITABLE_OFFSET: i32 =
         MemoryRegion::VM_GAP_SHIFT_OFFSET + std::mem::size_of::<u8>() as i32;
 
-    /// Creates a new MemoryRegion structure from a slice
-    pub fn new_from_slice(slice: &[u8], vm_addr: u64, vm_gap_size: u64, is_writable: bool) -> Self {
+    fn new(slice: &[u8], vm_addr: u64, vm_gap_size: u64, is_writable: bool) -> Self {
         let mut vm_gap_shift = (std::mem::size_of::<u64>() as u8)
             .saturating_mul(8)
             .saturating_sub(1);
@@ -66,6 +65,31 @@ impl MemoryRegion {
             vm_gap_shift,
             is_writable,
         }
+    }
+
+    /// Only to be used in tests and benches
+    pub fn new_for_testing(
+        slice: &[u8],
+        vm_addr: u64,
+        vm_gap_size: u64,
+        is_writable: bool,
+    ) -> Self {
+        Self::new(slice, vm_addr, vm_gap_size, is_writable)
+    }
+
+    /// Creates a new readonly MemoryRegion from a slice
+    pub fn new_readonly(slice: &[u8], vm_addr: u64) -> Self {
+        Self::new(slice, vm_addr, 0, false)
+    }
+
+    /// Creates a new writable MemoryRegion from a mutable slice
+    pub fn new_writable(slice: &mut [u8], vm_addr: u64) -> Self {
+        Self::new(slice, vm_addr, 0, true)
+    }
+
+    /// Creates a new writable gapped MemoryRegion from a mutable slice
+    pub fn new_writable_gapped(slice: &mut [u8], vm_addr: u64, vm_gap_size: u64) -> Self {
+        Self::new(slice, vm_addr, vm_gap_size, true)
     }
 
     /// Convert a virtual machine address into a host address

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -179,16 +179,16 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 /// use solana_rbpf::vm::{Config, SyscallObject};
 /// use solana_rbpf::user_error::UserError;
 ///
-/// let val = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33];
+/// let mut val = &mut [0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33];
 /// let val_va = 0x100000000;
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_from_slice(&val, val_va, 0, true)], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_writable(val, val_va)], &config).unwrap();
 /// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
-/// assert_eq!(val, vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
+/// assert_eq!(val, &[0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
 /// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
-/// assert_eq!(val, vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
+/// assert_eq!(val, &[0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub struct BpfMemFrob {}
 impl BpfMemFrob {
@@ -275,11 +275,11 @@ impl SyscallObject<UserError> for BpfSqrtI {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false)], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_readonly(foo.as_bytes(), va_foo)], &config).unwrap();
 /// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &memory_mapping, &mut result);
 /// assert!(result.unwrap() == 0);
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_from_slice(foo.as_bytes(), va_foo, 0, false), MemoryRegion::new_from_slice(bar.as_bytes(), va_bar, 0, false)], &config).unwrap();
+/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_readonly(foo.as_bytes(), va_foo), MemoryRegion::new_readonly(bar.as_bytes(), va_bar)], &config).unwrap();
 /// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &memory_mapping, &mut result);
 /// assert!(result.unwrap() != 0);
 /// ```

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -463,7 +463,7 @@ macro_rules! translate_memory_access {
 /// # Examples
 ///
 /// ```
-/// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, user_error::UserError};
+/// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, memory_region::MemoryRegion, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, user_error::UserError};
 ///
 /// let prog = &[
 ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -478,7 +478,8 @@ macro_rules! translate_memory_access {
 /// let syscall_registry = SyscallRegistry::default();
 /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
 /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
-/// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], mem).unwrap();
+/// let mem_region = MemoryRegion::new_from_slice(mem, ebpf::MM_INPUT_START, 0, true);
+/// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 ///
 /// // Provide a reference to the packet data.
 /// let res = vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 1 }).unwrap();
@@ -516,12 +517,12 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let syscall_registry = SyscallRegistry::default();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
-    /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
+    /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
     /// ```
     pub fn new(
         executable: &'a Pin<Box<Executable<E, I>>>,
         heap_region: &mut [u8],
-        input_region: &mut [u8],
+        additional_regions: Vec<MemoryRegion>,
     ) -> Result<EbpfVm<'a, E, I>, EbpfError<E>> {
         let config = executable.get_config();
         let stack = CallFrames::new(config);
@@ -530,8 +531,10 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
             executable.get_ro_region(),
             stack.get_memory_region(),
             MemoryRegion::new_from_slice(heap_region, ebpf::MM_HEAP_START, 0, true),
-            MemoryRegion::new_from_slice(input_region, ebpf::MM_INPUT_START, 0, true),
-        ];
+        ]
+        .into_iter()
+        .chain(additional_regions.into_iter())
+        .collect();
         let (program_vm_addr, program) = executable.get_text_bytes();
         let number_of_syscalls = executable.get_syscall_registry().get_number_of_syscalls();
         let mut vm = EbpfVm {
@@ -606,7 +609,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let mut bpf_functions = std::collections::BTreeMap::new();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
-    /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
+    /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
     /// // Bind a context object instance to the previously registered syscall
     /// vm.bind_syscall_context_objects(0, None);
     /// ```
@@ -667,7 +670,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, memory_region::MemoryRegion, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, user_error::UserError};
     ///
     /// let prog = &[
     ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -682,7 +685,8 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let syscall_registry = SyscallRegistry::default();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
-    /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], mem).unwrap();
+    /// let mem_region = MemoryRegion::new_from_slice(mem, ebpf::MM_INPUT_START, 0, true);
+    /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
     ///
     /// // Provide a reference to the packet data.
     /// let res = vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 1 }).unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -478,7 +478,7 @@ macro_rules! translate_memory_access {
 /// let syscall_registry = SyscallRegistry::default();
 /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
 /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
-/// let mem_region = MemoryRegion::new_from_slice(mem, ebpf::MM_INPUT_START, 0, true);
+/// let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
 /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 ///
 /// // Provide a reference to the packet data.
@@ -525,12 +525,12 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
         additional_regions: Vec<MemoryRegion>,
     ) -> Result<EbpfVm<'a, E, I>, EbpfError<E>> {
         let config = executable.get_config();
-        let stack = CallFrames::new(config);
+        let mut stack = CallFrames::new(config);
         let regions: Vec<MemoryRegion> = vec![
-            MemoryRegion::new_from_slice(&[], 0, 0, false),
+            MemoryRegion::new_readonly(&[], 0),
             executable.get_ro_region(),
             stack.get_memory_region(),
-            MemoryRegion::new_from_slice(heap_region, ebpf::MM_HEAP_START, 0, true),
+            MemoryRegion::new_writable(heap_region, ebpf::MM_HEAP_START),
         ]
         .into_iter()
         .chain(additional_regions.into_iter())
@@ -685,7 +685,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let syscall_registry = SyscallRegistry::default();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
     /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, None, config, syscall_registry, bpf_functions).unwrap();
-    /// let mem_region = MemoryRegion::new_from_slice(mem, ebpf::MM_INPUT_START, 0, true);
+    /// let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
     ///
     /// // Provide a reference to the packet data.

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -133,9 +133,12 @@ fn test_fuzz_execute() {
                 Config::default(),
                 syscall_registry,
             ) {
-                let mut vm =
-                    EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut [])
-                        .unwrap();
+                let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+                    &executable,
+                    &mut [],
+                    Vec::new(),
+                )
+                .unwrap();
                 vm.bind_syscall_context_objects(0, None).unwrap();
                 vm.bind_syscall_context_objects(0, None).unwrap();
                 let _ = vm.execute_program_interpreted(&mut TestInstructionMeter {

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -19,8 +19,7 @@ use solana_rbpf::{
     ebpf,
     elf::{register_bpf_function, ElfError, Executable},
     error::EbpfError,
-    memory_region::AccessType,
-    memory_region::MemoryMapping,
+    memory_region::{AccessType, MemoryMapping, MemoryRegion},
     syscalls::{self, BpfSyscallContext, Result},
     user_error::UserError,
     vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
@@ -43,7 +42,8 @@ macro_rules! test_interpreter_and_jit {
         let mut check_closure = $check;
         let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
-            let mut vm = EbpfVm::new(&$executable, &mut [], &mut mem).unwrap();
+            let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+            let mut vm = EbpfVm::new(&$executable, &mut [], vec![mem_region]).unwrap();
             test_interpreter_and_jit!(bind, vm, $syscall_context);
             let result = vm.execute_program_interpreted(&mut TestInstructionMeter {
                 remaining: $expected_instruction_count,
@@ -58,7 +58,8 @@ macro_rules! test_interpreter_and_jit {
             let compilation_result =
                 Executable::<UserError, TestInstructionMeter>::jit_compile(&mut $executable);
             let mut mem = $mem;
-            let mut vm = EbpfVm::new(&$executable, &mut [], &mut mem).unwrap();
+            let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+            let mut vm = EbpfVm::new(&$executable, &mut [], vec![mem_region]).unwrap();
             match compilation_result {
                 Err(err) => assert!(check_closure(&vm, Err(err))),
                 Ok(()) => {
@@ -4225,7 +4226,8 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     }
     let (instruction_count_interpreter, tracer_interpreter, result_interpreter) = {
         let mut mem = vec![0u8; mem_size];
-        let mut vm = EbpfVm::new(&executable, &mut [], &mut mem).unwrap();
+        let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+        let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
         let result_interpreter = vm.execute_program_interpreted(&mut TestInstructionMeter {
             remaining: max_instruction_count,
         });
@@ -4237,7 +4239,8 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         )
     };
     let mut mem = vec![0u8; mem_size];
-    let mut vm = EbpfVm::new(&executable, &mut [], &mut mem).unwrap();
+    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+    let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
     let result_jit = vm.execute_program_jit(&mut TestInstructionMeter {
         remaining: max_instruction_count,
     });

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -42,7 +42,7 @@ macro_rules! test_interpreter_and_jit {
         let mut check_closure = $check;
         let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
-            let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+            let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
             let mut vm = EbpfVm::new(&$executable, &mut [], vec![mem_region]).unwrap();
             test_interpreter_and_jit!(bind, vm, $syscall_context);
             let result = vm.execute_program_interpreted(&mut TestInstructionMeter {
@@ -58,7 +58,7 @@ macro_rules! test_interpreter_and_jit {
             let compilation_result =
                 Executable::<UserError, TestInstructionMeter>::jit_compile(&mut $executable);
             let mut mem = $mem;
-            let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+            let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
             let mut vm = EbpfVm::new(&$executable, &mut [], vec![mem_region]).unwrap();
             match compilation_result {
                 Err(err) => assert!(check_closure(&vm, Err(err))),
@@ -4226,7 +4226,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     }
     let (instruction_count_interpreter, tracer_interpreter, result_interpreter) = {
         let mut mem = vec![0u8; mem_size];
-        let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+        let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
         let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
         let result_interpreter = vm.execute_program_interpreted(&mut TestInstructionMeter {
             remaining: max_instruction_count,
@@ -4239,7 +4239,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         )
     };
     let mut mem = vec![0u8; mem_size];
-    let mem_region = MemoryRegion::new_from_slice(&mem, ebpf::MM_INPUT_START, 0, true);
+    let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
     let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
     let result_jit = vm.execute_program_jit(&mut TestInstructionMeter {
         remaining: max_instruction_count,

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -54,7 +54,7 @@ fn test_verifier_success() {
     )
     .unwrap();
     let _vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], &mut []).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This will allow ABIv2 in the program runtime to map individual accounts into the programs virtual address space.