### PR TITLE
Verifier is not optional

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -39,7 +39,6 @@ fn bench_load_elf(bencher: &mut Bencher) {
     bencher.iter(|| {
         Executable::<UserError, TestInstructionMeter>::from_elf(
             &elf,
-            None,
             Config::default(),
             syscall_registry(),
         )
@@ -55,7 +54,6 @@ fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
     bencher.iter(|| {
         let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
             &elf,
-            None,
             Config::default(),
             syscall_registry(),
         )
@@ -72,7 +70,6 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
     bencher.iter(|| {
         let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
             &elf,
-            None,
             Config::default(),
             syscall_registry(),
         )

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -12,10 +12,18 @@ extern crate test;
 use solana_rbpf::{
     elf::Executable,
     user_error::UserError,
+    verifier::{Verifier, VerifierError},
     vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
+
+struct TautologyVerifier {}
+impl Verifier for TautologyVerifier {
+    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
+        Ok(())
+    }
+}
 
 #[bench]
 fn bench_init_vm(bencher: &mut Bencher) {
@@ -29,12 +37,11 @@ fn bench_init_vm(bencher: &mut Bencher) {
     )
     .unwrap();
     let verified_executable =
-        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
-            .unwrap();
-    bencher.iter(|| {
-        EbpfVm::<UserError, TestInstructionMeter>::new(&verified_executable, &mut [], Vec::new())
-            .unwrap()
-    });
+        VerifiedExecutable::<TautologyVerifier, UserError, TestInstructionMeter>::from_executable(
+            executable,
+        )
+        .unwrap();
+    bencher.iter(|| EbpfVm::new(&verified_executable, &mut [], Vec::new()).unwrap());
 }
 
 #[cfg(not(windows))]
@@ -50,7 +57,9 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     )
     .unwrap();
     let mut verified_executable =
-        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
-            .unwrap();
+        VerifiedExecutable::<TautologyVerifier, UserError, TestInstructionMeter>::from_executable(
+            executable,
+        )
+        .unwrap();
     bencher.iter(|| verified_executable.jit_compile().unwrap());
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -12,7 +12,7 @@ extern crate test;
 use solana_rbpf::{
     elf::Executable,
     user_error::UserError,
-    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -24,13 +24,16 @@ fn bench_init_vm(bencher: &mut Bencher) {
     file.read_to_end(&mut elf).unwrap();
     let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
     bencher.iter(|| {
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap()
+        EbpfVm::<UserError, TestInstructionMeter>::new(&verified_executable, &mut [], Vec::new())
+            .unwrap()
     });
 }
 
@@ -40,14 +43,14 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
-    bencher.iter(|| {
-        Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap()
-    });
+    let mut verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
+    bencher.iter(|| verified_executable.jit_compile().unwrap());
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -12,18 +12,11 @@ extern crate test;
 use solana_rbpf::{
     elf::Executable,
     user_error::UserError,
-    verifier::{Verifier, VerifierError},
     vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
-
-struct TautologyVerifier {}
-impl Verifier for TautologyVerifier {
-    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
-        Ok(())
-    }
-}
+use test_utils::TautologyVerifier;
 
 #[bench]
 fn bench_init_vm(bencher: &mut Bencher) {

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -14,18 +14,11 @@ use solana_rbpf::{
     elf::Executable,
     memory_region::MemoryRegion,
     user_error::UserError,
-    verifier::{Verifier, VerifierError},
     vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
-
-struct TautologyVerifier {}
-impl Verifier for TautologyVerifier {
-    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
-        Ok(())
-    }
-}
+use test_utils::TautologyVerifier;
 
 #[bench]
 fn bench_init_interpreter_execution(bencher: &mut Bencher) {

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -14,7 +14,7 @@ use solana_rbpf::{
     elf::Executable,
     memory_region::MemoryRegion,
     user_error::UserError,
-    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -26,13 +26,16 @@ fn bench_init_interpreter_execution(bencher: &mut Bencher) {
     file.read_to_end(&mut elf).unwrap();
     let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&verified_executable, &mut [], Vec::new())
+            .unwrap();
     bencher.iter(|| {
         vm.execute_program_interpreted(&mut TestInstructionMeter { remaining: 29 })
             .unwrap()
@@ -45,16 +48,19 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
-    Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
+    let mut verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
+    verified_executable.jit_compile().unwrap();
     let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&verified_executable, &mut [], Vec::new())
+            .unwrap();
     bencher.iter(|| {
         vm.execute_program_jit(&mut TestInstructionMeter { remaining: 29 })
             .unwrap()
@@ -69,16 +75,18 @@ fn bench_jit_vs_interpreter(
     instruction_meter: u64,
     mem: &mut [u8],
 ) {
-    let mut executable = solana_rbpf::assembler::assemble::<UserError, TestInstructionMeter>(
+    let executable = solana_rbpf::assembler::assemble::<UserError, TestInstructionMeter>(
         assembly,
-        None,
         config,
         SyscallRegistry::default(),
     )
     .unwrap();
-    Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
+    let mut verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
+    verified_executable.jit_compile().unwrap();
     let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
-    let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
+    let mut vm = EbpfVm::new(&verified_executable, &mut [], vec![mem_region]).unwrap();
     let interpreter_summary = bencher
         .bench(|bencher| {
             bencher.iter(|| {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,10 @@ use solana_rbpf::{
     syscalls::Result,
     user_error::UserError,
     verifier::check,
-    vm::{Config, DynamicAnalysis, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
+    vm::{
+        Config, DynamicAnalysis, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter,
+        VerifiedExecutable,
+    },
 };
 use std::{fs::File, io::Read, path::Path};
 
@@ -119,21 +122,19 @@ fn main() {
         enable_symbol_and_section_labels: true,
         ..Config::default()
     };
-    let verifier: Option<for<'r> fn(&'r [u8], &Config) -> std::result::Result<_, _>> =
-        if matches.is_present("verify") {
-            Some(check)
-        } else {
-            None
-        };
+    let verifier = if matches.is_present("verify") {
+        check
+    } else {
+        |_prog: &[u8], _config: &Config| Ok(())
+    };
     let syscall_registry = SyscallRegistry::default();
-    let mut executable = match matches.value_of("assembler") {
+    let executable = match matches.value_of("assembler") {
         Some(asm_file_name) => {
             let mut file = File::open(&Path::new(asm_file_name)).unwrap();
             let mut source = Vec::new();
             file.read_to_end(&mut source).unwrap();
             assemble::<UserError, TestInstructionMeter>(
                 std::str::from_utf8(source.as_slice()).unwrap(),
-                verifier,
                 config,
                 syscall_registry,
             )
@@ -142,16 +143,14 @@ fn main() {
             let mut file = File::open(&Path::new(matches.value_of("elf").unwrap())).unwrap();
             let mut elf = Vec::new();
             file.read_to_end(&mut elf).unwrap();
-            Executable::<UserError, TestInstructionMeter>::from_elf(
-                &elf,
-                verifier,
-                config,
-                syscall_registry,
-            )
-            .map_err(|err| format!("Executable constructor failed: {:?}", err))
+            Executable::<UserError, TestInstructionMeter>::from_elf(&elf, config, syscall_registry)
+                .map_err(|err| format!("Executable constructor failed: {:?}", err))
         }
     }
     .unwrap();
+
+    let mut verified_executable =
+        VerifiedExecutable::from_executable(executable, verifier).unwrap();
 
     let mut mem = match matches.value_of("input").unwrap().parse::<usize>() {
         Ok(allocate) => vec![0u8; allocate],
@@ -178,17 +177,17 @@ fn main() {
             .unwrap()
     ];
     if matches.value_of("use") == Some("jit") {
-        Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
+        verified_executable.jit_compile().unwrap();
     }
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-    let mut vm = EbpfVm::new(&executable, &mut heap, vec![mem_region]).unwrap();
+    let mut vm = EbpfVm::new(&verified_executable, &mut heap, vec![mem_region]).unwrap();
 
     let analysis = if matches.value_of("use") == Some("cfg")
         || matches.value_of("use") == Some("disassembler")
         || matches.is_present("trace")
         || matches.is_present("profile")
     {
-        Some(Analysis::from_executable(&executable).unwrap())
+        Some(Analysis::from_executable(verified_executable.get_executable()).unwrap())
     } else {
         None
     };

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -9,7 +9,6 @@ use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
     user_error::UserError,
-    verifier::check,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
@@ -34,7 +33,6 @@ fn main() {
     ];
     let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         &program,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -16,7 +16,6 @@ use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
     user_error::UserError,
-    verifier::check,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
@@ -32,7 +31,6 @@ use std::collections::BTreeMap;
 fn to_json(program: &[u8]) -> String {
     let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         &program,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "num-traits",
  "rayon",
  "solana_rbpf",
+ "test_utils",
 ]
 
 [[package]]
@@ -382,6 +383,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "test_utils"
+version = "0.2.30"
+dependencies = [
+ "libc",
+ "solana_rbpf",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ arbitrary = { version = "1.0", features = ["derive"] }
 libfuzzer-sys = "0.4"
 num-traits = "0.2"
 rayon = "1.5"
+test_utils = { path = "../test_utils/" }
 
 [dependencies.solana_rbpf]
 path = ".."

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -2,10 +2,7 @@ use std::mem::size_of;
 
 use arbitrary::{Arbitrary, Unstructured};
 
-use solana_rbpf::{
-    verifier::{Verifier, VerifierError},
-    vm::Config,
-};
+use solana_rbpf::vm::Config;
 
 #[derive(Debug)]
 pub struct ConfigTemplate {
@@ -86,12 +83,5 @@ impl From<ConfigTemplate> for Config {
                 ..Default::default()
             },
         }
-    }
-}
-
-pub struct TautologyVerifier {}
-impl Verifier for TautologyVerifier {
-    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
-        Ok(())
     }
 }

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -2,7 +2,10 @@ use std::mem::size_of;
 
 use arbitrary::{Arbitrary, Unstructured};
 
-use solana_rbpf::vm::Config;
+use solana_rbpf::{
+    verifier::{Verifier, VerifierError},
+    vm::Config,
+};
 
 #[derive(Debug)]
 pub struct ConfigTemplate {
@@ -83,5 +86,12 @@ impl From<ConfigTemplate> for Config {
                 ..Default::default()
             },
         }
+    }
+}
+
+pub struct TautologyVerifier {}
+impl Verifier for TautologyVerifier {
+    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
+        Ok(())
     }
 }

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -14,8 +14,9 @@ use solana_rbpf::{
     verifier::{RequisiteVerifier, Verifier},
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
+use test_utils::TautologyVerifier;
 
-use crate::common::{ConfigTemplate, TautologyVerifier};
+use crate::common::ConfigTemplate;
 
 mod common;
 

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -12,7 +12,7 @@ use solana_rbpf::{
     memory_region::MemoryRegion,
     user_error::UserError,
     verifier::check,
-    vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 
 use crate::common::ConfigTemplate;
@@ -39,15 +39,21 @@ fuzz_target!(|data: DumbFuzzData| {
     register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
     let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         &prog,
-        None,
         config,
         SyscallRegistry::default(),
         bpf_functions,
     )
     .unwrap();
+    let verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-    let mut vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
+    let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+        &verified_executable,
+        &mut [],
+        vec![mem_region],
+    )
+    .unwrap();
 
     drop(black_box(vm.execute_program_interpreted(
         &mut TestInstructionMeter { remaining: 1024 },

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -16,8 +16,9 @@ use solana_rbpf::{
     verifier::{RequisiteVerifier, Verifier},
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
+use test_utils::TautologyVerifier;
 
-use crate::common::{ConfigTemplate, TautologyVerifier};
+use crate::common::ConfigTemplate;
 
 mod common;
 mod grammar_aware;

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -14,8 +14,9 @@ use solana_rbpf::{
     verifier::{RequisiteVerifier, Verifier},
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
+use test_utils::TautologyVerifier;
 
-use crate::common::{ConfigTemplate, TautologyVerifier};
+use crate::common::ConfigTemplate;
 
 mod common;
 mod grammar_aware;

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -12,7 +12,7 @@ use solana_rbpf::{
     memory_region::MemoryRegion,
     user_error::UserError,
     verifier::check,
-    vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 
 use crate::common::ConfigTemplate;
@@ -49,23 +49,31 @@ fuzz_target!(|data: FuzzData| {
     let registry = SyscallRegistry::default();
     let mut bpf_functions = BTreeMap::new();
     register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog.into_bytes(),
-        None,
         config,
         SyscallRegistry::default(),
         bpf_functions,
     )
     .unwrap();
-    if Executable::jit_compile(&mut executable).is_ok() {
+    let mut verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
+    if verified_executable.jit_compile().is_ok() {
         let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
-        let mut interp_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![interp_mem_region])
-                .unwrap();
+        let mut interp_vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+            &verified_executable,
+            &mut [],
+            vec![interp_mem_region],
+        )
+        .unwrap();
         let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
-        let mut jit_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![jit_mem_region])
-                .unwrap();
+        let mut jit_vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+            &verified_executable,
+            &mut [],
+            vec![jit_mem_region],
+        )
+        .unwrap();
 
         let mut interp_meter = TestInstructionMeter { remaining: 1 << 16 };
         let interp_res = interp_vm.execute_program_interpreted(&mut interp_meter);

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -16,8 +16,9 @@ use solana_rbpf::{
     verifier::{RequisiteVerifier, Verifier},
     vm::{EbpfVm, InstructionMeter, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
+use test_utils::TautologyVerifier;
 
-use crate::common::{ConfigTemplate, TautologyVerifier};
+use crate::common::ConfigTemplate;
 
 mod common;
 mod semantic_aware;

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -14,7 +14,9 @@ use solana_rbpf::{
     static_analysis::Analysis,
     user_error::UserError,
     verifier::check,
-    vm::{EbpfVm, InstructionMeter, SyscallRegistry, TestInstructionMeter},
+    vm::{
+        Config, EbpfVm, InstructionMeter, SyscallRegistry, TestInstructionMeter, VerifiedExecutable,
+    },
 };
 
 use crate::common::ConfigTemplate;
@@ -29,8 +31,10 @@ struct FuzzData {
     mem: Vec<u8>,
 }
 
-fn dump_insns<E: UserDefinedError, I: InstructionMeter>(executable: &Executable<E, I>) {
-    let analysis = Analysis::from_executable(executable).unwrap();
+fn dump_insns<E: UserDefinedError, I: InstructionMeter>(
+    verified_executable: &VerifiedExecutable<E, I>,
+) {
+    let analysis = Analysis::from_executable(verified_executable.get_executable()).unwrap();
     eprint!("Using the following disassembly");
     analysis.disassemble(&mut std::io::stderr().lock()).unwrap();
 }
@@ -47,23 +51,31 @@ fuzz_target!(|data: FuzzData| {
     let registry = SyscallRegistry::default();
     let mut bpf_functions = BTreeMap::new();
     register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog.into_bytes(),
-        None,
         config,
         SyscallRegistry::default(),
         bpf_functions,
     )
     .unwrap();
-    if Executable::jit_compile(&mut executable).is_ok() {
+    let mut verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
+    if verified_executable.jit_compile().is_ok() {
         let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
-        let mut interp_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![interp_mem_region])
-                .unwrap();
+        let mut interp_vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+            &verified_executable,
+            &mut [],
+            vec![interp_mem_region],
+        )
+        .unwrap();
         let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
-        let mut jit_vm =
-            EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![jit_mem_region])
-                .unwrap();
+        let mut jit_vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+            &verified_executable,
+            &mut [],
+            vec![jit_mem_region],
+        )
+        .unwrap();
 
         let mut interp_meter = TestInstructionMeter { remaining: 1 << 16 };
         let interp_res = interp_vm.execute_program_interpreted(&mut interp_meter);
@@ -82,20 +94,20 @@ fuzz_target!(|data: FuzzData| {
                 }
             }
             eprintln!("{:#?}", &data.prog);
-            dump_insns(&executable);
+            dump_insns(&verified_executable);
             panic!("Expected {:?}, but got {:?}", interp_res, jit_res);
         }
         if interp_res.is_ok() {
             // we know jit res must be ok if interp res is by this point
             if interp_meter.remaining != jit_meter.remaining {
-                dump_insns(&executable);
+                dump_insns(&verified_executable);
                 panic!(
                     "Expected {} insts remaining, but got {}",
                     interp_meter.remaining, jit_meter.remaining
                 );
             }
             if interp_mem != jit_mem {
-                dump_insns(&executable);
+                dump_insns(&verified_executable);
                 panic!(
                     "Expected different memory. From interpreter: {:?}\nFrom JIT: {:?}",
                     interp_mem, jit_mem

--- a/fuzz/fuzz_targets/verify_semantic_aware.rs
+++ b/fuzz/fuzz_targets/verify_semantic_aware.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::fuzz_target;
 
 use semantic_aware::*;
 use solana_rbpf::insn_builder::IntoBytes;
-use solana_rbpf::verifier::check;
+use solana_rbpf::verifier::{RequisiteVerifier, Verifier};
 
 use crate::common::ConfigTemplate;
 
@@ -20,5 +20,5 @@ struct FuzzData {
 fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
-    check(prog.into_bytes(), &config).unwrap();
+    RequisiteVerifier::verify(prog.into_bytes(), &config).unwrap();
 });

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -20,7 +20,7 @@ use crate::{
     ebpf::{self, Insn},
     elf::{register_bpf_function, Executable},
     error::UserDefinedError,
-    vm::{Config, InstructionMeter, SyscallRegistry, Verifier},
+    vm::{Config, InstructionMeter, SyscallRegistry},
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -194,7 +194,6 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 ///     be16 r0
 ///     neg64 r2
 ///     exit",
-///     Some(check),
 ///     Config::default(),
 ///     SyscallRegistry::default(),
 /// ).unwrap();
@@ -221,7 +220,6 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 /// ```
 pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     src: &str,
-    verifier: Option<Verifier>,
     config: Config,
     syscall_registry: SyscallRegistry,
 ) -> Result<Pin<Box<Executable<E, I>>>, String> {
@@ -389,6 +387,6 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
         .iter()
         .flat_map(|insn| insn.to_vec())
         .collect::<Vec<_>>();
-    Executable::<E, I>::from_text_bytes(&program, verifier, config, syscall_registry, bpf_functions)
+    Executable::<E, I>::from_text_bytes(&program, config, syscall_registry, bpf_functions)
         .map_err(|err| format!("Executable constructor {:?}", err))
 }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -186,7 +186,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 /// # Examples
 ///
 /// ```
-/// use solana_rbpf::{assembler::assemble, user_error::UserError, vm::{Config, TestInstructionMeter, SyscallRegistry}, verifier::check};
+/// use solana_rbpf::{assembler::assemble, user_error::UserError, vm::{Config, TestInstructionMeter, SyscallRegistry}};
 /// let executable = assemble::<UserError, TestInstructionMeter>(
 ///    "add64 r1, 0x605
 ///     mov64 r2, 0x32

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2086,13 +2086,9 @@ mod test {
         let mut elf_bytes = Vec::new();
         file.read_to_end(&mut elf_bytes)
             .expect("failed to read elf file");
-        let mut executable = ElfExecutable::from_elf(
-            &elf_bytes,
-            Some(crate::verifier::check),
-            Config::default(),
-            syscall_registry(),
-        )
-        .expect("validation failed");
+        let mut executable =
+            ElfExecutable::from_elf(&elf_bytes, Config::default(), syscall_registry())
+                .expect("validation failed");
         {
             Executable::jit_compile(&mut executable).unwrap();
         }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -18,6 +18,7 @@ use crate::{
     error::{EbpfError, UserDefinedError},
     memory_region::AccessType,
     user_error::UserError,
+    verifier::Verifier,
     vm::{
         EbpfVm, InstructionMeter, ProgramResult, SyscallFunction, SYSCALL_CONTEXT_OBJECTS_OFFSET,
     },
@@ -57,9 +58,8 @@ macro_rules! translate_memory_access {
 }
 
 /// State of an interpreter
-pub struct Interpreter<'a, 'b, E: UserDefinedError, I: InstructionMeter> {
-    vm: &'a mut EbpfVm<'b, E, I>,
-
+pub struct Interpreter<'a, 'b, V: Verifier, E: UserDefinedError, I: InstructionMeter> {
+    vm: &'a mut EbpfVm<'b, V, E, I>,
     instruction_meter: &'a mut I,
     pub(crate) initial_insn_count: u64,
     remaining_insn_count: u64,
@@ -71,10 +71,10 @@ pub struct Interpreter<'a, 'b, E: UserDefinedError, I: InstructionMeter> {
     pub pc: usize,
 }
 
-impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I> {
+impl<'a, 'b, V: Verifier, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, V, E, I> {
     /// Creates a new interpreter state
     pub fn new(
-        vm: &'a mut EbpfVm<'b, E, I>,
+        vm: &'a mut EbpfVm<'b, V, E, I>,
         instruction_meter: &'a mut I,
     ) -> Result<Self, EbpfError<E>> {
         let executable = vm.verified_executable.get_executable();

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -77,7 +77,8 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
         vm: &'a mut EbpfVm<'b, E, I>,
         instruction_meter: &'a mut I,
     ) -> Result<Self, EbpfError<E>> {
-        let initial_insn_count = if vm.executable.get_config().enable_instruction_meter {
+        let executable = vm.verified_executable.get_executable();
+        let initial_insn_count = if executable.get_config().enable_instruction_meter {
             instruction_meter.get_remaining()
         } else {
             0
@@ -96,7 +97,7 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
             0,
             vm.stack.get_frame_ptr(),
         ];
-        let pc = vm.executable.get_entrypoint_instruction_offset()?;
+        let pc = executable.get_entrypoint_instruction_offset()?;
         Ok(Self {
             vm,
             instruction_meter,
@@ -130,7 +131,8 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
     /// Advances the interpreter state by one instruction
     #[rustfmt::skip]
     pub fn step(&mut self) -> Result<Option<u64>, EbpfError<E>> {
-        let config = &self.vm.executable.get_config();
+        let executable = self.vm.verified_executable.get_executable();
+        let config = &executable.get_config();
 
         let mut instruction_width = 1;
         self.due_insn_count += 1;
@@ -451,7 +453,7 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
                 };
 
                 if syscalls {
-                    if let Some(syscall) = self.vm.executable.get_syscall_registry().lookup_syscall(insn.imm as u32) {
+                    if let Some(syscall) = executable.get_syscall_registry().lookup_syscall(insn.imm as u32) {
                         resolved = true;
 
                         if config.enable_instruction_meter {
@@ -477,7 +479,7 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
                 }
 
                 if calls {
-                    if let Some(target_pc) = self.vm.executable.lookup_bpf_function(insn.imm as u32) {
+                    if let Some(target_pc) = executable.lookup_bpf_function(insn.imm as u32) {
                         resolved = true;
 
                         // make BPF to BPF call
@@ -491,7 +493,7 @@ impl<'a, 'b, E: UserDefinedError, I: InstructionMeter> Interpreter<'a, 'b, E, I>
                     if config.disable_unresolved_symbols_at_runtime {
                         return Err(EbpfError::UnsupportedInstruction(pc + ebpf::ELF_INSN_DUMP_OFFSET));
                     } else {
-                        self.vm.executable.report_unresolved_symbol(pc)?;
+                        executable.report_unresolved_symbol(pc)?;
                     }
                 }
             }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1821,7 +1821,6 @@ mod tests {
         bpf_functions.insert(0xFFFFFFFF, (8, "foo".to_string()));
         Executable::<UserError, TestInstructionMeter>::from_text_bytes(
             program,
-            None,
             config,
             syscall_registry,
             bpf_functions,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -368,3 +368,11 @@ impl Verifier for RequisiteVerifier {
         Ok(())
     }
 }
+
+// Warning: For test purposes only
+pub(crate) struct TautologyVerifier {}
+impl Verifier for TautologyVerifier {
+    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
+        Ok(())
+    }
+}

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -79,6 +79,19 @@ pub enum VerifierError {
     InvalidRegister(usize),
 }
 
+/// eBPF Verifier
+pub trait Verifier {
+    /// eBPF verification function that returns an error if the program does not meet its requirements.
+    ///
+    /// Some examples of things the verifier may reject the program for:
+    ///
+    ///   - Program does not terminate.
+    ///   - Unknown instructions.
+    ///   - Bad formed instruction.
+    ///   - Unknown eBPF syscall index.
+    fn verify(prog: &[u8], config: &Config) -> Result<(), VerifierError>;
+}
+
 fn adj_insn_ptr(insn_ptr: usize) -> usize {
     insn_ptr + ebpf::ELF_INSN_DUMP_OFFSET
 }
@@ -190,163 +203,168 @@ fn check_imm_register(
     Ok(())
 }
 
-/// Check the program against the verifier's rules
-#[rustfmt::skip]
-pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
-    check_prog_len(prog)?;
+/// Mandatory verifier for solana programs to run on-chain
+#[derive(Debug)]
+pub struct RequisiteVerifier {}
+impl Verifier for RequisiteVerifier {
+    /// Check the program against the verifier's rules
+    #[rustfmt::skip]
+    fn verify(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
+        check_prog_len(prog)?;
 
-    let mut insn_ptr: usize = 0;
-    while (insn_ptr + 1) * ebpf::INSN_SIZE <= prog.len() {
-        let insn = ebpf::get_insn(prog, insn_ptr);
-        let mut store = false;
+        let mut insn_ptr: usize = 0;
+        while (insn_ptr + 1) * ebpf::INSN_SIZE <= prog.len() {
+            let insn = ebpf::get_insn(prog, insn_ptr);
+            let mut store = false;
 
-        match insn.opc {
-            ebpf::LD_ABS_B
-            | ebpf::LD_ABS_H
-            | ebpf::LD_ABS_W
-            | ebpf::LD_ABS_DW
-            | ebpf::LD_IND_B
-            | ebpf::LD_IND_H
-            | ebpf::LD_IND_W
-            | ebpf::LD_IND_DW if config.disable_deprecated_load_instructions => {
-                return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
-            },
+            match insn.opc {
+                ebpf::LD_ABS_B
+                | ebpf::LD_ABS_H
+                | ebpf::LD_ABS_W
+                | ebpf::LD_ABS_DW
+                | ebpf::LD_IND_B
+                | ebpf::LD_IND_H
+                | ebpf::LD_IND_W
+                | ebpf::LD_IND_DW if config.disable_deprecated_load_instructions => {
+                    return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
+                },
 
-            // BPF_LD class
-            ebpf::LD_ABS_B   => {},
-            ebpf::LD_ABS_H   => {},
-            ebpf::LD_ABS_W   => {},
-            ebpf::LD_ABS_DW  => {},
-            ebpf::LD_IND_B   => {},
-            ebpf::LD_IND_H   => {},
-            ebpf::LD_IND_W   => {},
-            ebpf::LD_IND_DW  => {},
+                // BPF_LD class
+                ebpf::LD_ABS_B   => {},
+                ebpf::LD_ABS_H   => {},
+                ebpf::LD_ABS_W   => {},
+                ebpf::LD_ABS_DW  => {},
+                ebpf::LD_IND_B   => {},
+                ebpf::LD_IND_H   => {},
+                ebpf::LD_IND_W   => {},
+                ebpf::LD_IND_DW  => {},
 
-            ebpf::LD_DW_IMM  => {
-                check_load_dw(prog, insn_ptr)?;
-                insn_ptr += 1;
-            },
+                ebpf::LD_DW_IMM  => {
+                    check_load_dw(prog, insn_ptr)?;
+                    insn_ptr += 1;
+                },
 
-            // BPF_LDX class
-            ebpf::LD_B_REG   => {},
-            ebpf::LD_H_REG   => {},
-            ebpf::LD_W_REG   => {},
-            ebpf::LD_DW_REG  => {},
+                // BPF_LDX class
+                ebpf::LD_B_REG   => {},
+                ebpf::LD_H_REG   => {},
+                ebpf::LD_W_REG   => {},
+                ebpf::LD_DW_REG  => {},
 
-            // BPF_ST class
-            ebpf::ST_B_IMM   => store = true,
-            ebpf::ST_H_IMM   => store = true,
-            ebpf::ST_W_IMM   => store = true,
-            ebpf::ST_DW_IMM  => store = true,
+                // BPF_ST class
+                ebpf::ST_B_IMM   => store = true,
+                ebpf::ST_H_IMM   => store = true,
+                ebpf::ST_W_IMM   => store = true,
+                ebpf::ST_DW_IMM  => store = true,
 
-            // BPF_STX class
-            ebpf::ST_B_REG   => store = true,
-            ebpf::ST_H_REG   => store = true,
-            ebpf::ST_W_REG   => store = true,
-            ebpf::ST_DW_REG  => store = true,
+                // BPF_STX class
+                ebpf::ST_B_REG   => store = true,
+                ebpf::ST_H_REG   => store = true,
+                ebpf::ST_W_REG   => store = true,
+                ebpf::ST_DW_REG  => store = true,
 
-            // BPF_ALU class
-            ebpf::ADD32_IMM  => {},
-            ebpf::ADD32_REG  => {},
-            ebpf::SUB32_IMM  => {},
-            ebpf::SUB32_REG  => {},
-            ebpf::MUL32_IMM  => {},
-            ebpf::MUL32_REG  => {},
-            ebpf::DIV32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::DIV32_REG  => {},
-            ebpf::SDIV32_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::SDIV32_REG if config.enable_sdiv => {},
-            ebpf::OR32_IMM   => {},
-            ebpf::OR32_REG   => {},
-            ebpf::AND32_IMM  => {},
-            ebpf::AND32_REG  => {},
-            ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
-            ebpf::LSH32_REG  => {},
-            ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
-            ebpf::RSH32_REG  => {},
-            ebpf::NEG32      => {},
-            ebpf::MOD32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::MOD32_REG  => {},
-            ebpf::XOR32_IMM  => {},
-            ebpf::XOR32_REG  => {},
-            ebpf::MOV32_IMM  => {},
-            ebpf::MOV32_REG  => {},
-            ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr, 32)?; },
-            ebpf::ARSH32_REG => {},
-            ebpf::LE         => { check_imm_endian(&insn, insn_ptr)?; },
-            ebpf::BE         => { check_imm_endian(&insn, insn_ptr)?; },
+                // BPF_ALU class
+                ebpf::ADD32_IMM  => {},
+                ebpf::ADD32_REG  => {},
+                ebpf::SUB32_IMM  => {},
+                ebpf::SUB32_REG  => {},
+                ebpf::MUL32_IMM  => {},
+                ebpf::MUL32_REG  => {},
+                ebpf::DIV32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::DIV32_REG  => {},
+                ebpf::SDIV32_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::SDIV32_REG if config.enable_sdiv => {},
+                ebpf::OR32_IMM   => {},
+                ebpf::OR32_REG   => {},
+                ebpf::AND32_IMM  => {},
+                ebpf::AND32_REG  => {},
+                ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
+                ebpf::LSH32_REG  => {},
+                ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
+                ebpf::RSH32_REG  => {},
+                ebpf::NEG32      => {},
+                ebpf::MOD32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::MOD32_REG  => {},
+                ebpf::XOR32_IMM  => {},
+                ebpf::XOR32_REG  => {},
+                ebpf::MOV32_IMM  => {},
+                ebpf::MOV32_REG  => {},
+                ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr, 32)?; },
+                ebpf::ARSH32_REG => {},
+                ebpf::LE         => { check_imm_endian(&insn, insn_ptr)?; },
+                ebpf::BE         => { check_imm_endian(&insn, insn_ptr)?; },
 
-            // BPF_ALU64 class
-            ebpf::ADD64_IMM  => {},
-            ebpf::ADD64_REG  => {},
-            ebpf::SUB64_IMM  => {},
-            ebpf::SUB64_REG  => {},
-            ebpf::MUL64_IMM  => {},
-            ebpf::MUL64_REG  => {},
-            ebpf::DIV64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::DIV64_REG  => {},
-            ebpf::SDIV64_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::SDIV64_REG if config.enable_sdiv => {},
-            ebpf::OR64_IMM   => {},
-            ebpf::OR64_REG   => {},
-            ebpf::AND64_IMM  => {},
-            ebpf::AND64_REG  => {},
-            ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
-            ebpf::LSH64_REG  => {},
-            ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
-            ebpf::RSH64_REG  => {},
-            ebpf::NEG64      => {},
-            ebpf::MOD64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::MOD64_REG  => {},
-            ebpf::XOR64_IMM  => {},
-            ebpf::XOR64_REG  => {},
-            ebpf::MOV64_IMM  => {},
-            ebpf::MOV64_REG  => {},
-            ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr, 64)?; },
-            ebpf::ARSH64_REG => {},
+                // BPF_ALU64 class
+                ebpf::ADD64_IMM  => {},
+                ebpf::ADD64_REG  => {},
+                ebpf::SUB64_IMM  => {},
+                ebpf::SUB64_REG  => {},
+                ebpf::MUL64_IMM  => {},
+                ebpf::MUL64_REG  => {},
+                ebpf::DIV64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::DIV64_REG  => {},
+                ebpf::SDIV64_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::SDIV64_REG if config.enable_sdiv => {},
+                ebpf::OR64_IMM   => {},
+                ebpf::OR64_REG   => {},
+                ebpf::AND64_IMM  => {},
+                ebpf::AND64_REG  => {},
+                ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
+                ebpf::LSH64_REG  => {},
+                ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
+                ebpf::RSH64_REG  => {},
+                ebpf::NEG64      => {},
+                ebpf::MOD64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::MOD64_REG  => {},
+                ebpf::XOR64_IMM  => {},
+                ebpf::XOR64_REG  => {},
+                ebpf::MOV64_IMM  => {},
+                ebpf::MOV64_REG  => {},
+                ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr, 64)?; },
+                ebpf::ARSH64_REG => {},
 
-            // BPF_JMP class
-            ebpf::JA         => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JEQ_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JEQ_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSET_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSET_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JNE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JNE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::CALL_IMM   => {},
-            ebpf::CALL_REG   => { check_imm_register(&insn, insn_ptr, config)?; },
-            ebpf::EXIT       => {},
+                // BPF_JMP class
+                ebpf::JA         => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JEQ_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JEQ_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSET_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSET_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JNE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JNE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::CALL_IMM   => {},
+                ebpf::CALL_REG   => { check_imm_register(&insn, insn_ptr, config)?; },
+                ebpf::EXIT       => {},
 
-            _                => {
-                return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
+                _                => {
+                    return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
+                }
             }
+
+            check_registers(&insn, store, insn_ptr, config.dynamic_stack_frames)?;
+
+            insn_ptr += 1;
         }
 
-        check_registers(&insn, store, insn_ptr, config.dynamic_stack_frames)?;
+        // insn_ptr should now be equal to number of instructions.
+        if insn_ptr != prog.len() / ebpf::INSN_SIZE {
+            return Err(VerifierError::JumpOutOfCode(adj_insn_ptr(insn_ptr), adj_insn_ptr(insn_ptr)));
+        }
 
-        insn_ptr += 1;
+        Ok(())
     }
-
-    // insn_ptr should now be equal to number of instructions.
-    if insn_ptr != prog.len() / ebpf::INSN_SIZE {
-        return Err(VerifierError::JumpOutOfCode(adj_insn_ptr(insn_ptr), adj_insn_ptr(insn_ptr)));
-    }
-
-    Ok(())
 }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -151,3 +151,13 @@ pub const TCP_SACK_NOMATCH: [u8; 66] = [
     0x08, 0x0a, 0x00, 0x17, 0x95, 0x6f, 0x8d, 0x9d, //
     0x9e, 0x27, //
 ];
+
+pub struct TautologyVerifier {}
+impl solana_rbpf::verifier::Verifier for TautologyVerifier {
+    fn verify(
+        _prog: &[u8],
+        _config: &solana_rbpf::vm::Config,
+    ) -> std::result::Result<(), solana_rbpf::verifier::VerifierError> {
+        Ok(())
+    }
+}

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -12,7 +12,6 @@ use solana_rbpf::{
     assembler::assemble,
     ebpf,
     user_error::UserError,
-    verifier::check,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
@@ -20,7 +19,6 @@ use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
 fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
     let executable = assemble::<UserError, TestInstructionMeter>(
         src,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )?;
@@ -578,7 +576,6 @@ fn test_large_immediate() {
 fn test_tcp_sack() {
     let executable = assemble::<UserError, TestInstructionMeter>(
         TCP_SACK_ASM,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -22,13 +22,9 @@ macro_rules! disasm {
             enable_symbol_and_section_labels: true,
             ..Config::default()
         };
-        let executable = assemble::<UserError, TestInstructionMeter>(
-            src,
-            None,
-            config,
-            SyscallRegistry::default(),
-        )
-        .unwrap();
+        let executable =
+            assemble::<UserError, TestInstructionMeter>(src, config, SyscallRegistry::default())
+                .unwrap();
         let analysis = Analysis::from_executable(&executable).unwrap();
         let mut reasm = Vec::new();
         analysis.disassemble(&mut reasm).unwrap();

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -26,7 +26,7 @@ use solana_rbpf::{
     fuzz::fuzz,
     syscalls::{BpfSyscallContext, BpfSyscallString, BpfSyscallU64},
     user_error::UserError,
-    verifier::check,
+    verifier::RequisiteVerifier,
     vm::{
         Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter, VerifiedExecutable,
     },
@@ -134,10 +134,13 @@ fn test_fuzz_execute() {
                 Config::default(),
                 syscall_registry,
             ) {
-                if let Ok(verified_executable) =
-                    VerifiedExecutable::from_executable(executable, check)
+                if let Ok(verified_executable) = VerifiedExecutable::<
+                    RequisiteVerifier,
+                    UserError,
+                    TestInstructionMeter,
+                >::from_executable(executable)
                 {
-                    let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(
+                    let mut vm = EbpfVm::<RequisiteVerifier, UserError, TestInstructionMeter>::new(
                         &verified_executable,
                         &mut [],
                         Vec::new(),

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -22,8 +22,9 @@ use solana_rbpf::{
     memory_region::{AccessType, MemoryMapping, MemoryRegion},
     syscalls::{self, BpfSyscallContext, Result},
     user_error::UserError,
-    verifier::check,
-    vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
+    vm::{
+        Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter, VerifiedExecutable,
+    },
 };
 use std::{collections::BTreeMap, fs::File, io::Read};
 use test_utils::{PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH};
@@ -40,10 +41,17 @@ macro_rules! test_interpreter_and_jit {
     ($executable:expr, $mem:tt, $syscall_context:expr, $check:block, $expected_instruction_count:expr) => {
         #[allow(unused_mut)]
         let mut check_closure = $check;
+        #[allow(unused_mut)]
+        let mut verified_executable =
+            VerifiedExecutable::from_executable($executable, |_prog: &[u8], _config: &Config| {
+                Ok(())
+            })
+            .unwrap();
         let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
             let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-            let mut vm = EbpfVm::new(&$executable, &mut [], vec![mem_region]).unwrap();
+
+            let mut vm = EbpfVm::new(&verified_executable, &mut [], vec![mem_region]).unwrap();
             test_interpreter_and_jit!(bind, vm, $syscall_context);
             let result = vm.execute_program_interpreted(&mut TestInstructionMeter {
                 remaining: $expected_instruction_count,
@@ -55,11 +63,10 @@ macro_rules! test_interpreter_and_jit {
         {
             #[allow(unused_mut)]
             let mut check_closure = $check;
-            let compilation_result =
-                Executable::<UserError, TestInstructionMeter>::jit_compile(&mut $executable);
+            let compilation_result = verified_executable.jit_compile();
             let mut mem = $mem;
             let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-            let mut vm = EbpfVm::new(&$executable, &mut [], vec![mem_region]).unwrap();
+            let mut vm = EbpfVm::new(&verified_executable, &mut [], vec![mem_region]).unwrap();
             match compilation_result {
                 Err(err) => assert!(check_closure(&vm, Err(err))),
                 Ok(()) => {
@@ -71,9 +78,10 @@ macro_rules! test_interpreter_and_jit {
                     if !check_closure(&vm, result)
                         || !solana_rbpf::vm::Tracer::compare(&_tracer_interpreter, tracer_jit)
                     {
-                        let analysis =
-                            solana_rbpf::static_analysis::Analysis::from_executable(&$executable)
-                                .unwrap();
+                        let analysis = solana_rbpf::static_analysis::Analysis::from_executable(
+                            verified_executable.get_executable(),
+                        )
+                        .unwrap();
                         let stdout = std::io::stdout();
                         _tracer_interpreter
                             .write(&mut stdout.lock(), &analysis)
@@ -81,14 +89,22 @@ macro_rules! test_interpreter_and_jit {
                         tracer_jit.write(&mut stdout.lock(), &analysis).unwrap();
                         panic!();
                     }
-                    if $executable.get_config().enable_instruction_meter {
+                    if verified_executable
+                        .get_executable()
+                        .get_config()
+                        .enable_instruction_meter
+                    {
                         let instruction_count_jit = vm.get_total_instruction_count();
                         assert_eq!(instruction_count_interpreter, instruction_count_jit);
                     }
                 }
             }
         }
-        if $executable.get_config().enable_instruction_meter {
+        if verified_executable
+            .get_executable()
+            .get_config()
+            .enable_instruction_meter
+        {
             assert_eq!(instruction_count_interpreter, $expected_instruction_count);
         }
     };
@@ -100,7 +116,7 @@ macro_rules! test_interpreter_and_jit_asm {
         {
             let mut syscall_registry = SyscallRegistry::default();
             $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_init; $syscall_function);)*
-            let mut executable = assemble($source, Some(check), $config, syscall_registry).unwrap();
+            let mut executable = assemble($source, $config, syscall_registry).unwrap();
             test_interpreter_and_jit!(executable, $mem, $syscall_context, $check, $expected_instruction_count);
         }
     };
@@ -126,7 +142,15 @@ macro_rules! test_interpreter_and_jit_elf {
         {
             let mut syscall_registry = SyscallRegistry::default();
             $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_init; $syscall_function);)*
+<<<<<<< HEAD
             let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, Some(check), $config, syscall_registry).unwrap();
+=======
+<<<<<<< HEAD
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, Some(solana_rbpf::verifier::check), $config, syscall_registry).unwrap();
+=======
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, $config, syscall_registry).unwrap();
+>>>>>>> 8dba993 (Verifier is not optional)
+>>>>>>> ba982fe (Verifier is not optional)
             test_interpreter_and_jit!(executable, $mem, $syscall_context, $check, $expected_instruction_count);
         }
     };
@@ -2891,7 +2915,10 @@ fn test_err_mem_access_out_of_bound() {
         #[allow(unused_mut)]
         let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
             &prog,
+<<<<<<< HEAD
             Some(check),
+=======
+>>>>>>> ba982fe (Verifier is not optional)
             config,
             syscall_registry,
             bpf_functions,
@@ -3416,7 +3443,10 @@ impl SyscallObject<UserError> for NestedVmSyscall {
                 ldxb r1, [r1]
                 syscall NestedVmSyscall
                 exit",
+<<<<<<< HEAD
                 Some(check),
+=======
+>>>>>>> ba982fe (Verifier is not optional)
                 Config::default(),
                 syscall_registry,
             )
@@ -3552,6 +3582,7 @@ fn test_custom_entrypoint() {
     let mut syscall_registry = SyscallRegistry::default();
     test_interpreter_and_jit!(register, syscall_registry, b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call);
     #[allow(unused_mut)]
+<<<<<<< HEAD
     let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
         &elf,
         Some(check),
@@ -3559,6 +3590,11 @@ fn test_custom_entrypoint() {
         syscall_registry,
     )
     .unwrap();
+=======
+    let mut executable =
+        Executable::<UserError, TestInstructionMeter>::from_elf(&elf, config, syscall_registry)
+            .unwrap();
+>>>>>>> ba982fe (Verifier is not optional)
     test_interpreter_and_jit!(
         executable,
         [],
@@ -3981,7 +4017,11 @@ fn test_err_unresolved_elf() {
         ..Config::default()
     };
     assert!(
+<<<<<<< HEAD
         matches!(Executable::<UserError, TestInstructionMeter>::from_elf(&elf, Some(check), config, syscall_registry), Err(EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset))) if symbol == "log_64" && pc == 550 && offset == 4168)
+=======
+        matches!(Executable::<UserError, TestInstructionMeter>::from_elf(&elf, config, syscall_registry), Err(EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset))) if symbol == "log_64" && pc == 550 && offset == 4168)
+>>>>>>> ba982fe (Verifier is not optional)
     );
 }
 
@@ -4382,23 +4422,33 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     .unwrap();
     let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
+<<<<<<< HEAD
         Some(check),
+=======
+>>>>>>> ba982fe (Verifier is not optional)
         config,
         syscall_registry,
         bpf_functions,
     );
-    let mut executable = if let Ok(executable) = executable {
+    let executable = if let Ok(executable) = executable {
         executable
     } else {
         return false;
     };
-    if Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).is_err() {
+    let verified_executable =
+        VerifiedExecutable::from_executable(executable, solana_rbpf::verifier::check);
+    let mut verified_executable = if let Ok(verified_executable) = verified_executable {
+        verified_executable
+    } else {
+        return false;
+    };
+    if verified_executable.jit_compile().is_err() {
         return false;
     }
     let (instruction_count_interpreter, tracer_interpreter, result_interpreter) = {
         let mut mem = vec![0u8; mem_size];
         let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-        let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
+        let mut vm = EbpfVm::new(&verified_executable, &mut [], vec![mem_region]).unwrap();
         let result_interpreter = vm.execute_program_interpreted(&mut TestInstructionMeter {
             remaining: max_instruction_count,
         });
@@ -4411,7 +4461,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     };
     let mut mem = vec![0u8; mem_size];
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-    let mut vm = EbpfVm::new(&executable, &mut [], vec![mem_region]).unwrap();
+    let mut vm = EbpfVm::new(&verified_executable, &mut [], vec![mem_region]).unwrap();
     let result_jit = vm.execute_program_jit(&mut TestInstructionMeter {
         remaining: max_instruction_count,
     });
@@ -4419,8 +4469,10 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     if result_interpreter != result_jit
         || !solana_rbpf::vm::Tracer::compare(&tracer_interpreter, tracer_jit)
     {
-        let analysis =
-            solana_rbpf::static_analysis::Analysis::from_executable(&executable).unwrap();
+        let analysis = solana_rbpf::static_analysis::Analysis::from_executable(
+            verified_executable.get_executable(),
+        )
+        .unwrap();
         println!("result_interpreter={:?}", result_interpreter);
         println!("result_jit={:?}", result_jit);
         let stdout = std::io::stdout();
@@ -4430,7 +4482,11 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         tracer_jit.write(&mut stdout.lock(), &analysis).unwrap();
         panic!();
     }
-    if executable.get_config().enable_instruction_meter {
+    if verified_executable
+        .get_executable()
+        .get_config()
+        .enable_instruction_meter
+    {
         let instruction_count_jit = vm.get_total_instruction_count();
         assert_eq!(instruction_count_interpreter, instruction_count_jit);
     }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -22,20 +22,13 @@ use solana_rbpf::{
     memory_region::{AccessType, MemoryMapping, MemoryRegion},
     syscalls::{self, BpfSyscallContext, Result},
     user_error::UserError,
-    verifier::{RequisiteVerifier, Verifier, VerifierError},
+    verifier::RequisiteVerifier,
     vm::{
         Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter, VerifiedExecutable,
     },
 };
 use std::{collections::BTreeMap, fs::File, io::Read};
 use test_utils::{PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH};
-
-struct TautologyVerifier {}
-impl Verifier for TautologyVerifier {
-    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
-        Ok(())
-    }
-}
 
 macro_rules! test_interpreter_and_jit {
     (register, $syscall_registry:expr, $location:expr => $syscall_init:expr; $syscall_function:expr) => {

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -32,6 +32,7 @@ use solana_rbpf::{
     vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::collections::BTreeMap;
+use test_utils::TautologyVerifier;
 use thiserror::Error;
 
 /// Error definitions
@@ -41,13 +42,6 @@ pub enum VerifierTestError {
     Rejected(String),
 }
 impl UserDefinedError for VerifierTestError {}
-
-struct TautologyVerifier {}
-impl Verifier for TautologyVerifier {
-    fn verify(_prog: &[u8], _config: &Config) -> std::result::Result<(), VerifierError> {
-        Ok(())
-    }
-}
 
 struct ContradictionVerifier {}
 impl Verifier for ContradictionVerifier {

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -29,7 +29,7 @@ use solana_rbpf::{
     error::UserDefinedError,
     user_error::UserError,
     verifier::{check, VerifierError},
-    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
 };
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -48,13 +48,16 @@ fn test_verifier_success() {
         "
         mov32 r0, 0xBEE
         exit",
-        Some(|_prog: &[u8], _config: &Config| Ok(())),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let verified_executable =
+        VerifiedExecutable::from_executable(executable, |_prog: &[u8], _config: &Config| Ok(()))
+            .unwrap();
     let _vm =
-        EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
+        EbpfVm::<UserError, TestInstructionMeter>::new(&verified_executable, &mut [], Vec::new())
+            .unwrap();
 }
 
 #[test]
@@ -63,30 +66,31 @@ fn test_verifier_fail() {
     fn verifier_fail(_prog: &[u8], _config: &Config) -> Result<(), VerifierError> {
         Err(VerifierError::NoProgram)
     }
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         mov32 r0, 0xBEE
         exit",
-        Some(verifier_fail),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable =
+        VerifiedExecutable::from_executable(executable, verifier_fail).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "DivisionByZero(30)")]
 fn test_verifier_err_div_by_zero_imm() {
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         mov32 r0, 1
         div32 r0, 0
         exit",
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
@@ -97,14 +101,14 @@ fn test_verifier_err_endian_size() {
         0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
@@ -115,14 +119,14 @@ fn test_verifier_err_incomplete_lddw() {
         0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
@@ -130,19 +134,22 @@ fn test_verifier_err_invalid_reg_dst() {
     // r11 is disabled when dynamic_stack_frames=false, and only sub and add are
     // allowed when dynamic_stack_frames=true
     for dynamic_stack_frames in [false, true] {
+        let executable = assemble::<UserError, TestInstructionMeter>(
+            "
+            mov r11, 1
+            exit",
+            Config {
+                dynamic_stack_frames,
+                ..Config::default()
+            },
+            SyscallRegistry::default(),
+        )
+        .unwrap();
+        let result = VerifiedExecutable::from_executable(executable, check)
+            .map_err(|err| format!("Executable constructor {:?}", err));
+
         assert_eq!(
-            assemble::<UserError, TestInstructionMeter>(
-                "
-                mov r11, 1
-                exit",
-                Some(check),
-                Config {
-                    dynamic_stack_frames,
-                    ..Config::default()
-                },
-                SyscallRegistry::default(),
-            )
-            .unwrap_err(),
+            result.unwrap_err(),
             "Executable constructor VerifierError(InvalidDestinationRegister(29))"
         );
     }
@@ -153,19 +160,22 @@ fn test_verifier_err_invalid_reg_src() {
     // r11 is disabled when dynamic_stack_frames=false, and only sub and add are
     // allowed when dynamic_stack_frames=true
     for dynamic_stack_frames in [false, true] {
+        let executable = assemble::<UserError, TestInstructionMeter>(
+            "
+            mov r0, r11
+            exit",
+            Config {
+                dynamic_stack_frames,
+                ..Config::default()
+            },
+            SyscallRegistry::default(),
+        )
+        .unwrap();
+        let result = VerifiedExecutable::from_executable(executable, check)
+            .map_err(|err| format!("Executable constructor {:?}", err));
+
         assert_eq!(
-            assemble::<UserError, TestInstructionMeter>(
-                "
-                mov r0, r11
-                exit",
-                Some(check),
-                Config {
-                    dynamic_stack_frames,
-                    ..Config::default()
-                },
-                SyscallRegistry::default(),
-            )
-            .unwrap_err(),
+            result.unwrap_err(),
             "Executable constructor VerifierError(InvalidSourceRegister(29))"
         );
     }
@@ -173,12 +183,11 @@ fn test_verifier_err_invalid_reg_src() {
 
 #[test]
 fn test_verifier_resize_stack_ptr_success() {
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         sub r11, 1
         add r11, 1
         exit",
-        Some(check),
         Config {
             dynamic_stack_frames: true,
             enable_stack_frame_gaps: false,
@@ -187,49 +196,50 @@ fn test_verifier_resize_stack_ptr_success() {
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JumpToMiddleOfLDDW(2, 29)")]
 fn test_verifier_err_jmp_lddw() {
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         ja +1
         lddw r0, 0x1122334455667788
         exit",
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JumpOutOfCode(3, 29)")]
-fn test_verifier_err_jmp_out_end() {
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+fn test_verifier_err_jmp_out() {
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         ja +2
         exit",
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JumpOutOfCode(18446744073709551615, 29)")]
 fn test_verifier_err_jmp_out_start() {
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         ja -2
         exit",
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
@@ -239,28 +249,28 @@ fn test_verifier_err_unknown_opcode() {
         0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let _ = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
         prog,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "CannotWriteR10(29)")]
 fn test_verifier_err_write_r10() {
-    let _executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<UserError, TestInstructionMeter>(
         "
         mov r10, 1
         exit",
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
+    let _verified_executable = VerifiedExecutable::from_executable(executable, check).unwrap();
 }
 
 #[test]
@@ -291,12 +301,14 @@ fn test_verifier_err_all_shift_overflows() {
 
     for (overflowing_instruction, expected) in testcases {
         let assembly = format!("\n{}\nexit", overflowing_instruction);
-        let result = assemble::<UserError, TestInstructionMeter>(
+        let executable = assemble::<UserError, TestInstructionMeter>(
             &assembly,
-            Some(check),
             Config::default(),
             SyscallRegistry::default(),
-        );
+        )
+        .unwrap();
+        let result = VerifiedExecutable::from_executable(executable, check)
+            .map_err(|err| format!("Executable constructor {:?}", err));
         match expected {
             Ok(()) => assert!(result.is_ok()),
             Err(overflow_msg) => match result {
@@ -326,16 +338,17 @@ fn test_verifier_err_ldabs_ldind_disabled() {
     for (opc, instruction) in instructions {
         for disable_deprecated_load_instructions in [true, false] {
             let assembly = format!("\n{}\nexit", instruction);
-            let result = assemble::<UserError, TestInstructionMeter>(
+            let executable = assemble::<UserError, TestInstructionMeter>(
                 &assembly,
-                Some(check),
                 Config {
                     disable_deprecated_load_instructions,
                     ..Config::default()
                 },
                 SyscallRegistry::default(),
-            );
-
+            )
+            .unwrap();
+            let result = VerifiedExecutable::from_executable(executable, check)
+                .map_err(|err| format!("Executable constructor {:?}", err));
             if disable_deprecated_load_instructions {
                 assert_eq!(
                     result.unwrap_err(),
@@ -364,16 +377,17 @@ fn test_sdiv_disabled() {
     for (opc, instruction) in instructions {
         for enable_sdiv in [true, false] {
             let assembly = format!("\n{}\nexit", instruction);
-            let result = assemble::<UserError, TestInstructionMeter>(
+            let executable = assemble::<UserError, TestInstructionMeter>(
                 &assembly,
-                Some(check),
                 Config {
                     enable_sdiv,
                     ..Config::default()
                 },
                 SyscallRegistry::default(),
-            );
-
+            )
+            .unwrap();
+            let result = VerifiedExecutable::from_executable(executable, check)
+                .map_err(|err| format!("Executable constructor {:?}", err));
             if enable_sdiv {
                 assert!(result.is_ok());
             } else {


### PR DESCRIPTION
The code path to creating a vm allows for the executable to be optional.  The executable verification is an integral step in creating a VM and should never be optional.  This change removes the optional mechanics and requires the caller to provide a verification function in order to create a virtual machine.  Doing so will reduce the chance that a mistake is made where the executable is not verified.

The BPF loader currently does verify the ELF but the rBPF apis don't encourage good behavior or good protection to leaving out the verifier.