### PR TITLE
Refactor: Offset the IP/PC section

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -237,9 +237,9 @@ pub fn emit<T, E: UserDefinedError>(jit: &mut JitCompiler, data: T) -> Result<()
         return Err(EbpfError::ExhausedTextSegment(jit.pc));
     }
     unsafe {
+        let ptr = jit.result.text_section.as_ptr().add(jit.offset_in_text_section);
         #[allow(clippy::cast_ptr_alignment)]
-        let ptr = jit.result.text_section.as_ptr().add(jit.offset_in_text_section) as *mut T;
-        *ptr = data as T;
+        ptr::write_unaligned(ptr as *mut T, data as T);
     }
     jit.offset_in_text_section += size;
     Ok(())


### PR DESCRIPTION
Turns the type of `pc_section`, `anchors` and `Jump::location` from `u64` into `*const u8` and offsets them by `text_section.as_ptr()`.