### PR TITLE
Optimize random no-op insertion

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -8,7 +8,7 @@ use solana_rbpf::vm::Config;
 pub struct ConfigTemplate {
     max_call_depth: usize,
     instruction_meter_checkpoint_distance: usize,
-    noop_instruction_ratio: u32,
+    noop_instruction_rate: u32,
     enable_stack_frame_gaps: bool,
     enable_symbol_and_section_labels: bool,
     disable_unresolved_symbols_at_runtime: bool,
@@ -27,7 +27,7 @@ impl<'a> Arbitrary<'a> for ConfigTemplate {
         Ok(ConfigTemplate {
             max_call_depth: usize::from(u8::arbitrary(u)?) + 1, // larger is unreasonable + must be non-zero
             instruction_meter_checkpoint_distance: usize::from(u16::arbitrary(u)?), // larger is unreasonable
-            noop_instruction_ratio: u32::arbitrary(u)?,
+            noop_instruction_rate: u32::from(u16::arbitrary(u)?),
             enable_stack_frame_gaps: bools & (1 << 0) != 0,
             enable_symbol_and_section_labels: bools & (1 << 1) != 0,
             disable_unresolved_symbols_at_runtime: bools & (1 << 2) != 0,
@@ -55,7 +55,7 @@ impl From<ConfigTemplate> for Config {
             ConfigTemplate {
                 max_call_depth,
                 instruction_meter_checkpoint_distance,
-                noop_instruction_ratio,
+                noop_instruction_rate,
                 enable_stack_frame_gaps,
                 enable_symbol_and_section_labels,
                 disable_unresolved_symbols_at_runtime,
@@ -72,7 +72,7 @@ impl From<ConfigTemplate> for Config {
                 instruction_meter_checkpoint_distance,
                 enable_symbol_and_section_labels,
                 disable_unresolved_symbols_at_runtime,
-                noop_instruction_ratio,
+                noop_instruction_rate,
                 sanitize_user_provided_values,
                 encrypt_environment_registers,
                 disable_deprecated_load_instructions,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -212,8 +212,8 @@ pub struct Config {
     pub disable_unresolved_symbols_at_runtime: bool,
     /// Reject ELF files containing issues that the verifier did not catch before (up to v0.2.21)
     pub reject_broken_elfs: bool,
-    /// Ratio of random no-ops per instruction in JIT (0 = OFF)
-    pub noop_instruction_ratio: u32,
+    /// Ratio of native host instructions per random no-op in JIT (0 = OFF)
+    pub noop_instruction_rate: u32,
     /// Enable disinfection of immediate values and offsets provided by the user in JIT
     pub sanitize_user_provided_values: bool,
     /// Encrypt the environment registers in JIT
@@ -256,7 +256,7 @@ impl Default for Config {
             enable_symbol_and_section_labels: false,
             disable_unresolved_symbols_at_runtime: true,
             reject_broken_elfs: false,
-            noop_instruction_ratio: std::u32::MAX / 256,
+            noop_instruction_rate: 256,
             sanitize_user_provided_values: true,
             encrypt_environment_registers: true,
             disable_deprecated_load_instructions: true,


### PR DESCRIPTION
Changes the machinecode diversification no-op insertion approach from [PDM](https://en.wikipedia.org/wiki/Pulse-density_modulation) to [PWM](https://en.wikipedia.org/wiki/Pulse-width_modulation).
The mean number of no-ops inserted stays the same.
However, as a side affect, the standard deviation (of the number of no-ops inserted) is cut in half.