### PR TITLE
AlignedMemory tweaks

### DIFF
--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -5,22 +5,22 @@ use std::mem;
 
 /// Provides u8 slices at a specified alignment
 #[derive(Clone, Debug, PartialEq)]
-pub struct AlignedMemory {
+pub struct AlignedMemory<const ALIGN: usize> {
     max_len: usize,
     align_offset: usize,
     mem: Vec<u8>,
 }
-impl AlignedMemory {
-    fn get_mem(max_len: usize, align: usize) -> (Vec<u8>, usize) {
-        let mut mem: Vec<u8> = Vec::with_capacity(max_len + align);
+impl<const ALIGN: usize> AlignedMemory<ALIGN> {
+    fn get_mem(max_len: usize) -> (Vec<u8>, usize) {
+        let mut mem: Vec<u8> = Vec::with_capacity(max_len + ALIGN);
         mem.push(0);
-        let align_offset = mem.as_ptr().align_offset(align);
+        let align_offset = mem.as_ptr().align_offset(ALIGN);
         mem.resize(align_offset, 0);
         (mem, align_offset)
     }
     /// Return a new AlignedMemory type
-    pub fn new(max_len: usize, align: usize) -> Self {
-        let (mem, align_offset) = Self::get_mem(max_len, align);
+    pub fn new(max_len: usize) -> Self {
+        let (mem, align_offset) = Self::get_mem(max_len);
         Self {
             max_len,
             align_offset,
@@ -28,8 +28,8 @@ impl AlignedMemory {
         }
     }
     /// Return a pre-filled AlignedMemory type
-    pub fn new_with_size(len: usize, align: usize) -> Self {
-        let (mut mem, align_offset) = Self::get_mem(len, align);
+    pub fn new_with_size(len: usize) -> Self {
+        let (mut mem, align_offset) = Self::get_mem(len);
         mem.resize(align_offset + len, 0);
         Self {
             max_len: len,
@@ -38,9 +38,9 @@ impl AlignedMemory {
         }
     }
     /// Return a pre-filled AlignedMemory type
-    pub fn new_with_data(data: &[u8], align: usize) -> Self {
+    pub fn new_with_data(data: &[u8]) -> Self {
         let max_len = data.len();
-        let (mut mem, align_offset) = Self::get_mem(max_len, align);
+        let (mut mem, align_offset) = Self::get_mem(max_len);
         mem.extend_from_slice(data);
         Self {
             max_len,
@@ -88,7 +88,8 @@ impl AlignedMemory {
         Ok(())
     }
 }
-impl std::io::Write for AlignedMemory {
+
+impl<const ALIGN: usize> std::io::Write for AlignedMemory<ALIGN> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.mem.len() + buf.len() > self.align_offset + self.max_len {
             return Err(std::io::Error::new(
@@ -104,13 +105,19 @@ impl std::io::Write for AlignedMemory {
     }
 }
 
+impl<const ALIGN: usize, T: AsRef<[u8]>> From<T> for AlignedMemory<ALIGN> {
+    fn from(bytes: T) -> Self {
+        AlignedMemory::new_with_data(bytes.as_ref())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
 
-    fn do_test(align: usize) {
-        let mut aligned_memory = AlignedMemory::new(10, align);
+    fn do_test<const ALIGN: usize>() {
+        let mut aligned_memory = AlignedMemory::<ALIGN>::new(10);
 
         assert_eq!(aligned_memory.write(&[42u8; 1]).unwrap(), 1);
         assert_eq!(aligned_memory.write(&[42u8; 9]).unwrap(), 9);
@@ -122,7 +129,7 @@ mod tests {
         aligned_memory.as_slice_mut().copy_from_slice(&[84u8; 10]);
         assert_eq!(aligned_memory.as_slice(), &[84u8; 10]);
 
-        let mut aligned_memory = AlignedMemory::new(10, align);
+        let mut aligned_memory = AlignedMemory::<ALIGN>::new(10);
         aligned_memory.resize(5, 0).unwrap();
         aligned_memory.resize(2, 1).unwrap();
         assert_eq!(aligned_memory.write(&[2u8; 3]).unwrap(), 3);
@@ -134,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_aligned_memory() {
-        do_test(1);
-        do_test(32768);
+        do_test::<1>();
+        do_test::<32768>();
     }
 }

--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -4,12 +4,13 @@
 use std::mem;
 
 /// Provides u8 slices at a specified alignment
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct AlignedMemory<const ALIGN: usize> {
     max_len: usize,
     align_offset: usize,
     mem: Vec<u8>,
 }
+
 impl<const ALIGN: usize> AlignedMemory<ALIGN> {
     fn get_mem(max_len: usize) -> (Vec<u8>, usize) {
         let mut mem: Vec<u8> = Vec::with_capacity(max_len + ALIGN);
@@ -86,6 +87,15 @@ impl<const ALIGN: usize> AlignedMemory<ALIGN> {
         }
         self.mem.resize(self.mem.len() + num, value);
         Ok(())
+    }
+}
+
+// Custom Clone impl is needed to ensure alignment. Derived clone would just
+// clone self.mem and there would be no guarantee that the clone allocation is
+// aligned.
+impl<const ALIGN: usize> Clone for AlignedMemory<ALIGN> {
+    fn clone(&self) -> Self {
+        AlignedMemory::new_with_data(self.as_slice())
     }
 }
 

--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -23,7 +23,7 @@ struct CallFrame {
 #[derive(Clone, Debug)]
 pub struct CallFrames<'a> {
     config: &'a Config,
-    stack: AlignedMemory,
+    stack: AlignedMemory<{ HOST_ALIGN }>,
     stack_ptr: u64,
     frame_index: usize,
     frame_index_max: usize,
@@ -33,7 +33,7 @@ impl<'a> CallFrames<'a> {
     /// New call frame, depth indicates maximum call depth
     pub fn new(config: &'a Config) -> Self {
         let stack_len = config.stack_size();
-        let mut stack = AlignedMemory::new(stack_len, HOST_ALIGN);
+        let mut stack = AlignedMemory::new(stack_len);
         stack.resize(stack_len, 0).unwrap();
 
         let mut frames = CallFrames {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -11,7 +11,7 @@ extern crate scroll;
 
 use crate::{
     aligned_memory::AlignedMemory,
-    ebpf::{self, EF_SBF_V2, INSN_SIZE},
+    ebpf::{self, EF_SBF_V2, HOST_ALIGN, INSN_SIZE},
     error::{EbpfError, UserDefinedError},
     jit::JitProgram,
     memory_region::MemoryRegion,
@@ -270,7 +270,7 @@ pub struct Executable<E: UserDefinedError, I: InstructionMeter> {
     /// Configuration settings
     config: Config,
     /// Loaded and executable elf
-    elf_bytes: AlignedMemory,
+    elf_bytes: AlignedMemory<{ HOST_ALIGN }>,
     /// Read-only section
     ro_section: Section,
     /// Text section info
@@ -414,7 +414,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
         syscall_registry: SyscallRegistry,
         bpf_functions: BTreeMap<u32, (usize, String)>,
     ) -> Self {
-        let elf_bytes = AlignedMemory::new_with_data(text_bytes, ebpf::HOST_ALIGN);
+        let elf_bytes = AlignedMemory::new_with_data(text_bytes);
         let enable_symbol_and_section_labels = config.enable_symbol_and_section_labels;
         Self {
             config,
@@ -443,7 +443,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
         syscall_registry: SyscallRegistry,
     ) -> Result<Self, ElfError> {
         let elf = Elf::parse(bytes)?;
-        let mut elf_bytes = AlignedMemory::new_with_data(bytes, ebpf::HOST_ALIGN);
+        let mut elf_bytes = AlignedMemory::new_with_data(bytes);
 
         Self::validate(&mut config, &elf, elf_bytes.as_slice())?;
 


### PR DESCRIPTION
This switches AlignedMemory to using const generics and fixes the Clone implementation.