### PR TITLE
derive Clone for SyscallRegistry

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -74,7 +74,7 @@ pub trait SyscallObject<E: UserDefinedError> {
 }
 
 /// Syscall function and binding slot for a context object
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Syscall {
     /// Syscall init
     pub init: u64,
@@ -107,7 +107,7 @@ pub struct DynTraitFatPointer {
 }
 
 /// Holds the syscall function pointers of an Executable
-#[derive(Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct SyscallRegistry {
     /// Function pointers by symbol
     entries: HashMap<u32, Syscall>,


### PR DESCRIPTION
## Problem

SyscallRegistry is moved when an executable is loaded (`Executable::from_elf`).
In certain cases, it makes sense to reuse a registry across multiple executions.

## Summary of changes

Recreating the registry for every execution is wasteful, so this PR adds the ability to clone it.