### PR TITLE
Refactor: Turns verifier into a trait

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -14,6 +14,7 @@ use solana_rbpf::{
     elf::Executable,
     syscalls::{BpfSyscallContext, BpfSyscallU64},
     user_error::UserError,
+    verifier::TautologyVerifier,
     vm::{Config, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
 use std::{fs::File, io::Read};
@@ -37,9 +38,8 @@ fn bench_load_elf(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        Executable::<UserError, TestInstructionMeter>::from_elf(
+        Executable::<UserError, TestInstructionMeter>::from_elf::<TautologyVerifier>(
             &elf,
-            None,
             Config::default(),
             syscall_registry(),
         )
@@ -53,13 +53,13 @@ fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
-            &elf,
-            None,
-            Config::default(),
-            syscall_registry(),
-        )
-        .unwrap();
+        let executable =
+            Executable::<UserError, TestInstructionMeter>::from_elf::<TautologyVerifier>(
+                &elf,
+                Config::default(),
+                syscall_registry(),
+            )
+            .unwrap();
         executable
     });
 }
@@ -70,13 +70,13 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
-            &elf,
-            None,
-            Config::default(),
-            syscall_registry(),
-        )
-        .unwrap();
+        let executable =
+            Executable::<UserError, TestInstructionMeter>::from_elf::<TautologyVerifier>(
+                &elf,
+                Config::default(),
+                syscall_registry(),
+            )
+            .unwrap();
         executable
     });
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -12,6 +12,7 @@ extern crate test;
 use solana_rbpf::{
     elf::Executable,
     user_error::UserError,
+    verifier::TautologyVerifier,
     vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter},
 };
 use std::{fs::File, io::Read};
@@ -22,9 +23,8 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<UserError, TestInstructionMeter>::from_elf(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_elf::<TautologyVerifier>(
         &elf,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )
@@ -40,13 +40,13 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
-        &elf,
-        None,
-        Config::default(),
-        SyscallRegistry::default(),
-    )
-    .unwrap();
+    let mut executable =
+        Executable::<UserError, TestInstructionMeter>::from_elf::<TautologyVerifier>(
+            &elf,
+            Config::default(),
+            SyscallRegistry::default(),
+        )
+        .unwrap();
     bencher.iter(|| {
         Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap()
     });

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
     user_error::UserError,
-    verifier::check,
+    verifier::SbfVerifier,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
@@ -32,9 +32,8 @@ fn main() {
         0x00, 0x00, 0x00, 0x00, 0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x95, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00,
     ];
