### PR TITLE
Speedup `X86Instruction::emit()`

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -8,7 +8,7 @@ use solana_rbpf::vm::Config;
 pub struct ConfigTemplate {
     max_call_depth: usize,
     instruction_meter_checkpoint_distance: usize,
-    noop_instruction_ratio: f64,
+    noop_instruction_ratio: u32,
     enable_stack_frame_gaps: bool,
     enable_symbol_and_section_labels: bool,
     disable_unresolved_symbols_at_runtime: bool,
@@ -27,10 +27,7 @@ impl<'a> Arbitrary<'a> for ConfigTemplate {
         Ok(ConfigTemplate {
             max_call_depth: usize::from(u8::arbitrary(u)?) + 1, // larger is unreasonable + must be non-zero
             instruction_meter_checkpoint_distance: usize::from(u16::arbitrary(u)?), // larger is unreasonable
-            noop_instruction_ratio: match f64::arbitrary(u)?.rem_euclid(1.) {
-                f if !f.is_normal() => 0.0,
-                f => f,
-            }, // map it between 0 and 1, drop NaN
+            noop_instruction_ratio: u32::arbitrary(u)?,
             enable_stack_frame_gaps: bools & (1 << 0) != 0,
             enable_symbol_and_section_labels: bools & (1 << 1) != 0,
             disable_unresolved_symbols_at_runtime: bools & (1 << 2) != 0,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -951,8 +951,8 @@ pub struct JitCompiler {
     last_instruction_meter_validation_pc: usize,
     program_vm_addr: u64,
     handler_anchors: HashMap<usize, usize>,
-    config: Config,
-    diversification_rng: SmallRng,
+    pub(crate) config: Config,
+    pub(crate) diversification_rng: SmallRng,
     stopwatch_is_active: bool,
     environment_stack_key: i32,
     program_argument_key: i32,
@@ -1019,7 +1019,7 @@ impl JitCompiler {
         }
 
         let mut code_length_estimate = MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION * pc;
-        code_length_estimate += (code_length_estimate as f64 * config.noop_instruction_ratio) as usize;
+        code_length_estimate += (code_length_estimate as f64 * (config.noop_instruction_ratio as f64 / std::u32::MAX as f64)) as usize;
         let mut diversification_rng = SmallRng::from_rng(rand::thread_rng()).unwrap();
         let (environment_stack_key, program_argument_key) =
             if config.encrypt_environment_registers {
@@ -1816,15 +1816,6 @@ impl JitCompiler {
         X86Instruction::return_near().emit(self)
     }
 
-    pub fn emit_random_noop<E: UserDefinedError>(&mut self) -> Result<(), EbpfError<E>> {
-        if self.config.noop_instruction_ratio != 0.0 && self.diversification_rng.gen_bool(self.config.noop_instruction_ratio) {
-            // X86Instruction::noop().emit(self)
-            emit::<u8, E>(self, 0x90)
-        } else {
-            Ok(())
-        }
-    }
-
     fn resolve_jumps(&mut self) {
         for jump in &self.pc_section_jumps {
             self.result.pc_section[jump.location] = jump.get_target_offset(self);
@@ -1861,7 +1852,7 @@ mod tests {
 
     fn create_mockup_executable(program: &[u8]) -> Pin<Box<Executable::<UserError, TestInstructionMeter>>> {
         let config = Config {
-            noop_instruction_ratio: 0.0,
+            noop_instruction_ratio: 0,
             ..Config::default()
         };
         let mut syscall_registry = SyscallRegistry::default();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -212,8 +212,8 @@ pub struct Config {
     pub disable_unresolved_symbols_at_runtime: bool,
     /// Reject ELF files containing issues that the verifier did not catch before (up to v0.2.21)
     pub reject_broken_elfs: bool,
-    /// Ratio of random no-ops per instruction in JIT (0.0 = OFF)
-    pub noop_instruction_ratio: f64,
+    /// Ratio of random no-ops per instruction in JIT (0 = OFF)
+    pub noop_instruction_ratio: u32,
     /// Enable disinfection of immediate values and offsets provided by the user in JIT
     pub sanitize_user_provided_values: bool,
     /// Encrypt the environment registers in JIT
@@ -256,7 +256,7 @@ impl Default for Config {
             enable_symbol_and_section_labels: false,
             disable_unresolved_symbols_at_runtime: true,
             reject_broken_elfs: false,
-            noop_instruction_ratio: 1.0 / 256.0,
+            noop_instruction_ratio: std::u32::MAX / 256,
             sanitize_user_provided_values: true,
             encrypt_environment_registers: true,
             disable_deprecated_load_instructions: true,


### PR DESCRIPTION
Inlines `emit_random_noop()` and avoids float arithmetic for a total speedup of compilation by about 10%.