### PR TITLE
Allow interpreter-only builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = "1.2"
 combine = "3.8.1"
 goblin = "0.5.1"
 hash32 = "0.2.0"
-libc = "0.2"
+libc = { version = "0.2", optional = true }
 log = "0.4.2"
 rand = { version = "0.8.5", features = ["small_rng"]}
 scroll = "0.11"
@@ -32,7 +32,9 @@ thiserror = "1.0.26"
 rustc-demangle = "0.1"
 
 [features]
+default = ["jit"]
 fuzzer-not-safe-for-production = ["arbitrary"]
+jit = ["libc"]
 
 [dev-dependencies]
 elf = "0.0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod error;
 pub mod fuzz;
 pub mod insn_builder;
 pub mod interpreter;
+#[cfg(feature = "jit")]
 mod jit;
 pub mod memory_region;
 pub mod static_analysis;
@@ -43,6 +44,7 @@ pub mod syscalls;
 pub mod user_error;
 pub mod verifier;
 pub mod vm;
+#[cfg(feature = "jit")]
 mod x86;
 
 trait ErrCheckedArithmetic: Sized {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -313,6 +313,7 @@ impl<V: Verifier, E: UserDefinedError, I: InstructionMeter> VerifiedExecutable<V
     }
 
     /// JIT compile the executable
+    #[cfg(feature = "jit")]
     pub fn jit_compile(&mut self) -> Result<(), EbpfError<E>> {
         Executable::<E, I>::jit_compile(&mut self.executable)
     }
@@ -695,6 +696,7 @@ impl<'a, V: Verifier, E: UserDefinedError, I: InstructionMeter> EbpfVm<'a, V, E,
     /// **WARNING:** JIT-compiled assembly code is not safe. It may be wise to check that
     /// the program works with the interpreter before running the JIT-compiled version of it.
     ///
+    #[cfg(feature = "jit")]
     pub fn execute_program_jit(&mut self, instruction_meter: &mut I) -> ProgramResult<E> {
         let executable = self.verified_executable.get_executable();
         let initial_insn_count = if executable.get_config().enable_instruction_meter {

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "jit")]
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
+#![cfg(feature = "jit")]
 // Copyright 2020 Solana Maintainers <maintainers@solana.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or


### PR DESCRIPTION
**Problem**

rbpf cannot run on wasm32 because of the `libc` dependency.

**Solution**

Make `libc` and the JIT compiler optional via a new `jit` crate feature.