-    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(
         &program,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -16,7 +16,7 @@ use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
     user_error::UserError,
-    verifier::check,
+    verifier::SbfVerifier,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use std::collections::BTreeMap;
@@ -30,9 +30,8 @@ use std::collections::BTreeMap;
 // * Print integers as integers, and not as strings containing their hexadecimal representation
 //   (just replace the relevant `format!()` calls by the commented values.
 fn to_json(program: &[u8]) -> String {
-    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(
         &program,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
         BTreeMap::default(),

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -13,7 +13,7 @@ use solana_rbpf::{
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
     user_error::UserError,
-    verifier::check,
+    verifier::{SbfVerifier, TautologyVerifier, Verifier},
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
 };
 
@@ -33,7 +33,7 @@ struct FuzzData {
 fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog, data.arch);
     let config = data.template.into();
-    if check(prog.into_bytes(), &config).is_err() {
+    if SbfVerifier::verify(prog.into_bytes(), &config).is_err() {
         // verify please
         return;
     }
@@ -41,9 +41,8 @@ fuzz_target!(|data: FuzzData| {
     let registry = SyscallRegistry::default();
     let mut bpf_functions = BTreeMap::new();
     register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
-    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<TautologyVerifier>(
         prog.into_bytes(),
-        None,
         config,
         SyscallRegistry::default(),
         bpf_functions,

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -11,7 +11,7 @@ use solana_rbpf::{
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
     user_error::UserError,
-    verifier::check,
+    verifier::{SbfVerifier, TautologyVerifier, Verifier},
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter},
 };
 
@@ -40,7 +40,7 @@ fuzz_target!(|data: FuzzData| {
         .set_imm(data.exit_imm)
         .push();
     let config = data.template.into();
-    if check(prog.into_bytes(), &config).is_err() {
+    if SbfVerifier::verify(prog.into_bytes(), &config).is_err() {
         // verify please
         return;
     }
@@ -49,9 +49,8 @@ fuzz_target!(|data: FuzzData| {
     let registry = SyscallRegistry::default();
     let mut bpf_functions = BTreeMap::new();
     register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<TautologyVerifier>(
         prog.into_bytes(),
-        None,
         config,
         SyscallRegistry::default(),
         bpf_functions,

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -13,7 +13,7 @@ use solana_rbpf::{
     memory_region::MemoryRegion,
     static_analysis::Analysis,
     user_error::UserError,
-    verifier::check,
+    verifier::{SbfVerifier, TautologyVerifier, Verifier},
     vm::{EbpfVm, InstructionMeter, SyscallRegistry, TestInstructionMeter},
 };
 
@@ -38,7 +38,7 @@ fn dump_insns<E: UserDefinedError, I: InstructionMeter>(executable: &Executable<
 fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
-    if check(prog.into_bytes(), &config).is_err() {
+    if SbfVerifier::verify(prog.into_bytes(), &config).is_err() {
         // verify please
         return;
     }
@@ -47,9 +47,8 @@ fuzz_target!(|data: FuzzData| {
     let registry = SyscallRegistry::default();
     let mut bpf_functions = BTreeMap::new();
     register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<TautologyVerifier>(
         prog.into_bytes(),
-        None,
         config,
         SyscallRegistry::default(),
         bpf_functions,

--- a/fuzz/fuzz_targets/verify_semantic_aware.rs
+++ b/fuzz/fuzz_targets/verify_semantic_aware.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::fuzz_target;
 
 use semantic_aware::*;
 use solana_rbpf::insn_builder::IntoBytes;
-use solana_rbpf::verifier::check;
+use solana_rbpf::verifier::{SbfVerifier, Verifier};
 
 use crate::common::ConfigTemplate;
 
@@ -20,5 +20,5 @@ struct FuzzData {
 fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
-    check(prog.into_bytes(), &config).unwrap();
+    SbfVerifier::verify(prog.into_bytes(), &config).unwrap();
 });

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2086,9 +2086,8 @@ mod test {
         let mut elf_bytes = Vec::new();
         file.read_to_end(&mut elf_bytes)
             .expect("failed to read elf file");
-        let mut executable = ElfExecutable::from_elf(
+        let mut executable = ElfExecutable::from_elf::<crate::verifier::SbfVerifier>(
             &elf_bytes,
-            Some(crate::verifier::check),
             Config::default(),
             syscall_registry(),
         )

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1792,7 +1792,7 @@ impl JitCompiler {
 #[cfg(all(test, target_arch = "x86_64", not(target_os = "windows")))]
 mod tests {
     use super::*;
-    use crate::{syscalls, vm::{SyscallRegistry, SyscallObject, TestInstructionMeter}, elf::register_bpf_function};
+    use crate::{syscalls, vm::{SyscallRegistry, SyscallObject, TestInstructionMeter}, elf::register_bpf_function, verifier::TautologyVerifier};
     use std::collections::BTreeMap;
     use byteorder::{LittleEndian, ByteOrder};
 
@@ -1819,9 +1819,8 @@ mod tests {
         )
         .unwrap();
         bpf_functions.insert(0xFFFFFFFF, (8, "foo".to_string()));
-        Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+        Executable::<UserError, TestInstructionMeter>::from_text_bytes::<TautologyVerifier>(
             program,
-            None,
             config,
             syscall_registry,
             bpf_functions,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -79,6 +79,21 @@ pub enum VerifierError {
     InvalidRegister(usize),
 }
 
+/// Sanity checks for programs before they are compiled or executed
+pub trait Verifier {
+    /// Checks the BPF code in `prog` according to the rules from `config`
+    fn verify(prog: &[u8], config: &Config) -> Result<(), VerifierError>;
+}
+
+/// A `Verifier` that never rejects any program, used for testing only
+pub struct TautologyVerifier {}
+
+impl Verifier for TautologyVerifier {
+    fn verify(_prog: &[u8], _config: &Config) -> Result<(), VerifierError> {
+        Ok(())
+    }
+}
+
 fn adj_insn_ptr(insn_ptr: usize) -> usize {
     insn_ptr + ebpf::ELF_INSN_DUMP_OFFSET
 }
@@ -190,163 +205,167 @@ fn check_imm_register(
     Ok(())
 }
 
-/// Check the program against the verifier's rules
-#[rustfmt::skip]
-pub fn check(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
-    check_prog_len(prog)?;
+/// The solana binary format verifier
+pub struct SbfVerifier {}
 
-    let mut insn_ptr: usize = 0;
-    while (insn_ptr + 1) * ebpf::INSN_SIZE <= prog.len() {
-        let insn = ebpf::get_insn(prog, insn_ptr);
-        let mut store = false;
+impl Verifier for SbfVerifier {
+    #[rustfmt::skip]
+    fn verify(prog: &[u8], config: &Config) -> Result<(), VerifierError> {
+        check_prog_len(prog)?;
 
-        match insn.opc {
-            ebpf::LD_ABS_B
-            | ebpf::LD_ABS_H
-            | ebpf::LD_ABS_W
-            | ebpf::LD_ABS_DW
-            | ebpf::LD_IND_B
-            | ebpf::LD_IND_H
-            | ebpf::LD_IND_W
-            | ebpf::LD_IND_DW if config.disable_deprecated_load_instructions => {
-                return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
-            },
+        let mut insn_ptr: usize = 0;
+        while (insn_ptr + 1) * ebpf::INSN_SIZE <= prog.len() {
+            let insn = ebpf::get_insn(prog, insn_ptr);
+            let mut store = false;
 
-            // BPF_LD class
-            ebpf::LD_ABS_B   => {},
-            ebpf::LD_ABS_H   => {},
-            ebpf::LD_ABS_W   => {},
-            ebpf::LD_ABS_DW  => {},
-            ebpf::LD_IND_B   => {},
-            ebpf::LD_IND_H   => {},
-            ebpf::LD_IND_W   => {},
-            ebpf::LD_IND_DW  => {},
+            match insn.opc {
+                ebpf::LD_ABS_B
+                | ebpf::LD_ABS_H
+                | ebpf::LD_ABS_W
+                | ebpf::LD_ABS_DW
+                | ebpf::LD_IND_B
+                | ebpf::LD_IND_H
+                | ebpf::LD_IND_W
+                | ebpf::LD_IND_DW if config.disable_deprecated_load_instructions => {
+                    return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
+                },
 
-            ebpf::LD_DW_IMM  => {
-                check_load_dw(prog, insn_ptr)?;
-                insn_ptr += 1;
-            },
+                // BPF_LD class
+                ebpf::LD_ABS_B   => {},
+                ebpf::LD_ABS_H   => {},
+                ebpf::LD_ABS_W   => {},
+                ebpf::LD_ABS_DW  => {},
+                ebpf::LD_IND_B   => {},
+                ebpf::LD_IND_H   => {},
+                ebpf::LD_IND_W   => {},
+                ebpf::LD_IND_DW  => {},
 
-            // BPF_LDX class
-            ebpf::LD_B_REG   => {},
-            ebpf::LD_H_REG   => {},
-            ebpf::LD_W_REG   => {},
-            ebpf::LD_DW_REG  => {},
+                ebpf::LD_DW_IMM  => {
+                    check_load_dw(prog, insn_ptr)?;
+                    insn_ptr += 1;
+                },
 
-            // BPF_ST class
-            ebpf::ST_B_IMM   => store = true,
-            ebpf::ST_H_IMM   => store = true,
-            ebpf::ST_W_IMM   => store = true,
-            ebpf::ST_DW_IMM  => store = true,
+                // BPF_LDX class
+                ebpf::LD_B_REG   => {},
+                ebpf::LD_H_REG   => {},
+                ebpf::LD_W_REG   => {},
+                ebpf::LD_DW_REG  => {},
 
-            // BPF_STX class
-            ebpf::ST_B_REG   => store = true,
-            ebpf::ST_H_REG   => store = true,
-            ebpf::ST_W_REG   => store = true,
-            ebpf::ST_DW_REG  => store = true,
+                // BPF_ST class
+                ebpf::ST_B_IMM   => store = true,
+                ebpf::ST_H_IMM   => store = true,
+                ebpf::ST_W_IMM   => store = true,
+                ebpf::ST_DW_IMM  => store = true,
 
-            // BPF_ALU class
-            ebpf::ADD32_IMM  => {},
-            ebpf::ADD32_REG  => {},
-            ebpf::SUB32_IMM  => {},
-            ebpf::SUB32_REG  => {},
-            ebpf::MUL32_IMM  => {},
-            ebpf::MUL32_REG  => {},
-            ebpf::DIV32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::DIV32_REG  => {},
-            ebpf::SDIV32_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::SDIV32_REG if config.enable_sdiv => {},
-            ebpf::OR32_IMM   => {},
-            ebpf::OR32_REG   => {},
-            ebpf::AND32_IMM  => {},
-            ebpf::AND32_REG  => {},
-            ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
-            ebpf::LSH32_REG  => {},
-            ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
-            ebpf::RSH32_REG  => {},
-            ebpf::NEG32      => {},
-            ebpf::MOD32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::MOD32_REG  => {},
-            ebpf::XOR32_IMM  => {},
-            ebpf::XOR32_REG  => {},
-            ebpf::MOV32_IMM  => {},
-            ebpf::MOV32_REG  => {},
-            ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr, 32)?; },
-            ebpf::ARSH32_REG => {},
-            ebpf::LE         => { check_imm_endian(&insn, insn_ptr)?; },
-            ebpf::BE         => { check_imm_endian(&insn, insn_ptr)?; },
+                // BPF_STX class
+                ebpf::ST_B_REG   => store = true,
+                ebpf::ST_H_REG   => store = true,
+                ebpf::ST_W_REG   => store = true,
+                ebpf::ST_DW_REG  => store = true,
 
-            // BPF_ALU64 class
-            ebpf::ADD64_IMM  => {},
-            ebpf::ADD64_REG  => {},
-            ebpf::SUB64_IMM  => {},
-            ebpf::SUB64_REG  => {},
-            ebpf::MUL64_IMM  => {},
-            ebpf::MUL64_REG  => {},
-            ebpf::DIV64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::DIV64_REG  => {},
-            ebpf::SDIV64_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::SDIV64_REG if config.enable_sdiv => {},
-            ebpf::OR64_IMM   => {},
-            ebpf::OR64_REG   => {},
-            ebpf::AND64_IMM  => {},
-            ebpf::AND64_REG  => {},
-            ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
-            ebpf::LSH64_REG  => {},
-            ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
-            ebpf::RSH64_REG  => {},
-            ebpf::NEG64      => {},
-            ebpf::MOD64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
-            ebpf::MOD64_REG  => {},
-            ebpf::XOR64_IMM  => {},
-            ebpf::XOR64_REG  => {},
-            ebpf::MOV64_IMM  => {},
-            ebpf::MOV64_REG  => {},
-            ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr, 64)?; },
-            ebpf::ARSH64_REG => {},
+                // BPF_ALU class
+                ebpf::ADD32_IMM  => {},
+                ebpf::ADD32_REG  => {},
+                ebpf::SUB32_IMM  => {},
+                ebpf::SUB32_REG  => {},
+                ebpf::MUL32_IMM  => {},
+                ebpf::MUL32_REG  => {},
+                ebpf::DIV32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::DIV32_REG  => {},
+                ebpf::SDIV32_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::SDIV32_REG if config.enable_sdiv => {},
+                ebpf::OR32_IMM   => {},
+                ebpf::OR32_REG   => {},
+                ebpf::AND32_IMM  => {},
+                ebpf::AND32_REG  => {},
+                ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
+                ebpf::LSH32_REG  => {},
+                ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr, 32)?; },
+                ebpf::RSH32_REG  => {},
+                ebpf::NEG32      => {},
+                ebpf::MOD32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::MOD32_REG  => {},
+                ebpf::XOR32_IMM  => {},
+                ebpf::XOR32_REG  => {},
+                ebpf::MOV32_IMM  => {},
+                ebpf::MOV32_REG  => {},
+                ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr, 32)?; },
+                ebpf::ARSH32_REG => {},
+                ebpf::LE         => { check_imm_endian(&insn, insn_ptr)?; },
+                ebpf::BE         => { check_imm_endian(&insn, insn_ptr)?; },
 
-            // BPF_JMP class
-            ebpf::JA         => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JEQ_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JEQ_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JGE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JLE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSET_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSET_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JNE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JNE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSGE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
-            ebpf::CALL_IMM   => {},
-            ebpf::CALL_REG   => { check_imm_register(&insn, insn_ptr, config)?; },
-            ebpf::EXIT       => {},
+                // BPF_ALU64 class
+                ebpf::ADD64_IMM  => {},
+                ebpf::ADD64_REG  => {},
+                ebpf::SUB64_IMM  => {},
+                ebpf::SUB64_REG  => {},
+                ebpf::MUL64_IMM  => {},
+                ebpf::MUL64_REG  => {},
+                ebpf::DIV64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::DIV64_REG  => {},
+                ebpf::SDIV64_IMM if config.enable_sdiv => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::SDIV64_REG if config.enable_sdiv => {},
+                ebpf::OR64_IMM   => {},
+                ebpf::OR64_REG   => {},
+                ebpf::AND64_IMM  => {},
+                ebpf::AND64_REG  => {},
+                ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
+                ebpf::LSH64_REG  => {},
+                ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr, 64)?; },
+                ebpf::RSH64_REG  => {},
+                ebpf::NEG64      => {},
+                ebpf::MOD64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+                ebpf::MOD64_REG  => {},
+                ebpf::XOR64_IMM  => {},
+                ebpf::XOR64_REG  => {},
+                ebpf::MOV64_IMM  => {},
+                ebpf::MOV64_REG  => {},
+                ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr, 64)?; },
+                ebpf::ARSH64_REG => {},
 
-            _                => {
-                return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
+                // BPF_JMP class
+                ebpf::JA         => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JEQ_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JEQ_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JGE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JLE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSET_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSET_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JNE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JNE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSGE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+                ebpf::CALL_IMM   => {},
+                ebpf::CALL_REG   => { check_imm_register(&insn, insn_ptr, config)?; },
+                ebpf::EXIT       => {},
+
+                _                => {
+                    return Err(VerifierError::UnknownOpCode(insn.opc, adj_insn_ptr(insn_ptr)));
+                }
             }
+
+            check_registers(&insn, store, insn_ptr, config.dynamic_stack_frames)?;
+
+            insn_ptr += 1;
         }
 
-        check_registers(&insn, store, insn_ptr, config.dynamic_stack_frames)?;
+        // insn_ptr should now be equal to number of instructions.
+        if insn_ptr != prog.len() / ebpf::INSN_SIZE {
+            return Err(VerifierError::JumpOutOfCode(adj_insn_ptr(insn_ptr), adj_insn_ptr(insn_ptr)));
+        }
 
-        insn_ptr += 1;
+        Ok(())
     }
-
-    // insn_ptr should now be equal to number of instructions.
-    if insn_ptr != prog.len() / ebpf::INSN_SIZE {
-        return Err(VerifierError::JumpOutOfCode(adj_insn_ptr(insn_ptr), adj_insn_ptr(insn_ptr)));
-    }
-
-    Ok(())
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -276,6 +276,7 @@ impl<E: UserDefinedError, I: 'static + InstructionMeter> Executable<E, I> {
         <V as Verifier>::verify(executable.get_text_bytes().1, executable.get_config())?;
         Ok(Pin::new(Box::new(executable)))
     }
+
     /// Creates a verified executable from machine code
     pub fn from_text_bytes<V: Verifier>(
         text_bytes: &[u8],
@@ -283,13 +284,10 @@ impl<E: UserDefinedError, I: 'static + InstructionMeter> Executable<E, I> {
         syscall_registry: SyscallRegistry,
         bpf_functions: BTreeMap<u32, (usize, String)>,
     ) -> Result<Pin<Box<Self>>, EbpfError<E>> {
-        <V as Verifier>::verify(text_bytes, &config).map_err(EbpfError::VerifierError)?;
-        Ok(Pin::new(Box::new(Executable::new_from_text_bytes(
-            config,
-            text_bytes,
-            syscall_registry,
-            bpf_functions,
-        ))))
+        let executable =
+            Executable::new_from_text_bytes(config, text_bytes, syscall_registry, bpf_functions);
+        <V as Verifier>::verify(executable.get_text_bytes().1, executable.get_config())?;
+        Ok(Pin::new(Box::new(executable)))
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -22,7 +22,7 @@ use crate::{
     jit::JitProgramArgument,
     memory_region::{MemoryMapping, MemoryRegion},
     static_analysis::Analysis,
-    verifier::VerifierError,
+    verifier::Verifier,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -31,16 +31,6 @@ use std::{
     pin::Pin,
     u32,
 };
-
-/// eBPF verification function that returns an error if the program does not meet its requirements.
-///
-/// Some examples of things the verifier may reject the program for:
-///
-///   - Program does not terminate.
-///   - Unknown instructions.
-///   - Bad formed instruction.
-///   - Unknown eBPF syscall index.
-pub type Verifier = fn(prog: &[u8], config: &Config) -> Result<(), VerifierError>;
 
 /// Return value of programs and syscalls
 pub type ProgramResult<E> = Result<u64, EbpfError<E>>;
@@ -277,29 +267,23 @@ pub const SYSCALL_CONTEXT_OBJECTS_OFFSET: usize = 4;
 /// Static constructors for Executable
 impl<E: UserDefinedError, I: 'static + InstructionMeter> Executable<E, I> {
     /// Creates a verified executable from an ELF file
-    pub fn from_elf(
+    pub fn from_elf<V: Verifier>(
         elf_bytes: &[u8],
-        verifier: Option<Verifier>,
         config: Config,
         syscall_registry: SyscallRegistry,
     ) -> Result<Pin<Box<Self>>, EbpfError<E>> {
         let executable = Executable::load(config, elf_bytes, syscall_registry)?;
-        if let Some(verifier) = verifier {
-            verifier(executable.get_text_bytes().1, executable.get_config())?;
-        }
+        <V as Verifier>::verify(executable.get_text_bytes().1, executable.get_config())?;
         Ok(Pin::new(Box::new(executable)))
     }
     /// Creates a verified executable from machine code
-    pub fn from_text_bytes(
+    pub fn from_text_bytes<V: Verifier>(
         text_bytes: &[u8],
-        verifier: Option<Verifier>,
         config: Config,
         syscall_registry: SyscallRegistry,
         bpf_functions: BTreeMap<u32, (usize, String)>,
     ) -> Result<Pin<Box<Self>>, EbpfError<E>> {
-        if let Some(verifier) = verifier {
-            verifier(text_bytes, &config).map_err(EbpfError::VerifierError)?;
-        }
+        <V as Verifier>::verify(text_bytes, &config).map_err(EbpfError::VerifierError)?;
         Ok(Pin::new(Box::new(Executable::new_from_text_bytes(
             config,
             text_bytes,
@@ -437,7 +421,7 @@ impl Tracer {
 /// # Examples
 ///
 /// ```
-/// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, memory_region::MemoryRegion, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, verifier::check, user_error::UserError};
+/// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, memory_region::MemoryRegion, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, verifier::SbfVerifier, user_error::UserError};
 ///
 /// let prog = &[
 ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -451,7 +435,7 @@ impl Tracer {
 /// let mut bpf_functions = std::collections::BTreeMap::new();
 /// let syscall_registry = SyscallRegistry::default();
 /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
-/// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, Some(check), config, syscall_registry, bpf_functions).unwrap();
+/// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(prog, config, syscall_registry, bpf_functions).unwrap();
 /// let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
 /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
 ///
@@ -478,7 +462,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, verifier::check, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, verifier::SbfVerifier, user_error::UserError};
     ///
     /// let prog = &[
     ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -489,7 +473,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let mut bpf_functions = std::collections::BTreeMap::new();
     /// let syscall_registry = SyscallRegistry::default();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
-    /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, Some(check), config, syscall_registry, bpf_functions).unwrap();
+    /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(prog, config, syscall_registry, bpf_functions).unwrap();
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
     /// ```
     pub fn new(
@@ -554,7 +538,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter}, verifier::check, syscalls::BpfTracePrintf, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter}, verifier::SbfVerifier, syscalls::BpfTracePrintf, user_error::UserError};
     ///
     /// // This program was compiled with clang, from a C program containing the following single
     /// // instruction: `return bpf_trace_printk("foo %c %c %c\n", 10, 1, 2, 3);`
@@ -580,7 +564,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let config = Config::default();
     /// let mut bpf_functions = std::collections::BTreeMap::new();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
-    /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, Some(check), config, syscall_registry, bpf_functions).unwrap();
+    /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(prog, config, syscall_registry, bpf_functions).unwrap();
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], Vec::new()).unwrap();
     /// // Bind a context object instance to the previously registered syscall
     /// vm.bind_syscall_context_objects(0);
@@ -632,7 +616,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// # Examples
     ///
     /// ```
-    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, memory_region::MemoryRegion, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, verifier::check, user_error::UserError};
+    /// use solana_rbpf::{ebpf, elf::{Executable, register_bpf_function}, memory_region::MemoryRegion, vm::{Config, EbpfVm, TestInstructionMeter, SyscallRegistry}, verifier::SbfVerifier, user_error::UserError};
     ///
     /// let prog = &[
     ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
@@ -646,7 +630,7 @@ impl<'a, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, E, I> {
     /// let mut bpf_functions = std::collections::BTreeMap::new();
     /// let syscall_registry = SyscallRegistry::default();
     /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
-    /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(prog, Some(check), config, syscall_registry, bpf_functions).unwrap();
+    /// let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(prog, config, syscall_registry, bpf_functions).unwrap();
     /// let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
     /// let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(&executable, &mut [], vec![mem_region]).unwrap();
     ///

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -12,15 +12,14 @@ use solana_rbpf::{
     assembler::assemble,
     ebpf,
     user_error::UserError,
-    verifier::check,
+    verifier::{SbfVerifier, TautologyVerifier},
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
 
 fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
-    let executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<TautologyVerifier, UserError, TestInstructionMeter>(
         src,
-        None,
         Config::default(),
         SyscallRegistry::default(),
     )?;
@@ -576,9 +575,8 @@ fn test_large_immediate() {
 
 #[test]
 fn test_tcp_sack() {
-    let executable = assemble::<UserError, TestInstructionMeter>(
+    let executable = assemble::<SbfVerifier, UserError, TestInstructionMeter>(
         TCP_SACK_ASM,
-        Some(check),
         Config::default(),
         SyscallRegistry::default(),
     )

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -11,6 +11,7 @@ use solana_rbpf::{
     assembler::assemble,
     static_analysis::Analysis,
     user_error::UserError,
+    verifier::TautologyVerifier,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
 
@@ -22,9 +23,8 @@ macro_rules! disasm {
             enable_symbol_and_section_labels: true,
             ..Config::default()
         };
-        let executable = assemble::<UserError, TestInstructionMeter>(
+        let executable = assemble::<TautologyVerifier, UserError, TestInstructionMeter>(
             src,
-            None,
             config,
             SyscallRegistry::default(),
         )

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -26,7 +26,7 @@ use solana_rbpf::{
     fuzz::fuzz,
     syscalls::{BpfSyscallContext, BpfSyscallString, BpfSyscallU64},
     user_error::UserError,
-    verifier::check,
+    verifier::SbfVerifier,
     vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
 use std::{fs::File, io::Read};
@@ -127,12 +127,10 @@ fn test_fuzz_execute() {
                     BpfSyscallU64::call,
                 )
                 .unwrap();
-            if let Ok(executable) = Executable::<UserError, TestInstructionMeter>::from_elf(
-                bytes,
-                Some(check),
-                Config::default(),
-                syscall_registry,
-            ) {
+            if let Ok(executable) = Executable::<UserError, TestInstructionMeter>::from_elf::<
+                SbfVerifier,
+            >(bytes, Config::default(), syscall_registry)
+            {
                 let mut vm = EbpfVm::<UserError, TestInstructionMeter>::new(
                     &executable,
                     &mut [],

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -22,7 +22,7 @@ use solana_rbpf::{
     memory_region::{AccessType, MemoryMapping, MemoryRegion},
     syscalls::{self, BpfSyscallContext, Result},
     user_error::UserError,
-    verifier::check,
+    verifier::SbfVerifier,
     vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
 use std::{collections::BTreeMap, fs::File, io::Read};
@@ -100,7 +100,7 @@ macro_rules! test_interpreter_and_jit_asm {
         {
             let mut syscall_registry = SyscallRegistry::default();
             $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_init; $syscall_function);)*
-            let mut executable = assemble($source, Some(check), $config, syscall_registry).unwrap();
+            let mut executable = assemble::<SbfVerifier, UserError, TestInstructionMeter>($source, $config, syscall_registry).unwrap();
             test_interpreter_and_jit!(executable, $mem, $syscall_context, $check, $expected_instruction_count);
         }
     };
@@ -126,7 +126,7 @@ macro_rules! test_interpreter_and_jit_elf {
         {
             let mut syscall_registry = SyscallRegistry::default();
             $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_init; $syscall_function);)*
-            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(&elf, Some(check), $config, syscall_registry).unwrap();
+            let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf::<SbfVerifier>(&elf, $config, syscall_registry).unwrap();
             test_interpreter_and_jit!(executable, $mem, $syscall_context, $check, $expected_instruction_count);
         }
     };
@@ -2889,13 +2889,9 @@ fn test_err_mem_access_out_of_bound() {
         )
         .unwrap();
         #[allow(unused_mut)]
-        let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
-            &prog,
-            Some(check),
-            config,
-            syscall_registry,
-            bpf_functions,
-        )
+        let mut executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<
+            SbfVerifier,
+        >(&prog, config, syscall_registry, bpf_functions)
         .unwrap();
         test_interpreter_and_jit!(
             executable,
@@ -3410,13 +3406,12 @@ impl SyscallObject<UserError> for NestedVmSyscall {
                 )
                 .unwrap();
             let mem = [depth as u8 - 1, throw as u8];
-            let mut executable = assemble::<UserError, TestInstructionMeter>(
+            let mut executable = assemble::<SbfVerifier, UserError, TestInstructionMeter>(
                 "
                 ldxb r2, [r1+1]
                 ldxb r1, [r1]
                 syscall NestedVmSyscall
                 exit",
-                Some(check),
                 Config::default(),
                 syscall_registry,
             )
@@ -3552,9 +3547,8 @@ fn test_custom_entrypoint() {
     let mut syscall_registry = SyscallRegistry::default();
     test_interpreter_and_jit!(register, syscall_registry, b"log_64" => syscalls::BpfSyscallU64::init::<BpfSyscallContext, UserError>; syscalls::BpfSyscallU64::call);
     #[allow(unused_mut)]
-    let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf(
+    let mut executable = Executable::<UserError, TestInstructionMeter>::from_elf::<SbfVerifier>(
         &elf,
-        Some(check),
         config,
         syscall_registry,
     )
@@ -3981,7 +3975,7 @@ fn test_err_unresolved_elf() {
         ..Config::default()
     };
     assert!(
-        matches!(Executable::<UserError, TestInstructionMeter>::from_elf(&elf, Some(check), config, syscall_registry), Err(EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset))) if symbol == "log_64" && pc == 550 && offset == 4168)
+        matches!(Executable::<UserError, TestInstructionMeter>::from_elf::<SbfVerifier>(&elf, config, syscall_registry), Err(EbpfError::ElfError(ElfError::UnresolvedSymbol(symbol, pc, offset))) if symbol == "log_64" && pc == 550 && offset == 4168)
     );
 }
 
@@ -4380,9 +4374,8 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         "entrypoint",
     )
     .unwrap();
-    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<UserError, TestInstructionMeter>::from_text_bytes::<SbfVerifier>(
         prog,
-        Some(check),
         config,
         syscall_registry,
         bpf_functions,


### PR DESCRIPTION
Also, reorders `verify()` to happen last in `Executable::from_text_bytes()`.
`Executable::from_text_bytes()` is only used for tests and not in production (in the monorepo as well).