### PR TITLE
Feature: Makes `MemoryRegion` replaceable

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,7 +24,7 @@ impl SyscallObject<UserError> for MockSyscall {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         println!(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -466,7 +466,7 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
                             self.reg[3],
                             self.reg[4],
                             self.reg[5],
-                            &self.vm.memory_mapping,
+                            &mut self.vm.memory_mapping,
                             &mut result,
                         );
                         self.reg[0] = result?;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -57,8 +57,8 @@ pub const BPF_TRACE_PRINTK_IDX: u32 = 6;
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
-/// BpfTracePrintf::call(&mut BpfTracePrintf {}, 0, 0, 1, 15, 32, &memory_mapping, &mut result);
+/// let mut memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
+/// BpfTracePrintf::call(&mut BpfTracePrintf {}, 0, 0, 1, 15, 32, &mut memory_mapping, &mut result);
 /// assert_eq!(result.unwrap() as usize, "BpfTracePrintf: 0x1, 0xf, 0x20\n".len());
 /// ```
 ///
@@ -97,7 +97,7 @@ impl SyscallObject<UserError> for BpfTracePrintf {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         println!("BpfTracePrintf: {:#x}, {:#x}, {:#x}", arg3, arg4, arg5);
@@ -132,8 +132,8 @@ impl SyscallObject<UserError> for BpfTracePrintf {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
-/// BpfGatherBytes::call(&mut BpfGatherBytes {}, 0x11, 0x22, 0x33, 0x44, 0x55, &memory_mapping, &mut result);
+/// let mut memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
+/// BpfGatherBytes::call(&mut BpfGatherBytes {}, 0x11, 0x22, 0x33, 0x44, 0x55, &mut memory_mapping, &mut result);
 /// assert_eq!(result.unwrap(), 0x1122334455);
 /// ```
 pub struct BpfGatherBytes {}
@@ -151,7 +151,7 @@ impl SyscallObject<UserError> for BpfGatherBytes {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         *result = Result::Ok(
@@ -181,10 +181,10 @@ impl SyscallObject<UserError> for BpfGatherBytes {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_writable(val, val_va)], &config).unwrap();
-/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
+/// let mut memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_writable(val, val_va)], &config).unwrap();
+/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &mut memory_mapping, &mut result);
 /// assert_eq!(val, &[0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x3b, 0x08, 0x19]);
-/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &memory_mapping, &mut result);
+/// BpfMemFrob::call(&mut BpfMemFrob {}, val_va, 8, 0, 0, 0, &mut memory_mapping, &mut result);
 /// assert_eq!(val, &[0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33]);
 /// ```
 pub struct BpfMemFrob {}
@@ -202,7 +202,7 @@ impl SyscallObject<UserError> for BpfMemFrob {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         let host_addr = question_mark!(memory_mapping.map(AccessType::Store, vm_addr, len), result);
@@ -233,12 +233,12 @@ impl SyscallObject<UserError> for BpfMemFrob {
 ///
 /// let mut result: Result = Ok(0);
 /// let config = Config::default();
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_readonly(foo.as_bytes(), va_foo)], &config).unwrap();
-/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &memory_mapping, &mut result);
+/// let mut memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_readonly(foo.as_bytes(), va_foo)], &config).unwrap();
+/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_foo, 0, 0, 0, &mut memory_mapping, &mut result);
 /// assert!(result.unwrap() == 0);
 /// let mut result: Result = Ok(0);
-/// let memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_readonly(foo.as_bytes(), va_foo), MemoryRegion::new_readonly(bar.as_bytes(), va_bar)], &config).unwrap();
-/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &memory_mapping, &mut result);
+/// let mut memory_mapping = MemoryMapping::new::<UserError>(vec![MemoryRegion::default(), MemoryRegion::new_readonly(foo.as_bytes(), va_foo), MemoryRegion::new_readonly(bar.as_bytes(), va_bar)], &config).unwrap();
+/// BpfStrCmp::call(&mut BpfStrCmp {}, va_foo, va_bar, 0, 0, 0, &mut memory_mapping, &mut result);
 /// assert!(result.unwrap() != 0);
 /// ```
 pub struct BpfStrCmp {}
@@ -256,7 +256,7 @@ impl SyscallObject<UserError> for BpfStrCmp {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         // C-like strcmp, maybe shorter than converting the bytes to string and comparing?
@@ -302,7 +302,7 @@ impl SyscallObject<UserError> for BpfSyscallString {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         let host_addr = question_mark!(memory_mapping.map(AccessType::Load, vm_addr, len), result);
@@ -338,7 +338,7 @@ impl SyscallObject<UserError> for BpfSyscallU64 {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         println!(
@@ -368,7 +368,7 @@ impl SyscallObject<UserError> for SyscallWithContext {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         println!(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -65,7 +65,7 @@ pub type SyscallInit<'a, C, E> = fn(C) -> Box<(dyn SyscallObject<E> + 'a)>;
 
 /// Syscall function without context
 pub type SyscallFunction<E, O> =
-    fn(O, u64, u64, u64, u64, u64, &MemoryMapping, &mut ProgramResult<E>);
+    fn(O, u64, u64, u64, u64, u64, &mut MemoryMapping, &mut ProgramResult<E>);
 
 /// Syscall with context
 pub trait SyscallObject<E: UserDefinedError> {
@@ -78,7 +78,7 @@ pub trait SyscallObject<E: UserDefinedError> {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &mut MemoryMapping,
         result: &mut ProgramResult<E>,
     );
 }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -3431,7 +3431,7 @@ impl SyscallObject<UserError> for NestedVmSyscall {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &mut MemoryMapping,
         result: &mut Result,
     ) {
         #[allow(unused_mut)]
@@ -3484,12 +3484,12 @@ impl SyscallObject<UserError> for NestedVmSyscall {
 fn test_nested_vm_syscall() {
     let config = Config::default();
     let mut nested_vm_syscall = NestedVmSyscall {};
-    let memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
+    let mut memory_mapping = MemoryMapping::new::<UserError>(vec![], &config).unwrap();
     let mut result = Ok(0);
-    nested_vm_syscall.call(1, 0, 0, 0, 0, &memory_mapping, &mut result);
+    nested_vm_syscall.call(1, 0, 0, 0, 0, &mut memory_mapping, &mut result);
     assert!(result.unwrap() == 42);
     let mut result = Ok(0);
-    nested_vm_syscall.call(1, 1, 0, 0, 0, &memory_mapping, &mut result);
+    nested_vm_syscall.call(1, 1, 0, 0, 0, &mut memory_mapping, &mut result);
     assert!(matches!(result.unwrap_err(),
         EbpfError::CallDepthExceeded(pc, depth)
         if pc == 33 && depth == 0


### PR DESCRIPTION
For a resize syscall it is required to not only be able to change the size of a `MemoryRegion`, but also its host address as that might be affected by a reallocation. This PR also exposes all existing `MemoryRegion` as readable.

Furthermore, the syscalls for CPI and resizing need mutable access to the `MemoryMapping`.