### PR TITLE
use native types

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
                 .long("lim")
                 .takes_value(true)
                 .value_name("COUNT")
-                .default_value(&std::i64::MAX.to_string()),
+                .default_value(&i64::MAX.to_string()),
         )
         .arg(
             Arg::new("trace")

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -165,10 +165,10 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
     if dst < 0 || src >= 16 {
         return Err(format!("Invalid source register {}", src));
     }
-    if off < std::i16::MIN as i64 || off > std::i16::MAX as i64 {
+    if off < i16::MIN as i64 || off > i16::MAX as i64 {
         return Err(format!("Invalid offset {}", off));
     }
-    if imm < std::i32::MIN as i64 || imm > std::i32::MAX as i64 {
+    if imm < i32::MIN as i64 || imm > i32::MAX as i64 {
         return Err(format!("Invalid immediate {}", imm));
     }
     Ok(Insn {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1334,7 +1334,7 @@ mod test {
             ElfExecutable::load(Config::default(), &elf_bytes, syscall_registry())
         );
 
-        parsed_elf.header.e_entry = std::u64::MAX;
+        parsed_elf.header.e_entry = u64::MAX;
         let mut elf_bytes = elf_bytes;
         elf_bytes.pwrite(parsed_elf.header, 0).unwrap();
         assert_eq!(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -23,7 +23,6 @@ use crate::{
         EbpfVm, InstructionMeter, ProgramResult, SyscallFunction, SYSCALL_CONTEXT_OBJECTS_OFFSET,
     },
 };
-use std::u32;
 
 /// Translates a vm_addr into a host_addr and sets the pc in the error if one occurs
 macro_rules! translate_memory_access {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -295,7 +295,7 @@ fn emit_sanitized_load_immediate(jit: &mut JitCompiler, size: OperandSize, desti
             emit_ins(jit, X86Instruction::alu(size, 0xc1, 1, destination, 32, None)); // rotate_right(32)
             emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, lower_key, None)); // wrapping_add(lower_key)
         },
-        OperandSize::S64 if value >= std::i32::MIN as i64 && value <= std::i32::MAX as i64 => {
+        OperandSize::S64 if value >= i32::MIN as i64 && value <= i32::MAX as i64 => {
             let key = jit.diversification_rng.gen::<i32>() as i64;
             emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(key)));
             emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, key, None));
@@ -959,7 +959,7 @@ impl JitCompiler {
             offset_in_text_section: 0,
             pc: 0,
             last_instruction_meter_validation_pc: 0,
-            next_noop_insertion: if config.noop_instruction_rate == 0 { std::u32::MAX } else { diversification_rng.gen_range(0..config.noop_instruction_rate * 2) },
+            next_noop_insertion: if config.noop_instruction_rate == 0 { u32::MAX } else { diversification_rng.gen_range(0..config.noop_instruction_rate * 2) },
             program_vm_addr: 0,
             anchors: [std::ptr::null(); ANCHOR_COUNT],
             config: *config,

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -27,7 +27,7 @@ use crate::{
     user_error::UserError,
     vm::SyscallObject,
 };
-use std::{slice::from_raw_parts, str::from_utf8, u64};
+use std::{slice::from_raw_parts, str::from_utf8};
 
 /// Test syscall context
 pub type BpfSyscallContext = u64;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -30,7 +30,6 @@ use std::{
     marker::PhantomData,
     mem,
     pin::Pin,
-    u32,
 };
 
 /// Return value of programs and syscalls
@@ -365,7 +364,7 @@ impl DynamicAnalysis {
             edge_counter_max: 0,
             edges: BTreeMap::new(),
         };
-        let mut last_basic_block = std::usize::MAX;
+        let mut last_basic_block = usize::MAX;
         for traced_instruction in tracer.log.iter() {
             let pc = traced_instruction[11] as usize;
             if analysis.cfg_nodes.contains_key(&pc) {

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -472,12 +472,11 @@ impl X86Instruction {
     #[inline]
     pub const fn load_immediate(size: OperandSize, destination: u8, immediate: i64) -> Self {
         exclude_operand_sizes!(size, OperandSize::S0 | OperandSize::S8 | OperandSize::S16);
-        let immediate_size =
-            if immediate >= std::i32::MIN as i64 && immediate <= std::i32::MAX as i64 {
-                OperandSize::S32
-            } else {
-                OperandSize::S64
-            };
+        let immediate_size = if immediate >= i32::MIN as i64 && immediate <= i32::MAX as i64 {
+            OperandSize::S32
+        } else {
+            OperandSize::S64
+        };
         match immediate_size {
             OperandSize::S32 => Self {
                 size,


### PR DESCRIPTION
Per audit recomendations use native types rather than `std::`