### PR TITLE
Removes the optional `hash` parameter from `bind_syscall_context_objects()`.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -214,10 +214,7 @@ fn main() {
         _ => {}
     }
 
-    for (hash, name) in executable.get_syscall_symbols() {
-        vm.bind_syscall_context_objects(Box::new(MockSyscall { name: name.clone() }), Some(*hash))
-            .unwrap();
-    }
+    vm.bind_syscall_context_objects(0).unwrap();
     let result = if matches.value_of("use").unwrap() == "interpreter" {
         vm.execute_program_interpreted(&mut instruction_meter)
     } else {

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -139,8 +139,8 @@ fn test_fuzz_execute() {
                     Vec::new(),
                 )
                 .unwrap();
-                vm.bind_syscall_context_objects(0, None).unwrap();
-                vm.bind_syscall_context_objects(0, None).unwrap();
+                vm.bind_syscall_context_objects(0).unwrap();
+                vm.bind_syscall_context_objects(0).unwrap();
                 let _ = vm.execute_program_interpreted(&mut TestInstructionMeter {
                     remaining: 1_000_000,
                 });

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -34,8 +34,7 @@ macro_rules! test_interpreter_and_jit {
             .unwrap();
     };
     (bind, $vm:expr, $syscall_context:expr) => {
-        $vm.bind_syscall_context_objects($syscall_context, None)
-            .unwrap();
+        $vm.bind_syscall_context_objects($syscall_context).unwrap();
     };
     ($executable:expr, $mem:tt, $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         #[allow(unused_mut)]


### PR DESCRIPTION
See discussion at https://github.com/solana-labs/rbpf/pull/293#discussion_r858556686.