### PR TITLE
jit: add support for aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rustc-demangle = "0.1"
 
 [features]
 fuzzer-not-safe-for-production = ["arbitrary"]
+jit-aarch64-not-safe-for-production = []
 
 [dev-dependencies]
 elf = "0.0.10"

--- a/src/arm64.rs
+++ b/src/arm64.rs
@@ -1,0 +1,1011 @@
+#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::needless_update)]
+use crate::jit::{emit, JitCompilerCore, OperandSize};
+
+pub const X0: u8 = 0;
+pub const X1: u8 = 1;
+pub const X2: u8 = 2;
+pub const X3: u8 = 3;
+pub const X4: u8 = 4;
+pub const X5: u8 = 5;
+pub const X6: u8 = 6;
+pub const X7: u8 = 7;
+pub const X8: u8 = 8;
+pub const XR: u8 = X8;
+pub const X9: u8 = 9;
+pub const X10: u8 = 10;
+pub const X11: u8 = 11;
+pub const X12: u8 = 12;
+pub const X13: u8 = 13;
+pub const X14: u8 = 14;
+pub const X15: u8 = 15;
+
+// There are more registers, but I'm not sure we have a use for them
+// NOTE: x18 is reserved on Apple platforms
+
+pub const X19: u8 = 19;
+pub const X20: u8 = 20;
+pub const X21: u8 = 21;
+pub const X22: u8 = 22;
+pub const X23: u8 = 23;
+pub const X24: u8 = 24;
+pub const X25: u8 = 25;
+pub const X26: u8 = 26;
+pub const X27: u8 = 27;
+pub const X28: u8 = 28;
+pub const FP: u8 = 29; // NOTE: On Apple platforms, they say FP must always address a valid frame record
+pub const LR: u8 = 30;
+pub const SP_XZR: u8 = 31; // SP or XZR, depending on context
+
+// Tested on Linux, macOS, but not on Windows
+pub const ARGUMENT_REGISTERS: [u8; 8] = [X0, X1, X2, X3, X4, X5, X6, X7];
+pub const CALLER_SAVED_REGISTERS: [u8; 7] = [X9, X10, X11, X12, X13, X14, X15];
+pub const CALLEE_SAVED_REGISTERS: [u8; 12] =
+    [X19, X20, X21, X22, X23, X24, X25, X26, X27, X28, LR, FP];
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ShiftType {
+    LSL = 0, // logical shift left
+             // LSR = 1, // logical shift right
+             // ASR = 2, // arithmetic shift right
+             // ROR = 3, // rotate right
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Condition {
+    EQ = 0,  // equal
+    NE = 1,  // not equal
+    CS = 2,  // carry set, also HS (unsigned >=)
+    CC = 3,  // carry clear, also LO (unsigned <)
+    HI = 8,  // unsigned >
+    LS = 9,  // unsigned <=
+    GE = 10, // signed >=
+    LT = 11, // signed <
+    GT = 12, // signed >
+    LE = 13, // signed <=
+             // AL = 14, // always
+}
+
+impl Condition {
+    // Aliases
+    pub const HS: Condition = Condition::CS; // unsigned >=
+    pub const LO: Condition = Condition::CC; // unsigned <
+}
+
+pub struct ARM64BitwiseImm {
+    immr: u8, // 6 bits
+    imms: u8, // 6 bits
+    n: u8,    // 1 bit
+}
+
+impl ARM64BitwiseImm {
+    pub const ONE: ARM64BitwiseImm = ARM64BitwiseImm {
+        immr: 0,
+        imms: 0,
+        n: 1,
+    };
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub enum ARM64MemoryOperand {
+    #[allow(dead_code)]
+    OffsetScaled(u16), // ldr dst, [src, #offset] (unsigned offset, scaled)
+    Offset(i16),                // ldur dst, [src, #offset] (signed offset, unscaled)
+    OffsetPreIndex(i16), // ldr dst, [src, #offset]! (signed offset, unscaled) **autoincrement**
+    OffsetPostIndex(i16), // ldr dst, [src], #offset (signed offset, unscaled) **autoincrement**
+    OffsetIndexShift(u8, bool), // ldr dst, [src, idx << 3]; u8 is idx register, bool is whether to shift
+}
+
+// Instructions are broken up based on the encoding scheme used
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub enum ARM64Instruction {
+    LogicalRegister(ARM64InstructionLogicalShiftedRegister),
+    AddSubRegister(ARM64InstructionLogicalShiftedRegister),
+    AddSubImm(ARM64InstructionAddSubImm),
+    ConditionalBranch(ARM64InstructionConditonalBranch),
+    LogicalImm(ARM64InstructionLogicalImm),
+    BitfieldImm(ARM64InstructionLogicalImm),
+    MovWideImm(ARM64InstructionWideImm),
+    DataProcessing1Src(ARM64InstructionDataProcessing),
+    DataProcessing2Src(ARM64InstructionDataProcessing),
+    DataProcessing3Src(ARM64InstructionDataProcessing),
+    BranchImm26(ARM64InstructionImm26),
+    BLR(ARM64InstructionBLR),
+    Load(ARM64InstructionLoadStore),
+    Store(ARM64InstructionLoadStore),
+    RET,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionLogicalShiftedRegister {
+    pub size: OperandSize,
+    pub opcode: u8,            // 2 bits
+    pub n: u8,                 // negation (1 bit)
+    pub shift_type: ShiftType, // 2 bits
+    pub dest: u8,              // Rd, 5 bits
+    pub src1: u8,              // Rn, 5 bits
+    pub src2: u8,              // Rm, 5 bits
+    pub imm6: u8,              // shift amount (0-31 or 0-63)
+}
+
+impl Default for ARM64InstructionLogicalShiftedRegister {
+    fn default() -> Self {
+        Self {
+            size: OperandSize::S64,
+            opcode: 0,
+            n: 0,
+            shift_type: ShiftType::LSL,
+            dest: 0,
+            src1: 0,
+            src2: 0,
+            imm6: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionDataProcessing {
+    pub size: OperandSize,
+    pub opcode: u8, // 6 bits
+    pub dest: u8,   // Rd, 5 bits
+    pub src1: u8,   // Rn, 5 bits
+    pub src2: u8,   // Rm, 5 bits, only used in 2, 3-src insts
+    pub src3: u8,   // R1, 5 bits, only used in 3-src insts
+    pub o0: u8,     // 1 bit, used only in 3-src insts
+}
+
+impl Default for ARM64InstructionDataProcessing {
+    fn default() -> Self {
+        Self {
+            size: OperandSize::S64,
+            opcode: 0,
+            dest: 0,
+            src1: 0,
+            src2: 0,
+            src3: 0,
+            o0: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionAddSubImm {
+    pub size: OperandSize,
+    pub opcode: u8,     // 1 bit
+    pub sets_flags: u8, // 1 bit
+    pub shift_mode: u8, // 00 (LSL 0) and 01 (LSL 12) are supported
+    pub dest: u8,       // Rd, 5 bits
+    pub src: u8,        // Rn, 5 bits
+    pub imm12: u16,     // unsigned imm12
+}
+
+impl Default for ARM64InstructionAddSubImm {
+    fn default() -> Self {
+        Self {
+            size: OperandSize::S64,
+            opcode: 0,
+            sets_flags: 0,
+            shift_mode: 0,
+            dest: 0,
+            src: 0,
+            imm12: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionLogicalImm {
+    pub size: OperandSize,
+    pub opcode: u8, // 2 bits
+    pub n: u8,      // negation (1 bit)
+    pub dest: u8,   // Rd, 5 bits
+    pub src: u8,    // Rn, 5 bits
+    pub immr: u8,   // imm6
+    pub imms: u8,   // imm6
+}
+
+impl Default for ARM64InstructionLogicalImm {
+    fn default() -> Self {
+        Self {
+            size: OperandSize::S64,
+            opcode: 0,
+            n: 0,
+            dest: 0,
+            src: 0,
+            immr: 0,
+            imms: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionWideImm {
+    pub size: OperandSize,
+    pub opcode: u8, // 2 bits
+    pub hw: u8,     // shift (0, 16, 32, 48), encoded as 2-bits
+    pub dest: u8,   // Rd, 5 bits
+    pub imm16: u16, // imm6
+}
+
+impl Default for ARM64InstructionWideImm {
+    fn default() -> Self {
+        Self {
+            size: OperandSize::S64,
+            opcode: 0,
+            hw: 0,
+            dest: 0,
+            imm16: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionConditonalBranch {
+    pub cond: u8,   // 4 bits
+    pub imm19: i32, // offset from current instruction, divided by 4
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionImm26 {
+    pub opcode: u8, // 6 bits
+    pub imm26: i32, // offset from current instruction, divided by 4
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionBLR {
+    pub target: u8, // 5 bit target register
+}
+
+// Load
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct ARM64InstructionLoadStore {
+    pub size: OperandSize,
+    pub data: u8, // Rt, 5 bits
+    pub base: u8, // Rn, 5 bits (base register)
+    pub mem: ARM64MemoryOperand,
+}
+
+impl Default for ARM64InstructionLoadStore {
+    fn default() -> Self {
+        Self {
+            size: OperandSize::S64,
+            data: 0,
+            base: 0,
+            mem: ARM64MemoryOperand::Offset(0), // default to an LDUR (no autoincrement)
+        }
+    }
+}
+
+impl ARM64Instruction {
+    pub fn emit(&self, jit: &mut JitCompilerCore) {
+        let mut ins: u32 = 0;
+
+        match self {
+            ARM64Instruction::LogicalRegister(s) | ARM64Instruction::AddSubRegister(s) => {
+                ins |= (s.dest & 0b11111) as u32;
+                ins |= ((s.src1 & 0b11111) as u32) << 5;
+                ins |= ((s.src2 & 0b11111) as u32) << 16;
+                ins |= ((s.imm6 & 0b111111) as u32) << 10;
+                ins |= ((s.n & 0b1) as u32) << 21;
+                ins |= (s.shift_type as u32) << 22;
+                ins |= ((s.opcode & 0b11) as u32) << 29;
+
+                match self {
+                    ARM64Instruction::LogicalRegister(_) => ins |= 0b01010u32 << 24,
+                    ARM64Instruction::AddSubRegister(_) => ins |= 0b01011u32 << 24,
+                    _ => unreachable!(),
+                };
+
+                let sf: u8 = match s.size {
+                    OperandSize::S64 => 1,
+                    _ => 0,
+                };
+
+                ins |= (sf as u32) << 31;
+            }
+            ARM64Instruction::DataProcessing2Src(s) | ARM64Instruction::DataProcessing1Src(s) => {
+                ins |= (s.dest & 0b11111) as u32;
+                ins |= ((s.src1 & 0b11111) as u32) << 5;
+                ins |= ((s.src2 & 0b11111) as u32) << 16;
+                ins |= ((s.opcode & 0b111111) as u32) << 10;
+                if let ARM64Instruction::DataProcessing1Src(_) = self {
+                    ins |= 0b1u32 << 30
+                }
+                ins |= 0b11010110u32 << 21;
+                let sf: u8 = match s.size {
+                    OperandSize::S64 => 1,
+                    _ => 0,
+                };
+
+                ins |= (sf as u32) << 31;
+            }
+            ARM64Instruction::DataProcessing3Src(s) => {
+                ins |= (s.dest & 0b11111) as u32;
+                ins |= ((s.src1 & 0b11111) as u32) << 5;
+                ins |= ((s.src2 & 0b11111) as u32) << 16;
+                ins |= ((s.src3 & 0b11111) as u32) << 10;
+                ins |= ((s.opcode & 0b111) as u32) << 21;
+                ins |= ((s.o0 & 0b1) as u32) << 15;
+
+                ins |= 0b11011u32 << 24;
+                let sf: u8 = match s.size {
+                    OperandSize::S64 => 1,
+                    _ => 0,
+                };
+
+                ins |= (sf as u32) << 31;
+            }
+            ARM64Instruction::AddSubImm(s) => {
+                ins |= (s.dest & 0b11111) as u32;
+                ins |= ((s.src & 0b11111) as u32) << 5;
+                ins |= ((s.imm12 & 0b111111111111) as u32) << 10;
+                ins |= (s.shift_mode as u32) << 22;
+                ins |= ((s.sets_flags & 0b1) as u32) << 29;
+                ins |= ((s.opcode & 0b1) as u32) << 30;
+
+                match self {
+                    ARM64Instruction::AddSubImm(_) => ins |= 0b10001u32 << 24,
+                    _ => unreachable!(),
+                };
+
+                let sf: u8 = match s.size {
+                    OperandSize::S64 => 1,
+                    _ => 0,
+                };
+
+                ins |= (sf as u32) << 31;
+            }
+            ARM64Instruction::LogicalImm(s) | ARM64Instruction::BitfieldImm(s) => {
+                ins |= (s.dest & 0b11111) as u32;
+                ins |= ((s.src & 0b11111) as u32) << 5;
+                ins |= ((s.imms & 0b111111) as u32) << 10;
+                ins |= ((s.immr & 0b111111) as u32) << 16;
+                ins |= ((s.n & 0b1) as u32) << 22;
+                ins |= ((s.opcode & 0b11) as u32) << 29;
+
+                match self {
+                    ARM64Instruction::LogicalImm(_) => ins |= 0b100100u32 << 23,
+                    ARM64Instruction::BitfieldImm(_) => ins |= 0b100110u32 << 23,
+                    _ => unreachable!(),
+                };
+
+                let sf: u8 = match s.size {
+                    OperandSize::S64 => 1,
+                    _ => 0,
+                };
+
+                ins |= (sf as u32) << 31;
+            }
+            ARM64Instruction::MovWideImm(s) => {
+                ins |= (s.dest & 0b11111) as u32;
+                ins |= (s.imm16 as u32) << 5;
+                ins |= ((s.hw & 0b11) as u32) << 21;
+                ins |= ((s.opcode & 0b11) as u32) << 29;
+
+                match self {
+                    ARM64Instruction::MovWideImm(_) => ins |= 0b100101u32 << 23,
+                    _ => unreachable!(),
+                };
+
+                let sf: u8 = match s.size {
+                    OperandSize::S64 => 1,
+                    _ => 0,
+                };
+
+                ins |= (sf as u32) << 31;
+            }
+            ARM64Instruction::ConditionalBranch(s) => {
+                ins |= (s.cond & 0b1111) as u32;
+                ins |= ((s.imm19 as u32) & ((1u32 << 19) - 1u32)) << 5;
+                ins |= 0b01010100u32 << 24;
+            }
+            ARM64Instruction::BranchImm26(s) => {
+                ins |= (s.imm26 as u32) & ((1u32 << 26) - 1u32);
+                ins |= (s.opcode as u32) << 26;
+            }
+            ARM64Instruction::BLR(s) => {
+                ins |= 0b11010110001111110000000000000000u32;
+                ins |= ((s.target & 0b11111) as u32) << 5;
+            }
+            ARM64Instruction::RET => {
+                ins = 0xd65f03c0;
+            }
+            ARM64Instruction::Load(s) | ARM64Instruction::Store(s) => {
+                ins |= (s.data & 0b11111) as u32;
+                ins |= ((s.base & 0b11111) as u32) << 5;
+                let mode = match s.mem {
+                    ARM64MemoryOperand::OffsetPreIndex(_) => 0b11,
+                    ARM64MemoryOperand::OffsetPostIndex(_) => 0b01,
+                    ARM64MemoryOperand::OffsetScaled(_) => 0b00, // spot used for imm12,
+                    ARM64MemoryOperand::OffsetIndexShift(_, _) => 0b10,
+                    ARM64MemoryOperand::Offset(_) => 0b00,
+                };
+                ins |= (mode as u32) << 10;
+
+                // Encode the memory operand
+                match s.mem {
+                    ARM64MemoryOperand::OffsetPreIndex(imm9)
+                    | ARM64MemoryOperand::OffsetPostIndex(imm9)
+                    | ARM64MemoryOperand::Offset(imm9) => {
+                        ins |= ((imm9 & 0b111111111) as u32) << 12;
+                    }
+                    ARM64MemoryOperand::OffsetScaled(imm12) => {
+                        ins |= ((imm12 & 0b111111111111) as u32) << 10;
+                    }
+                    ARM64MemoryOperand::OffsetIndexShift(idx_reg, should_shift) => {
+                        if should_shift {
+                            ins |= 0b1u32 << 12;
+                        }
+                        ins |= 0b011u32 << 13;
+                        ins |= ((idx_reg & 0b11111) as u32) << 16;
+                    }
+                };
+
+                // Opcode (we choose the zero-extending version for all)
+                match s.mem {
+                    ARM64MemoryOperand::OffsetPreIndex(_)
+                    | ARM64MemoryOperand::OffsetPostIndex(_)
+                    | ARM64MemoryOperand::Offset(_) => {
+                        ins |= (if matches!(self, ARM64Instruction::Load(_)) {
+                            0b111000010u32
+                        } else {
+                            0b111000000
+                        }) << 21;
+                    }
+                    ARM64MemoryOperand::OffsetScaled(_) => {
+                        ins |= (if matches!(self, ARM64Instruction::Load(_)) {
+                            0b11100101u32
+                        } else {
+                            0b11100100
+                        }) << 22;
+                    }
+                    ARM64MemoryOperand::OffsetIndexShift(_, _) => {
+                        ins |= (if matches!(self, ARM64Instruction::Load(_)) {
+                            0b111000011u32
+                        } else {
+                            0b111000001
+                        }) << 21;
+                    }
+                };
+
+                // Encode size
+                let size: u32 = match s.size {
+                    OperandSize::S64 => 0b11,
+                    OperandSize::S32 => 0b10,
+                    OperandSize::S16 => 0b01,
+                    OperandSize::S8 => 0b00,
+                    OperandSize::S0 => panic!("bad operand size"),
+                };
+                ins |= size << 30;
+            }
+        }
+
+        emit::<u32>(jit, ins);
+    }
+
+    /// Move source to destination
+    #[must_use]
+    pub fn mov(size: OperandSize, source: u8, destination: u8) -> Self {
+        // mov is same as ORR <dst>, XZR, <src>
+        Self::LogicalRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 1,
+            n: 0,
+            dest: destination,
+            src1: SP_XZR,
+            src2: source,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn orr(size: OperandSize, source: u8, destination: u8) -> Self {
+        Self::LogicalRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 1,
+            n: 0,
+            dest: destination,
+            src1: destination,
+            src2: source,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn and(size: OperandSize, src1: u8, src2: u8, destination: u8) -> Self {
+        Self::LogicalRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 0,
+            n: 0,
+            dest: destination,
+            src1,
+            src2,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn eor(size: OperandSize, source: u8, destination: u8) -> Self {
+        Self::LogicalRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 2,
+            n: 0,
+            dest: destination,
+            src1: destination,
+            src2: source,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn tst(size: OperandSize, source: u8, destination: u8) -> Self {
+        Self::LogicalRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 3,
+            n: 0,
+            dest: SP_XZR, // discard result
+            src1: destination,
+            src2: source,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn tst_imm(source: u8, imm: ARM64BitwiseImm) -> Self {
+        Self::LogicalImm(ARM64InstructionLogicalImm {
+            size: OperandSize::S64,
+            opcode: 3,
+            n: imm.n,
+            immr: imm.immr,
+            imms: imm.imms,
+            dest: SP_XZR, // discard result
+            src: source,
+            ..ARM64InstructionLogicalImm::default()
+        })
+    }
+
+    // Here we implement the "shifted register" variant of ADD and SUB.
+    //
+    // There is also exists an "extended register" variant, which includes a zero/sign-extend of the 2nd
+    // source register. Implementing this variant instead of using a separate instruction for
+    // the extension might have performance benefits for some BPF instructions.
+
+    #[must_use]
+    pub fn add(size: OperandSize, src1: u8, src2: u8, destination: u8) -> Self {
+        Self::AddSubRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 0,
+            n: 0,
+            dest: destination,
+            src1,
+            src2,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn add_imm(size: OperandSize, src: u8, imm12: u16, destination: u8) -> Self {
+        debug_assert!(imm12 < (1u16 << 12));
+        Self::AddSubImm(ARM64InstructionAddSubImm {
+            size,
+            opcode: 0,
+            dest: destination,
+            src,
+            imm12,
+            ..ARM64InstructionAddSubImm::default()
+        })
+    }
+
+    // destination -= source
+    #[must_use]
+    pub fn sub(size: OperandSize, src1: u8, src2: u8, destination: u8) -> Self {
+        Self::AddSubRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 2,
+            n: 0,
+            dest: destination,
+            src1,
+            src2,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn sub_imm(size: OperandSize, src: u8, imm12: u16, destination: u8) -> Self {
+        debug_assert!(imm12 < (1u16 << 12));
+        Self::AddSubImm(ARM64InstructionAddSubImm {
+            size,
+            opcode: 1,
+            dest: destination,
+            src,
+            imm12,
+            ..ARM64InstructionAddSubImm::default()
+        })
+    }
+
+    // destination <=> source
+    #[must_use]
+    pub fn cmp(size: OperandSize, source: u8, destination: u8) -> Self {
+        Self::AddSubRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 3,
+            n: 0,
+            dest: SP_XZR,
+            src1: destination,
+            src2: source,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    #[must_use]
+    pub fn cmp_imm(size: OperandSize, src: u8, imm12: u16) -> Self {
+        debug_assert!(imm12 < (1u16 << 12));
+        Self::AddSubImm(ARM64InstructionAddSubImm {
+            size,
+            opcode: 1,
+            sets_flags: 1,
+            dest: SP_XZR,
+            src,
+            imm12,
+            ..ARM64InstructionAddSubImm::default()
+        })
+    }
+
+    #[must_use]
+    pub fn zero_extend_to_u64(from_size: OperandSize, source: u8, destination: u8) -> Self {
+        match from_size {
+            // UXTB
+            OperandSize::S8 => Self::BitfieldImm(ARM64InstructionLogicalImm {
+                size: OperandSize::S32,
+                opcode: 2,
+                immr: 0,
+                imms: 7,
+                dest: destination,
+                src: source,
+                ..ARM64InstructionLogicalImm::default()
+            }),
+            // UXTH
+            OperandSize::S16 => Self::BitfieldImm(ARM64InstructionLogicalImm {
+                size: OperandSize::S32,
+                opcode: 2,
+                immr: 0,
+                imms: 15,
+                dest: destination,
+                src: source,
+                ..ARM64InstructionLogicalImm::default()
+            }),
+            OperandSize::S32 => Self::mov(OperandSize::S32, source, destination), // 32-bit ops clear the upper bits
+            OperandSize::S0 | OperandSize::S64 => {
+                panic!("zero_extend is only valid on S8, S16, and S32")
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn sign_extend_to_i64(from_size: OperandSize, source: u8, destination: u8) -> Self {
+        match from_size {
+            // SXTB
+            OperandSize::S8 => Self::BitfieldImm(ARM64InstructionLogicalImm {
+                size: OperandSize::S64,
+                n: 1,
+                opcode: 0,
+                immr: 0,
+                imms: 7,
+                dest: destination,
+                src: source,
+                ..ARM64InstructionLogicalImm::default()
+            }),
+            // SXTH
+            OperandSize::S16 => Self::BitfieldImm(ARM64InstructionLogicalImm {
+                size: OperandSize::S64,
+                n: 1,
+                opcode: 0,
+                immr: 0,
+                imms: 15,
+                dest: destination,
+                src: source,
+                ..ARM64InstructionLogicalImm::default()
+            }),
+            // SXTW
+            OperandSize::S32 => Self::BitfieldImm(ARM64InstructionLogicalImm {
+                size: OperandSize::S64,
+                n: 1,
+                opcode: 0,
+                immr: 0,
+                imms: 31,
+                dest: destination,
+                src: source,
+                ..ARM64InstructionLogicalImm::default()
+            }),
+            OperandSize::S0 | OperandSize::S64 => {
+                panic!("zero_extend is only valid on S8, S16, and S32")
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn lsl_imm(source: u8, shift_imm: u8, destination: u8) -> Self {
+        debug_assert!(shift_imm > 0 && shift_imm < 64);
+        Self::BitfieldImm(ARM64InstructionLogicalImm {
+            size: OperandSize::S64,
+            n: 1,
+            opcode: 2,
+            immr: (-(shift_imm as i8)).rem_euclid(64) as u8,
+            imms: 63 - shift_imm,
+            dest: destination,
+            src: source,
+            ..ARM64InstructionLogicalImm::default()
+        })
+    }
+
+    #[must_use]
+    pub fn lsl_reg(size: OperandSize, src: u8, shift: u8, destination: u8) -> Self {
+        Self::DataProcessing2Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b001000,
+            dest: destination,
+            src1: src,
+            src2: shift,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+
+    #[must_use]
+    pub fn lsr_imm(source: u8, shift_imm: u8, destination: u8) -> Self {
+        debug_assert!(shift_imm > 0 && shift_imm < 64);
+        Self::BitfieldImm(ARM64InstructionLogicalImm {
+            size: OperandSize::S64,
+            n: 1,
+            opcode: 2,
+            immr: shift_imm,
+            imms: 0b111111,
+            dest: destination,
+            src: source,
+            ..ARM64InstructionLogicalImm::default()
+        })
+    }
+
+    #[must_use]
+    pub fn lsr_reg(size: OperandSize, src: u8, shift: u8, destination: u8) -> Self {
+        Self::DataProcessing2Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b001001,
+            dest: destination,
+            src1: src,
+            src2: shift,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+
+    #[must_use]
+    pub fn asr_reg(size: OperandSize, src: u8, shift: u8, destination: u8) -> Self {
+        Self::DataProcessing2Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b001010,
+            dest: destination,
+            src1: src,
+            src2: shift,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+
+    #[must_use]
+    pub fn rev(size: OperandSize, src: u8, destination: u8) -> Self {
+        Self::DataProcessing1Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: match size {
+                OperandSize::S16 => 0b1,
+                OperandSize::S32 => 0b10,
+                OperandSize::S64 => 0b11,
+                _ => panic!("bad operand size for rev"),
+            },
+            dest: destination,
+            src1: src,
+            src2: 0,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+    // conditional branch
+    // WARNING: You need to divide the byte offset by 4 before passing as imm19
+    #[must_use]
+    pub fn b_cond(cond: Condition, imm19: i32) -> Self {
+        Self::ConditionalBranch(ARM64InstructionConditonalBranch {
+            cond: cond as u8,
+            imm19,
+        })
+    }
+
+    // call
+    #[must_use]
+    pub fn bl(imm26: i32) -> Self {
+        Self::BranchImm26(ARM64InstructionImm26 {
+            opcode: 0b100101,
+            imm26,
+        })
+    }
+
+    // call
+    #[must_use]
+    pub fn blr(target: u8) -> Self {
+        Self::BLR(ARM64InstructionBLR { target })
+    }
+
+    // jump
+    #[must_use]
+    pub fn b(imm26: i32) -> Self {
+        Self::BranchImm26(ARM64InstructionImm26 {
+            opcode: 0b000101,
+            imm26,
+        })
+    }
+
+    #[must_use]
+    pub fn ret() -> Self {
+        Self::RET
+    }
+
+    // movk (64-bit)
+    #[must_use]
+    pub fn movk(destination: u8, shift_16: u8, immediate: u16) -> Self {
+        debug_assert!((0..4).contains(&shift_16));
+        Self::MovWideImm(ARM64InstructionWideImm {
+            size: OperandSize::S64,
+            dest: destination,
+            hw: shift_16,
+            imm16: immediate,
+            opcode: 3,
+        })
+    }
+
+    // movn (64-bit)
+    #[must_use]
+    pub fn movn(destination: u8, shift_16: u8, immediate: u16) -> Self {
+        debug_assert!((0..4).contains(&shift_16));
+        Self::MovWideImm(ARM64InstructionWideImm {
+            size: OperandSize::S64,
+            dest: destination,
+            hw: shift_16,
+            imm16: immediate,
+            opcode: 0,
+        })
+    }
+
+    // mvn (bitwise NOT)
+    #[must_use]
+    pub fn mvn(size: OperandSize, source: u8, destination: u8) -> Self {
+        Self::LogicalRegister(ARM64InstructionLogicalShiftedRegister {
+            size,
+            opcode: 1,
+            n: 1,
+            dest: destination,
+            src1: SP_XZR,
+            src2: source,
+            ..ARM64InstructionLogicalShiftedRegister::default()
+        })
+    }
+
+    /// Load data from [source + offset]
+    #[must_use]
+    pub fn load(size: OperandSize, source: u8, indirect: ARM64MemoryOperand, data: u8) -> Self {
+        debug_assert_ne!(size, OperandSize::S0);
+        debug_assert_ne!(size, OperandSize::S0);
+        match indirect {
+            ARM64MemoryOperand::OffsetPreIndex(_) | ARM64MemoryOperand::OffsetPostIndex(_) => {
+                // in arm64, loads with writeback to the base register cannot also use this
+                // register as the dest
+                debug_assert_ne!(source, data);
+            }
+            _ => {}
+        }
+        Self::Load(ARM64InstructionLoadStore {
+            size,
+            data,
+            base: source,
+            mem: indirect,
+        })
+    }
+
+    #[must_use]
+    pub fn store(size: OperandSize, data: u8, source: u8, indirect: ARM64MemoryOperand) -> Self {
+        debug_assert_ne!(size, OperandSize::S0);
+        match indirect {
+            ARM64MemoryOperand::OffsetPreIndex(_) | ARM64MemoryOperand::OffsetPostIndex(_) => {
+                // in arm64, loads with writeback to the base register cannot also use this
+                // register as the dest
+                debug_assert_ne!(source, data);
+            }
+            _ => {}
+        }
+        Self::Store(ARM64InstructionLoadStore {
+            size,
+            data,
+            base: source,
+            mem: indirect,
+        })
+    }
+
+    // Important: We have to maintain 16-byte SP alignment (enforced in hardware, at least on Apple
+    // platforms). To allow for minimal changes from the x86 code, we still want an 8-byte push,
+    // but the trade-off is that we have to allocate 16 bytes on the stack for every 8 byte push.
+    //
+    // A more efficient approach in many circumstances is to manually move SP down and load/store
+    // as desired.
+    #[must_use]
+    pub fn push64(reg: u8) -> Self {
+        debug_assert_ne!(SP_XZR, reg);
+        Self::Store(ARM64InstructionLoadStore {
+            size: OperandSize::S64,
+            data: reg,
+            base: SP_XZR, // this is SP in this context
+            mem: ARM64MemoryOperand::OffsetPreIndex(-16),
+        })
+    }
+
+    #[must_use]
+    pub fn pop64(reg: u8) -> Self {
+        debug_assert_ne!(SP_XZR, reg);
+        Self::Load(ARM64InstructionLoadStore {
+            size: OperandSize::S64,
+            data: reg,
+            base: SP_XZR, // this is SP in this context
+            mem: ARM64MemoryOperand::OffsetPostIndex(16),
+        })
+    }
+
+    // multiply-add
+    #[must_use]
+    pub fn madd(size: OperandSize, src1: u8, src2: u8, src3: u8, destination: u8) -> Self {
+        Self::DataProcessing3Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b000,
+            dest: destination,
+            src1,
+            src2,
+            src3,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+
+    // multiply-sub
+    #[must_use]
+    pub fn msub(size: OperandSize, src1: u8, src2: u8, src3: u8, destination: u8) -> Self {
+        Self::DataProcessing3Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b000,
+            dest: destination,
+            src1,
+            src2,
+            src3,
+            o0: 1,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+
+    #[must_use]
+    pub fn udiv(size: OperandSize, src1: u8, src2: u8, destination: u8) -> Self {
+        Self::DataProcessing2Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b000010,
+            dest: destination,
+            src1,
+            src2,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+
+    #[must_use]
+    pub fn sdiv(size: OperandSize, src1: u8, src2: u8, destination: u8) -> Self {
+        Self::DataProcessing2Src(ARM64InstructionDataProcessing {
+            size,
+            opcode: 0b000011,
+            dest: destination,
+            src1,
+            src2,
+            ..ARM64InstructionDataProcessing::default()
+        })
+    }
+}

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2079,7 +2079,7 @@ mod test {
             .expect("validation failed");
     }
 
-    #[cfg(all(not(windows), target_arch = "x86_64"))]
+    #[cfg(all(not(windows), any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
     fn test_size() {
         let mut file = File::open("tests/elfs/noop.so").expect("file open failed");
@@ -2093,6 +2093,9 @@ mod test {
             Executable::jit_compile(&mut executable).unwrap();
         }
 
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(18640, executable.mem_size());
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(43216, executable.mem_size());
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -26,16 +26,17 @@ use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 use crate::{
     elf::Executable,
-    vm::{Config, ProgramResult, InstructionMeter, Tracer, SYSCALL_CONTEXT_OBJECTS_OFFSET},
-    ebpf::{self, INSN_SIZE, FIRST_SCRATCH_REG, SCRATCH_REGS, FRAME_PTR_REG, MM_STACK_START, STACK_PTR_REG},
+    vm::{Config, ProgramResult, InstructionMeter},
+    ebpf::{self, Insn},
     error::{UserDefinedError, EbpfError},
-    memory_region::{AccessType, MemoryMapping, MemoryRegion},
-    user_error::UserError,
-    x86::*,
+    memory_region::{MemoryMapping},
 };
 
-const MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH: usize = 4096;
-const MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION: usize = 110;
+#[allow(unused_imports)]
+use crate::{
+    jit_x86::{JitCompilerX86},
+    jit_arm64::{JitCompilerARM64},
+};
 
 /// Argument for executing a eBPF JIT-compiled program
 pub struct JitProgramArgument<'a> {
@@ -45,12 +46,12 @@ pub struct JitProgramArgument<'a> {
     pub syscall_context_objects: [*const u8; 0],
 }
 
-struct JitProgramSections {
+pub(crate) struct JitProgramSections {
     /// OS page size in bytes and the alignment of the sections
     page_size: usize,
     /// A `*const u8` pointer into the text_section for each BPF instruction
-    pc_section: &'static mut [usize],
-    /// The x86 machinecode
+    pub(crate) pc_section: &'static mut [usize],
+    /// The machine code
     text_section: &'static mut [u8],
 }
 
@@ -170,16 +171,46 @@ impl<E: UserDefinedError, I: InstructionMeter> PartialEq for JitProgram<E, I> {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
+type JitCompilerNative = JitCompilerX86;
+
+#[cfg(all(target_arch = "aarch64"))]
+type JitCompilerNative = JitCompilerARM64;
+
 impl<E: UserDefinedError, I: InstructionMeter> JitProgram<E, I> {
     pub fn new(executable: &Pin<Box<Executable<E, I>>>) -> Result<Self, EbpfError<E>> {
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            let _ = executable;
+            panic!("JitProgram is only supported on x86_64 and ARM64");
+        }
+        #[cfg(all(target_arch = "aarch64", not(feature = "jit-aarch64-not-safe-for-production")))]
+        {
+            let _ = executable;
+            panic!("The aarch64 JIT compiler is intended for developer use only.");
+        }
+
         let program = executable.get_text_bytes().1;
-        let mut jit = JitCompiler::new::<E>(program, executable.get_config())?;
+        let jit_core = JitCompilerCore::new::<E>(program, executable.get_config())?;
+
+        let mut jit = JitCompilerNative::new::<E>(jit_core)?;
+
         jit.compile::<E, I>(executable)?;
-        let main = unsafe { mem::transmute(jit.result.text_section.as_ptr()) };
+        let main = unsafe { mem::transmute(jit.get_core().result.text_section.as_ptr()) };
         Ok(Self {
-            sections: jit.result,
+            sections: jit.get_result(),
             main,
         })
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn machine_code_bytes(&self) -> &[u8] {
+        self.sections.text_section
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn inst_to_addr(&self, idx: usize) -> usize {
+        self.sections.pc_section[idx]
     }
 
     pub fn mem_size(&self) -> usize {
@@ -193,50 +224,30 @@ impl<E: UserDefinedError, I: InstructionMeter> JitProgram<E, I> {
 }
 
 // Used to define subroutines and then call them
-// See JitCompiler::set_anchor() and JitCompiler::relative_to_anchor()
-const ANCHOR_EPILOGUE: usize = 0;
-const ANCHOR_TRACE: usize = 1;
-const ANCHOR_RUST_EXCEPTION: usize = 2;
-const ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS: usize = 3;
-const ANCHOR_EXCEPTION_AT: usize = 4;
-const ANCHOR_CALL_DEPTH_EXCEEDED: usize = 5;
-const ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT: usize = 6;
-const ANCHOR_DIV_BY_ZERO: usize = 7;
-const ANCHOR_DIV_OVERFLOW: usize = 8;
-const ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION: usize = 9;
-const ANCHOR_CALL_UNSUPPORTED_INSTRUCTION: usize = 10;
-const ANCHOR_EXIT: usize = 11;
-const ANCHOR_SYSCALL: usize = 12;
-const ANCHOR_BPF_CALL_PROLOGUE: usize = 13;
-const ANCHOR_BPF_CALL_REG: usize = 14;
-const ANCHOR_TRANSLATE_PC: usize = 15;
-const ANCHOR_TRANSLATE_PC_LOOP: usize = 16;
-const ANCHOR_MEMORY_ACCESS_VIOLATION: usize = 17;
-const ANCHOR_TRANSLATE_MEMORY_ADDRESS: usize = 25;
-const ANCHOR_COUNT: usize = 33; // Update me when adding or removing anchors
-
-const REGISTER_MAP: [u8; 11] = [
-    CALLER_SAVED_REGISTERS[0],
-    ARGUMENT_REGISTERS[1],
-    ARGUMENT_REGISTERS[2],
-    ARGUMENT_REGISTERS[3],
-    ARGUMENT_REGISTERS[4],
-    ARGUMENT_REGISTERS[5],
-    CALLEE_SAVED_REGISTERS[2],
-    CALLEE_SAVED_REGISTERS[3],
-    CALLEE_SAVED_REGISTERS[4],
-    CALLEE_SAVED_REGISTERS[5],
-    CALLEE_SAVED_REGISTERS[1],
-];
-
-// Special registers:
-//     ARGUMENT_REGISTERS[0]  RDI  BPF program counter limit (used by instruction meter)
-// CALLER_SAVED_REGISTERS[8]  R11  Scratch register
-// CALLER_SAVED_REGISTERS[7]  R10  Constant pointer to JitProgramArgument (also scratch register for exception handling)
-// CALLEE_SAVED_REGISTERS[0]  RBP  Constant pointer to initial RSP - 8
+// See JitCompilerCore::set_anchor() and JitCompilerCore::relative_to_anchor()
+pub(crate) const ANCHOR_EPILOGUE: usize = 0;
+pub(crate) const ANCHOR_TRACE: usize = 1;
+pub(crate) const ANCHOR_RUST_EXCEPTION: usize = 2;
+pub(crate) const ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS: usize = 3;
+pub(crate) const ANCHOR_EXCEPTION_AT: usize = 4;
+pub(crate) const ANCHOR_CALL_DEPTH_EXCEEDED: usize = 5;
+pub(crate) const ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT: usize = 6;
+pub(crate) const ANCHOR_DIV_BY_ZERO: usize = 7;
+pub(crate) const ANCHOR_DIV_OVERFLOW: usize = 8;
+pub(crate) const ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION: usize = 9;
+pub(crate) const ANCHOR_CALL_UNSUPPORTED_INSTRUCTION: usize = 10;
+pub(crate) const ANCHOR_EXIT: usize = 11;
+pub(crate) const ANCHOR_SYSCALL: usize = 12;
+pub(crate) const ANCHOR_BPF_CALL_PROLOGUE: usize = 13;
+pub(crate) const ANCHOR_BPF_CALL_REG: usize = 14;
+pub(crate) const ANCHOR_TRANSLATE_PC: usize = 15;
+pub(crate) const ANCHOR_TRANSLATE_PC_LOOP: usize = 16;
+pub(crate) const ANCHOR_MEMORY_ACCESS_VIOLATION: usize = 17;
+pub(crate) const ANCHOR_TRANSLATE_MEMORY_ADDRESS: usize = 25;
+pub(crate) const ANCHOR_COUNT: usize = 33; // Update me when adding or removing anchors
 
 #[inline]
-pub fn emit<T>(jit: &mut JitCompiler, data: T) {
+pub fn emit<T>(jit: &mut JitCompilerCore, data: T) {
     unsafe {
         let ptr = jit.result.text_section.as_ptr().add(jit.offset_in_text_section);
         #[allow(clippy::cast_ptr_alignment)]
@@ -246,7 +257,7 @@ pub fn emit<T>(jit: &mut JitCompiler, data: T) {
 }
 
 #[inline]
-pub fn emit_variable_length(jit: &mut JitCompiler, size: OperandSize, data: u64) {
+pub fn emit_variable_length(jit: &mut JitCompilerCore, size: OperandSize, data: u64) {
     match size {
         OperandSize::S0 => {},
         OperandSize::S8 => emit::<u8>(jit, data as u8),
@@ -256,150 +267,6 @@ pub fn emit_variable_length(jit: &mut JitCompiler, size: OperandSize, data: u64)
     }
 }
 
-// This function helps the optimizer to inline the machinecode emission while avoiding stack allocations
-#[inline(always)]
-pub fn emit_ins(jit: &mut JitCompiler, instruction: X86Instruction) {
-    instruction.emit(jit);
-    if jit.next_noop_insertion == 0 {
-        jit.next_noop_insertion = jit.diversification_rng.gen_range(0..jit.config.noop_instruction_rate * 2);
-        // X86Instruction::noop().emit(jit)?;
-        emit::<u8>(jit, 0x90);
-    } else {
-        jit.next_noop_insertion -= 1;
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum OperandSize {
-    S0  = 0,
-    S8  = 8,
-    S16 = 16,
-    S32 = 32,
-    S64 = 64,
-}
-
-#[inline]
-fn emit_sanitized_load_immediate(jit: &mut JitCompiler, size: OperandSize, destination: u8, value: i64) {
-    match size {
-        OperandSize::S32 => {
-            let key: i32 = jit.diversification_rng.gen();
-            emit_ins(jit, X86Instruction::load_immediate(size, destination, (value as i32).wrapping_sub(key) as i64));
-            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, key as i64, None));
-        },
-        OperandSize::S64 if destination == R11 => {
-            let key: i64 = jit.diversification_rng.gen();
-            let lower_key = key as i32 as i64;
-            let upper_key = (key >> 32) as i32 as i64;
-            emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(lower_key).rotate_right(32).wrapping_sub(upper_key)));
-            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, upper_key, None)); // wrapping_add(upper_key)
-            emit_ins(jit, X86Instruction::alu(size, 0xc1, 1, destination, 32, None)); // rotate_right(32)
-            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, lower_key, None)); // wrapping_add(lower_key)
-        },
-        OperandSize::S64 if value >= i32::MIN as i64 && value <= i32::MAX as i64 => {
-            let key = jit.diversification_rng.gen::<i32>() as i64;
-            emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(key)));
-            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, key, None));
-        },
-        OperandSize::S64 => {
-            let key: i64 = jit.diversification_rng.gen();
-            emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(key)));
-            emit_ins(jit, X86Instruction::load_immediate(size, R11, key));
-            emit_ins(jit, X86Instruction::alu(size, 0x01, R11, destination, 0, None));
-        },
-        _ => {
-            #[cfg(debug_assertions)]
-            unreachable!();
-        }
-    }
-}
-
-#[inline]
-fn should_sanitize_constant(jit: &JitCompiler, value: i64) -> bool {
-    if !jit.config.sanitize_user_provided_values {
-        return false;
-    }
-
-    match value as u64 {
-        0xFFFF
-        | 0xFFFFFF
-        | 0xFFFFFFFF
-        | 0xFFFFFFFFFF
-        | 0xFFFFFFFFFFFF
-        | 0xFFFFFFFFFFFFFF
-        | 0xFFFFFFFFFFFFFFFF => false,
-        v if v <= 0xFF => false,
-        v if !v <= 0xFF => false,
-        _ => true
-    }
-}
-
-#[inline]
-fn emit_sanitized_alu(jit: &mut JitCompiler, size: OperandSize, opcode: u8, opcode_extension: u8, destination: u8, immediate: i64) {
-    if should_sanitize_constant(jit, immediate) {
-        emit_sanitized_load_immediate(jit, size, R11, immediate);
-        emit_ins(jit, X86Instruction::alu(size, opcode, R11, destination, immediate, None));
-    } else {
-        emit_ins(jit, X86Instruction::alu(size, 0x81, opcode_extension, destination, immediate, None));
-    }
-}
-
-/// Indices of slots inside the struct at initial RSP
-#[repr(C)]
-enum EnvironmentStackSlot {
-    /// The 6 CALLEE_SAVED_REGISTERS
-    LastSavedRegister = 5,
-    /// The current call depth.
-    ///
-    /// Incremented on calls and decremented on exits. It's used to enforce
-    /// config.max_call_depth and to know when to terminate execution.
-    CallDepth = 6,
-    /// BPF frame pointer (REGISTER_MAP[FRAME_PTR_REG]).
-    BpfFramePtr = 7,
-    /// The BPF stack pointer (r11). Only used when config.dynamic_stack_frames=true.
-    ///
-    /// The stack pointer isn't exposed as an actual register. Only sub and add
-    /// instructions (typically generated by the LLVM backend) are allowed to
-    /// access it. Its value is only stored in this slot and therefore the
-    /// register is not tracked in REGISTER_MAP.
-    BpfStackPtr = 8,
-    /// Constant pointer to optional typed return value
-    OptRetValPtr = 9,
-    /// Last return value of instruction_meter.get_remaining()
-    PrevInsnMeter = 10,
-    /// Constant pointer to instruction_meter
-    InsnMeterPtr = 11,
-    /// CPU cycles accumulated by the stop watch
-    StopwatchNumerator = 12,
-    /// Number of times the stop watch was used
-    StopwatchDenominator = 13,
-    /// Bumper for size_of
-    SlotCount = 14,
-}
-
-fn slot_on_environment_stack(jit: &JitCompiler, slot: EnvironmentStackSlot) -> i32 {
-    -8 * (slot as i32 + jit.environment_stack_key)
-}
-
-#[allow(dead_code)]
-#[inline]
-fn emit_stopwatch(jit: &mut JitCompiler, begin: bool) {
-    jit.stopwatch_is_active = true;
-    emit_ins(jit, X86Instruction::push(RDX, None));
-    emit_ins(jit, X86Instruction::push(RAX, None));
-    emit_ins(jit, X86Instruction::fence(FenceType::Load)); // lfence
-    emit_ins(jit, X86Instruction::cycle_count()); // rdtsc
-    emit_ins(jit, X86Instruction::fence(FenceType::Load)); // lfence
-    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 4, RDX, 32, None)); // RDX <<= 32;
-    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x09, RDX, RAX, 0, None)); // RAX |= RDX;
-    if begin {
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, RAX, RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::StopwatchNumerator))))); // *numerator -= RAX;
-    } else {
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, RAX, RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::StopwatchNumerator))))); // *numerator += RAX;
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, 1, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::StopwatchDenominator))))); // *denominator += 1;
-    }
-    emit_ins(jit, X86Instruction::pop(RAX));
-    emit_ins(jit, X86Instruction::pop(RDX));
-}
 
 /* Explaination of the Instruction Meter
 
@@ -450,450 +317,40 @@ fn emit_stopwatch(jit: &mut JitCompiler, begin: bool) {
     and undo again can be anything, so we just set it to zero.
 */
 
-#[inline]
-fn emit_validate_instruction_count(jit: &mut JitCompiler, exclusive: bool, pc: Option<usize>) {
-    if let Some(pc) = pc {
-        jit.last_instruction_meter_validation_pc = pc;
-        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, ARGUMENT_REGISTERS[0], pc as i64 + 1, None));
-    } else {
-        emit_ins(jit, X86Instruction::cmp(OperandSize::S64, R11, ARGUMENT_REGISTERS[0], None));
-    }
-    emit_ins(jit, X86Instruction::conditional_jump_immediate(if exclusive { 0x82 } else { 0x86 }, jit.relative_to_anchor(ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS, 6)));
-}
 
-#[inline]
-fn emit_profile_instruction_count(jit: &mut JitCompiler, target_pc: Option<usize>) {
-    match target_pc {
-        Some(target_pc) => {
-            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], target_pc as i64 - jit.pc as i64 - 1, None)); // instruction_meter += target_pc - (jit.pc + 1);
-        },
-        None => {
-            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 5, ARGUMENT_REGISTERS[0], jit.pc as i64 + 1, None)); // instruction_meter -= jit.pc + 1;
-            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, R11, ARGUMENT_REGISTERS[0], jit.pc as i64, None)); // instruction_meter += target_pc;
-        },
-    }
-}
-
-#[inline]
-fn emit_validate_and_profile_instruction_count(jit: &mut JitCompiler, exclusive: bool, target_pc: Option<usize>) {
-    if jit.config.enable_instruction_meter {
-        emit_validate_instruction_count(jit, exclusive, Some(jit.pc));
-        emit_profile_instruction_count(jit, target_pc);
-    }
-}
-
-#[inline]
-fn emit_undo_profile_instruction_count(jit: &mut JitCompiler, target_pc: usize) {
-    if jit.config.enable_instruction_meter {
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], jit.pc as i64 + 1 - target_pc as i64, None)); // instruction_meter += (jit.pc + 1) - target_pc;
-    }
-}
-
-#[inline]
-fn emit_profile_instruction_count_finalize(jit: &mut JitCompiler, store_pc_in_exception: bool) {
-    if jit.config.enable_instruction_meter || store_pc_in_exception {
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, R11, 1, None)); // R11 += 1;
-    }
-    if jit.config.enable_instruction_meter {
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, R11, ARGUMENT_REGISTERS[0], 0, None)); // instruction_meter -= pc + 1;
-    }
-    if store_pc_in_exception {
-        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::OptRetValPtr))));
-        emit_ins(jit, X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(0), 1)); // is_err = true;
-        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, R11, ebpf::ELF_INSN_DUMP_OFFSET as i64 - 1, None));
-        emit_ins(jit, X86Instruction::store(OperandSize::S64, R11, R10, X86IndirectAccess::Offset(16))); // pc = jit.pc + ebpf::ELF_INSN_DUMP_OFFSET;
-    }
-}
-
-#[inline]
-fn emit_conditional_branch_reg(jit: &mut JitCompiler, op: u8, bitwise: bool, first_operand: u8, second_operand: u8, target_pc: usize) {
-    emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
-    if bitwise { // Logical
-        emit_ins(jit, X86Instruction::test(OperandSize::S64, first_operand, second_operand, None));
-    } else { // Arithmetic
-        emit_ins(jit, X86Instruction::cmp(OperandSize::S64, first_operand, second_operand, None));
-    }
-    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
-    let jump_offset = jit.relative_to_target_pc(target_pc, 6);
-    emit_ins(jit, X86Instruction::conditional_jump_immediate(op, jump_offset));
-    emit_undo_profile_instruction_count(jit, target_pc);
-}
-
-#[inline]
-fn emit_conditional_branch_imm(jit: &mut JitCompiler, op: u8, bitwise: bool, immediate: i64, second_operand: u8, target_pc: usize) {
-    emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
-    if should_sanitize_constant(jit, immediate) {
-        emit_sanitized_load_immediate(jit, OperandSize::S64, R11, immediate);
-        if bitwise { // Logical
-            emit_ins(jit, X86Instruction::test(OperandSize::S64, R11, second_operand, None));
-        } else { // Arithmetic
-            emit_ins(jit, X86Instruction::cmp(OperandSize::S64, R11, second_operand, None));
-        }
-    } else if bitwise { // Logical
-        emit_ins(jit, X86Instruction::test_immediate(OperandSize::S64, second_operand, immediate, None));
-    } else { // Arithmetic
-        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, second_operand, immediate, None));
-    }
-    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
-    let jump_offset = jit.relative_to_target_pc(target_pc, 6);
-    emit_ins(jit, X86Instruction::conditional_jump_immediate(op, jump_offset));
-    emit_undo_profile_instruction_count(jit, target_pc);
-}
-
-enum Value {
-    Register(u8),
-    RegisterIndirect(u8, i32, bool),
-    RegisterPlusConstant32(u8, i32, bool),
-    RegisterPlusConstant64(u8, i64, bool),
-    Constant64(i64, bool),
-}
-
-#[inline]
-fn emit_bpf_call(jit: &mut JitCompiler, dst: Value) {
-    // Store PC in case the bounds check fails
-    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
-
-    emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_BPF_CALL_PROLOGUE, 5)));
-
-    match dst {
-        Value::Register(reg) => {
-            // Move vm target_address into RAX
-            emit_ins(jit, X86Instruction::push(REGISTER_MAP[0], None));
-            if reg != REGISTER_MAP[0] {
-                emit_ins(jit, X86Instruction::mov(OperandSize::S64, reg, REGISTER_MAP[0]));
-            }
-
-            emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_BPF_CALL_REG, 5)));
-
-            emit_validate_and_profile_instruction_count(jit, false, None);
-            emit_ins(jit, X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], R11)); // Save target_pc
-            emit_ins(jit, X86Instruction::pop(REGISTER_MAP[0])); // Restore RAX
-            emit_ins(jit, X86Instruction::call_reg(R11, None)); // callq *%r11
-        },
-        Value::Constant64(target_pc, user_provided) => {
-            debug_assert!(!user_provided);
-            emit_validate_and_profile_instruction_count(jit, false, Some(target_pc as usize));
-            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
-            let jump_offset = jit.relative_to_target_pc(target_pc as usize, 5);
-            emit_ins(jit, X86Instruction::call_immediate(jump_offset));
-        },
-        _ => {
-            #[cfg(debug_assertions)]
-            unreachable!();
-        }
-    }
-
-    emit_undo_profile_instruction_count(jit, 0);
-
-    // Restore the previous frame pointer
-    emit_ins(jit, X86Instruction::pop(REGISTER_MAP[FRAME_PTR_REG]));
-    let frame_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::BpfFramePtr));
-    emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RBP, frame_ptr_access));
-    for reg in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).rev() {
-        emit_ins(jit, X86Instruction::pop(*reg));
-    }
-}
-
-struct Argument {
-    index: usize,
-    value: Value,
-}
-
-fn emit_rust_call(jit: &mut JitCompiler, dst: Value, arguments: &[Argument], result_reg: Option<u8>, check_exception: bool) {
-    let mut saved_registers = CALLER_SAVED_REGISTERS.to_vec();
-    if let Some(reg) = result_reg {
-        let dst = saved_registers.iter().position(|x| *x == reg);
-        debug_assert!(dst.is_some());
-        if let Some(dst) = dst {
-            saved_registers.remove(dst);
-        }
-    }
-
-    // Save registers on stack
-    for reg in saved_registers.iter() {
-        emit_ins(jit, X86Instruction::push(*reg, None));
-    }
-
-    // Pass arguments
-    let mut stack_arguments = 0;
-    for argument in arguments {
-        let is_stack_argument = argument.index >= ARGUMENT_REGISTERS.len();
-        let dst = if is_stack_argument {
-            stack_arguments += 1;
-            R11
-        } else {
-            ARGUMENT_REGISTERS[argument.index]
-        };
-        match argument.value {
-            Value::Register(reg) => {
-                if is_stack_argument {
-                    emit_ins(jit, X86Instruction::push(reg, None));
-                } else if reg != dst {
-                    emit_ins(jit, X86Instruction::mov(OperandSize::S64, reg, dst));
-                }
-            },
-            Value::RegisterIndirect(reg, offset, user_provided) => {
-                debug_assert!(!user_provided);
-                if is_stack_argument {
-                    emit_ins(jit, X86Instruction::push(reg, Some(X86IndirectAccess::Offset(offset))));
-                } else {
-                    emit_ins(jit, X86Instruction::load(OperandSize::S64, reg, dst, X86IndirectAccess::Offset(offset)));
-                }
-            },
-            Value::RegisterPlusConstant32(reg, offset, user_provided) => {
-                debug_assert!(!user_provided);
-                if is_stack_argument {
-                    emit_ins(jit, X86Instruction::push(reg, None));
-                    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, offset as i64, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))));
-                } else {
-                    emit_ins(jit, X86Instruction::lea(OperandSize::S64, reg, dst, Some(X86IndirectAccess::Offset(offset))));
-                }
-            },
-            Value::RegisterPlusConstant64(reg, offset, user_provided) => {
-                debug_assert!(!user_provided);
-                if is_stack_argument {
-                    emit_ins(jit, X86Instruction::push(reg, None));
-                    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, offset, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))));
-                } else {
-                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, dst, offset));
-                    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, reg, dst, 0, None));
-                }
-            },
-            Value::Constant64(value, user_provided) => {
-                debug_assert!(!user_provided && !is_stack_argument);
-                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, dst, value));
-            },
-        }
-    }
-
-    match dst {
-        Value::Register(reg) => {
-            emit_ins(jit, X86Instruction::call_reg(reg, None));
-        },
-        Value::Constant64(value, user_provided) => {
-            debug_assert!(!user_provided);
-            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, RAX, value));
-            emit_ins(jit, X86Instruction::call_reg(RAX, None));
-        },
-        _ => {
-            #[cfg(debug_assertions)]
-            unreachable!();
-        }
-    }
-
-    // Save returned value in result register
-    if let Some(reg) = result_reg {
-        emit_ins(jit, X86Instruction::mov(OperandSize::S64, RAX, reg));
-    }
-
-    // Restore registers from stack
-    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, stack_arguments * 8, None));
-    for reg in saved_registers.iter().rev() {
-        emit_ins(jit, X86Instruction::pop(*reg));
-    }
-
-    if check_exception {
-        // Test if result indicates that an error occured
-        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R11, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::OptRetValPtr))));
-        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, R11, 0, Some(X86IndirectAccess::Offset(0))));
-    }
-}
-
-#[inline]
-fn emit_address_translation(jit: &mut JitCompiler, host_addr: u8, vm_addr: Value, len: u64, access_type: AccessType) {
-    match vm_addr {
-        Value::RegisterPlusConstant64(reg, constant, user_provided) => {
-            if user_provided && should_sanitize_constant(jit, constant) {
-                emit_sanitized_load_immediate(jit, OperandSize::S64, R11, constant);
-            } else {
-                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, constant));
-            }
-            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, reg, R11, 0, None));
-        },
-        Value::Constant64(constant, user_provided) => {
-            if user_provided && should_sanitize_constant(jit, constant) {
-                emit_sanitized_load_immediate(jit, OperandSize::S64, R11, constant);
-            } else {
-                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, constant));
-            }
-        },
-        _ => {
-            #[cfg(debug_assertions)]
-            unreachable!();
-        },
-    }
-    let anchor = ANCHOR_TRANSLATE_MEMORY_ADDRESS + len.trailing_zeros() as usize + 4 * (access_type as usize);
-    emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(anchor, 5)));
-    emit_ins(jit, X86Instruction::mov(OperandSize::S64, R11, host_addr));
-}
-
-fn emit_shift(jit: &mut JitCompiler, size: OperandSize, opcode_extension: u8, source: u8, destination: u8, immediate: Option<i64>) {
-    if let Some(immediate) = immediate {
-        if should_sanitize_constant(jit, immediate) {
-            emit_sanitized_load_immediate(jit, OperandSize::S32, source, immediate);
-        } else {
-            emit_ins(jit, X86Instruction::alu(size, 0xc1, opcode_extension, destination, immediate, None));
-            return;
-        }
-    }
-    if let OperandSize::S32 = size {
-        emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x81, 4, destination, -1, None)); // Mask to 32 bit
-    }
-    if source == RCX {
-        if destination == RCX {
-            emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, destination, 0, None));
-        } else {
-            emit_ins(jit, X86Instruction::push(RCX, None));
-            emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, destination, 0, None));
-            emit_ins(jit, X86Instruction::pop(RCX));
-        }
-    } else if destination == RCX {
-        if source != R11 {
-            emit_ins(jit, X86Instruction::push(source, None));
-        }
-        emit_ins(jit, X86Instruction::xchg(OperandSize::S64, source, RCX, None));
-        emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, source, 0, None));
-        emit_ins(jit, X86Instruction::mov(OperandSize::S64, source, RCX));
-        if source != R11 {
-            emit_ins(jit, X86Instruction::pop(source));
-        }
-    } else {
-        emit_ins(jit, X86Instruction::push(RCX, None));
-        emit_ins(jit, X86Instruction::mov(OperandSize::S64, source, RCX));
-        emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, destination, 0, None));
-        emit_ins(jit, X86Instruction::pop(RCX));
-    }
-}
-
-fn emit_muldivmod(jit: &mut JitCompiler, opc: u8, src: u8, dst: u8, imm: Option<i64>) {
-    let mul = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MUL32_IMM & ebpf::BPF_ALU_OP_MASK);
-    let div = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::DIV32_IMM & ebpf::BPF_ALU_OP_MASK);
-    let sdiv = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::SDIV32_IMM & ebpf::BPF_ALU_OP_MASK);
-    let modrm = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MOD32_IMM & ebpf::BPF_ALU_OP_MASK);
-    let size = if (opc & ebpf::BPF_CLS_MASK) == ebpf::BPF_ALU64 { OperandSize::S64 } else { OperandSize::S32 };
-
-    if !mul && imm.is_none() {
-        // Save pc
-        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
-        emit_ins(jit, X86Instruction::test(size, src, src, None)); // src == 0
-        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x84, jit.relative_to_anchor(ANCHOR_DIV_BY_ZERO, 6)));
-    }
-
-    // sdiv overflows with MIN / -1. If we have an immediate and it's not -1, we
-    // don't need any checks.
-    if sdiv && imm.unwrap_or(-1) == -1 {
-        emit_ins(jit, X86Instruction::load_immediate(size, R11, if let OperandSize::S64 = size { i64::MIN } else { i32::MIN as i64 }));
-        emit_ins(jit, X86Instruction::cmp(size, dst, R11, None)); // dst == MIN
-
-        if imm.is_none() {
-            // The exception case is: dst == MIN && src == -1
-            // Via De Morgan's law becomes: !(dst != MIN || src != -1)
-            // Also, we know that src != 0 in here, so we can use it to set R11 to something not zero
-            emit_ins(jit, X86Instruction::load_immediate(size, R11, 0)); // No XOR here because we need to keep the status flags
-            emit_ins(jit, X86Instruction::cmov(size, 0x45, src, R11)); // if dst != MIN { r11 = src; }
-            emit_ins(jit, X86Instruction::cmp_immediate(size, src, -1, None)); // src == -1
-            emit_ins(jit, X86Instruction::cmov(size, 0x45, src, R11)); // if src != -1 { r11 = src; }
-            emit_ins(jit, X86Instruction::test(size, R11, R11, None)); // r11 == 0
-        }
-        
-        // MIN / -1, raise EbpfError::DivideOverflow(pc)
-        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
-        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x84, jit.relative_to_anchor(ANCHOR_DIV_OVERFLOW, 6)));
-    }
-
-    if dst != RAX {
-        emit_ins(jit, X86Instruction::push(RAX, None));
-    }
-    if dst != RDX {
-        emit_ins(jit, X86Instruction::push(RDX, None));
-    }
-
-    if let Some(imm) = imm {
-        if should_sanitize_constant(jit, imm) {
-            emit_sanitized_load_immediate(jit, OperandSize::S64, R11, imm);
-        } else {
-            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, imm));
-        }
-    } else {
-        emit_ins(jit, X86Instruction::mov(OperandSize::S64, src, R11));
-    }
-
-    if dst != RAX {
-        emit_ins(jit, X86Instruction::mov(OperandSize::S64, dst, RAX));
-    }
-
-    if div || modrm {
-        emit_ins(jit, X86Instruction::alu(size, 0x31, RDX, RDX, 0, None)); // RDX = 0
-    } else if sdiv {
-        emit_ins(jit, X86Instruction::dividend_sign_extension(size)); // (RAX, RDX) = RAX as i128
-    }
-
-    emit_ins(jit, X86Instruction::alu(size, 0xf7, if mul { 4 } else if sdiv { 7 } else { 6 }, R11, 0, None));
-
-    if dst != RDX {
-        if modrm {
-            emit_ins(jit, X86Instruction::mov(OperandSize::S64, RDX, dst));
-        }
-        emit_ins(jit, X86Instruction::pop(RDX));
-    }
-    if dst != RAX {
-        if !modrm {
-            emit_ins(jit, X86Instruction::mov(OperandSize::S64, RAX, dst));
-        }
-        emit_ins(jit, X86Instruction::pop(RAX));
-    }
-
-    if let OperandSize::S32 = size {
-        if mul || sdiv {
-            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
-        }
-    }
-}
-
-fn emit_set_exception_kind<E: UserDefinedError>(jit: &mut JitCompiler, err: EbpfError<E>) {
-    let err = Result::<u64, EbpfError<E>>::Err(err);
-    let err_kind = unsafe { *(&err as *const _ as *const u64).offset(1) };
-    emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlot::OptRetValPtr))));
-    emit_ins(jit, X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(8), err_kind as i64));
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum OperandSize {
+    S0  = 0,
+    S8  = 8,
+    S16 = 16,
+    S32 = 32,
+    S64 = 64,
 }
 
 #[derive(Debug)]
-struct Jump {
-    location: *const u8,
-    target_pc: usize,
+pub struct Jump {
+    pub(crate) location: *const u8,
+    pub(crate) target_pc: usize,
+    pub(crate) fixup_type: u8, // architecture-specific
 }
 
-pub struct JitCompiler {
-    result: JitProgramSections,
-    text_section_jumps: Vec<Jump>,
-    offset_in_text_section: usize,
-    pc: usize,
-    last_instruction_meter_validation_pc: usize,
-    next_noop_insertion: u32,
-    program_vm_addr: u64,
-    anchors: [*const u8; ANCHOR_COUNT],
+pub struct JitCompilerCore {
+    pub(crate) result: JitProgramSections,
+    pub(crate) text_section_jumps: Vec<Jump>,
+    pub(crate) offset_in_text_section: usize,
+    pub(crate) pc: usize,
+    pub(crate) last_instruction_meter_validation_pc: usize,
+    pub(crate) next_noop_insertion: u32,
+    pub(crate) program_vm_addr: u64,
+    pub(crate) anchors: [*const u8; ANCHOR_COUNT],
     pub(crate) config: Config,
     pub(crate) diversification_rng: SmallRng,
-    stopwatch_is_active: bool,
-    environment_stack_key: i32,
-    program_argument_key: i32,
+    pub(crate) stopwatch_is_active: bool,
+    pub(crate) environment_stack_key: i32,
+    pub(crate) program_argument_key: i32,
 }
 
-impl Index<usize> for JitCompiler {
-    type Output = u8;
-
-    fn index(&self, _index: usize) -> &u8 {
-        &self.result.text_section[_index]
-    }
-}
-
-impl IndexMut<usize> for JitCompiler {
-    fn index_mut(&mut self, _index: usize) -> &mut u8 {
-        &mut self.result.text_section[_index]
-    }
-}
-
-impl std::fmt::Debug for JitCompiler {
+impl std::fmt::Debug for JitCompilerCore {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FormatterError> {
         fmt.write_str("JIT text_section: [")?;
         for i in self.result.text_section as &[u8] {
@@ -910,22 +367,22 @@ impl std::fmt::Debug for JitCompiler {
             .finish()
     }
 }
+impl JitCompilerCore {
 
-impl JitCompiler {
     // Arguments are unused on windows
     fn new<E: UserDefinedError>(program: &[u8], config: &Config) -> Result<Self, EbpfError<E>> {
         #[cfg(target_os = "windows")]
         {
             let _ = program;
             let _ = config;
-            panic!("JIT not supported on windows");
+            panic!("JitCompilerX86 not supported on windows");
         }
 
-        #[cfg(not(target_arch = "x86_64"))]
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
         {
             let _ = program;
             let _ = config;
-            panic!("JIT is only supported on x86_64");
+            panic!("JitCompilerCore is only supported on x86_64 and ARM");
         }
 
         // Scan through program to find actual number of instructions
@@ -938,7 +395,7 @@ impl JitCompiler {
             };
         }
 
-        let mut code_length_estimate = MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION * pc;
+        let mut code_length_estimate = JitCompilerNative::get_max_empty_machine_code_length() + JitCompilerNative::get_max_machine_code_per_instruction() * pc;
         if config.noop_instruction_rate != 0 {
             code_length_estimate += code_length_estimate / config.noop_instruction_rate as usize;
         }
@@ -970,771 +427,153 @@ impl JitCompiler {
         })
     }
 
+    #[allow(dead_code)]
+    fn print_anchors(&self) {
+        for (anchor, addr) in self.anchors.iter().enumerate() {
+            println!("Anchor {:#x}: {:p}", (anchor) as i64, *addr);
+        }
+    }
+
+}
+
+
+impl Index<usize> for JitCompilerCore {
+    type Output = u8;
+
+    fn index(&self, _index: usize) -> &u8 {
+        &self.result.text_section[_index]
+    }
+}
+
+impl IndexMut<usize> for JitCompilerCore {
+    fn index_mut(&mut self, _index: usize) -> &mut u8 {
+        &mut self.result.text_section[_index]
+    }
+}
+
+pub(crate) trait JitCompilerImpl where Self: Sized {
+    fn get_max_empty_machine_code_length() -> usize;
+    fn get_max_machine_code_per_instruction() -> usize;
+    fn generate_subroutines<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore);
+    fn generate_prologue<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore, executable: &Pin<Box<Executable<E, I>>>);
+    fn handle_insn<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore, insn: Insn, executable: &Pin<Box<Executable<E, I>>>, program: &[u8]) -> Result<(), EbpfError<E>>;
+    fn emit_profile_instruction_count(jit: &mut JitCompilerCore, target_pc: Option<usize>);
+    fn emit_validate_instruction_count(jit: &mut JitCompilerCore, exclusive: bool, pc: Option<usize>);
+    fn emit_overrun<E: UserDefinedError>(jit: &mut JitCompilerCore);
+
+    fn get_core(&mut self) -> &mut JitCompilerCore;
+    fn get_result(self) -> JitProgramSections;
+    fn fixup_text_jumps(jit: &mut JitCompilerCore);
+    fn new<E: UserDefinedError>(jit: JitCompilerCore) -> Result<Self, EbpfError<E>>;
+    #[inline]
+    fn emit_validate_and_profile_instruction_count(jit: &mut JitCompilerCore, exclusive: bool, target_pc: Option<usize>) {
+        if jit.config.enable_instruction_meter {
+            Self::emit_validate_instruction_count(jit, exclusive, Some(jit.pc));
+            Self::emit_profile_instruction_count(jit, target_pc);
+        }
+    }
+
     fn compile<E: UserDefinedError, I: InstructionMeter>(&mut self,
             executable: &Pin<Box<Executable<E, I>>>) -> Result<(), EbpfError<E>> {
-        let text_section_base = self.result.text_section.as_ptr();
+        let jit = self.get_core();
+        let text_section_base = jit.result.text_section.as_ptr();
         let (program_vm_addr, program) = executable.get_text_bytes();
-        self.program_vm_addr = program_vm_addr;
+        jit.program_vm_addr = program_vm_addr;
 
-        self.generate_prologue::<E, I>(executable)?;
+        Self::generate_prologue::<E, I>(jit, executable);
 
-        // Have these in front so that the linear search of ANCHOR_TRANSLATE_PC does not terminate early
-        self.generate_subroutines::<E, I>()?;
+        // Have these in front so that the linear search of TARGET_PC_TRANSLATE_PC does not terminate early
+        Self::generate_subroutines::<E, I>(jit);
 
-        while self.pc * ebpf::INSN_SIZE < program.len() {
-            if self.offset_in_text_section + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION > self.result.text_section.len() {
-                return Err(EbpfError::ExhaustedTextSegment(self.pc));
-            }
-            let mut insn = ebpf::get_insn_unchecked(program, self.pc);
-            self.result.pc_section[self.pc] = unsafe { text_section_base.add(self.offset_in_text_section) } as usize;
+        while jit.pc * ebpf::INSN_SIZE < program.len() {
+            let insn = ebpf::get_insn_unchecked(program, jit.pc);
+
+            jit.result.pc_section[jit.pc] = unsafe { text_section_base.add(jit.offset_in_text_section) } as usize;
 
             // Regular instruction meter checkpoints to prevent long linear runs from exceeding their budget
-            if self.last_instruction_meter_validation_pc + self.config.instruction_meter_checkpoint_distance <= self.pc {
-                emit_validate_instruction_count(self, true, Some(self.pc));
+            // NOTE; These must be deterministic
+            if jit.last_instruction_meter_validation_pc + jit.config.instruction_meter_checkpoint_distance <= jit.pc {
+                Self::emit_validate_instruction_count(jit, true, Some(jit.pc));
             }
 
-            if self.config.enable_instruction_tracing {
-                emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, self.pc as i64));
-                emit_ins(self, X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_TRACE, 5)));
-                emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, 0));
-            }
+            Self::handle_insn(jit, insn, executable, program)?;
 
-            let dst = if insn.dst == STACK_PTR_REG as u8 { u8::MAX } else { REGISTER_MAP[insn.dst as usize] };
-            let src = REGISTER_MAP[insn.src as usize];
-            let target_pc = (self.pc as isize + insn.off as isize + 1) as usize;
-
-            match insn.opc {
-                _ if insn.dst == STACK_PTR_REG as u8 && self.config.dynamic_stack_frames => {
-                    let stack_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::BpfStackPtr));
-                    match insn.opc {
-                        ebpf::SUB64_IMM => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 5, RBP, insn.imm, Some(stack_ptr_access))),
-                        ebpf::ADD64_IMM => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, insn.imm, Some(stack_ptr_access))),
-                        _ => {
-                            #[cfg(debug_assertions)]
-                            unreachable!("unexpected insn on r11")
-                        }
-                    }
-                }
-
-                ebpf::LD_DW_IMM  => {
-                    emit_validate_and_profile_instruction_count(self, true, Some(self.pc + 2));
-                    self.pc += 1;
-                    self.result.pc_section[self.pc] = self.anchors[ANCHOR_CALL_UNSUPPORTED_INSTRUCTION] as usize;
-                    ebpf::augment_lddw_unchecked(program, &mut insn);
-                    if should_sanitize_constant(self, insn.imm) {
-                        emit_sanitized_load_immediate(self, OperandSize::S64, dst, insn.imm);
-                    } else {
-                        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, dst, insn.imm));
-                    }
-                },
-
-                // BPF_LDX class
-                ebpf::LD_B_REG   => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 1, AccessType::Load);
-                    emit_ins(self, X86Instruction::load(OperandSize::S8, R11, dst, X86IndirectAccess::Offset(0)));
-                },
-                ebpf::LD_H_REG   => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 2, AccessType::Load);
-                    emit_ins(self, X86Instruction::load(OperandSize::S16, R11, dst, X86IndirectAccess::Offset(0)));
-                },
-                ebpf::LD_W_REG   => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 4, AccessType::Load);
-                    emit_ins(self, X86Instruction::load(OperandSize::S32, R11, dst, X86IndirectAccess::Offset(0)));
-                },
-                ebpf::LD_DW_REG  => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 8, AccessType::Load);
-                    emit_ins(self, X86Instruction::load(OperandSize::S64, R11, dst, X86IndirectAccess::Offset(0)));
-                },
-
-                // BPF_ST class
-                ebpf::ST_B_IMM   => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 1, AccessType::Store);
-                    emit_ins(self, X86Instruction::store_immediate(OperandSize::S8, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
-                },
-                ebpf::ST_H_IMM   => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, AccessType::Store);
-                    emit_ins(self, X86Instruction::store_immediate(OperandSize::S16, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
-                },
-                ebpf::ST_W_IMM   => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4, AccessType::Store);
-                    emit_ins(self, X86Instruction::store_immediate(OperandSize::S32, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
-                },
-                ebpf::ST_DW_IMM  => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, AccessType::Store);
-                    emit_ins(self, X86Instruction::store_immediate(OperandSize::S64, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
-                },
-
-                // BPF_STX class
-                ebpf::ST_B_REG  => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 1, AccessType::Store);
-                    emit_ins(self, X86Instruction::store(OperandSize::S8, src, R11, X86IndirectAccess::Offset(0)));
-                },
-                ebpf::ST_H_REG  => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, AccessType::Store);
-                    emit_ins(self, X86Instruction::store(OperandSize::S16, src, R11, X86IndirectAccess::Offset(0)));
-                },
-                ebpf::ST_W_REG  => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4, AccessType::Store);
-                    emit_ins(self, X86Instruction::store(OperandSize::S32, src, R11, X86IndirectAccess::Offset(0)));
-                },
-                ebpf::ST_DW_REG  => {
-                    emit_address_translation(self, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, AccessType::Store);
-                    emit_ins(self, X86Instruction::store(OperandSize::S64, src, R11, X86IndirectAccess::Offset(0)));
-                },
-
-                // BPF_ALU class
-                ebpf::ADD32_IMM  => {
-                    emit_sanitized_alu(self, OperandSize::S32, 0x01, 0, dst, insn.imm);
-                    emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
-                },
-                ebpf::ADD32_REG  => {
-                    emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x01, src, dst, 0, None));
-                    emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
-                },
-                ebpf::SUB32_IMM  => {
-                    emit_sanitized_alu(self, OperandSize::S32, 0x29, 5, dst, insn.imm);
-                    emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
-                },
-                ebpf::SUB32_REG  => {
-                    emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x29, src, dst, 0, None));
-                    emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
-                },
-                ebpf::MUL32_IMM | ebpf::DIV32_IMM | ebpf::SDIV32_IMM | ebpf::MOD32_IMM  =>
-                    emit_muldivmod(self, insn.opc, dst, dst, Some(insn.imm)),
-                ebpf::MUL32_REG | ebpf::DIV32_REG | ebpf::SDIV32_REG | ebpf::MOD32_REG  =>
-                    emit_muldivmod(self, insn.opc, src, dst, None),
-                ebpf::OR32_IMM   => emit_sanitized_alu(self, OperandSize::S32, 0x09, 1, dst, insn.imm),
-                ebpf::OR32_REG   => emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x09, src, dst, 0, None)),
-                ebpf::AND32_IMM  => emit_sanitized_alu(self, OperandSize::S32, 0x21, 4, dst, insn.imm),
-                ebpf::AND32_REG  => emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x21, src, dst, 0, None)),
-                ebpf::LSH32_IMM  => emit_shift(self, OperandSize::S32, 4, R11, dst, Some(insn.imm)),
-                ebpf::LSH32_REG  => emit_shift(self, OperandSize::S32, 4, src, dst, None),
-                ebpf::RSH32_IMM  => emit_shift(self, OperandSize::S32, 5, R11, dst, Some(insn.imm)),
-                ebpf::RSH32_REG  => emit_shift(self, OperandSize::S32, 5, src, dst, None),
-                ebpf::NEG32      => emit_ins(self, X86Instruction::alu(OperandSize::S32, 0xf7, 3, dst, 0, None)),
-                ebpf::XOR32_IMM  => emit_sanitized_alu(self, OperandSize::S32, 0x31, 6, dst, insn.imm),
-                ebpf::XOR32_REG  => emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x31, src, dst, 0, None)),
-                ebpf::MOV32_IMM  => {
-                    if should_sanitize_constant(self, insn.imm) {
-                        emit_sanitized_load_immediate(self, OperandSize::S32, dst, insn.imm);
-                    } else {
-                        emit_ins(self, X86Instruction::load_immediate(OperandSize::S32, dst, insn.imm));
-                    }
-                }
-                ebpf::MOV32_REG  => emit_ins(self, X86Instruction::mov(OperandSize::S32, src, dst)),
-                ebpf::ARSH32_IMM => emit_shift(self, OperandSize::S32, 7, R11, dst, Some(insn.imm)),
-                ebpf::ARSH32_REG => emit_shift(self, OperandSize::S32, 7, src, dst, None),
-                ebpf::LE         => {
-                    match insn.imm {
-                        16 => {
-                            emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x81, 4, dst, 0xffff, None)); // Mask to 16 bit
-                        }
-                        32 => {
-                            emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x81, 4, dst, -1, None)); // Mask to 32 bit
-                        }
-                        64 => {}
-                        _ => {
-                            return Err(EbpfError::InvalidInstruction(self.pc + ebpf::ELF_INSN_DUMP_OFFSET));
-                        }
-                    }
-                },
-                ebpf::BE         => {
-                    match insn.imm {
-                        16 => {
-                            emit_ins(self, X86Instruction::bswap(OperandSize::S16, dst));
-                            emit_ins(self, X86Instruction::alu(OperandSize::S32, 0x81, 4, dst, 0xffff, None)); // Mask to 16 bit
-                        }
-                        32 => emit_ins(self, X86Instruction::bswap(OperandSize::S32, dst)),
-                        64 => emit_ins(self, X86Instruction::bswap(OperandSize::S64, dst)),
-                        _ => {
-                            return Err(EbpfError::InvalidInstruction(self.pc + ebpf::ELF_INSN_DUMP_OFFSET));
-                        }
-                    }
-                },
-
-                // BPF_ALU64 class
-                ebpf::ADD64_IMM  => emit_sanitized_alu(self, OperandSize::S64, 0x01, 0, dst, insn.imm),
-                ebpf::ADD64_REG  => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x01, src, dst, 0, None)),
-                ebpf::SUB64_IMM  => emit_sanitized_alu(self, OperandSize::S64, 0x29, 5, dst, insn.imm),
-                ebpf::SUB64_REG  => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x29, src, dst, 0, None)),
-                ebpf::MUL64_IMM | ebpf::DIV64_IMM | ebpf::SDIV64_IMM | ebpf::MOD64_IMM  =>
-                    emit_muldivmod(self, insn.opc, dst, dst, Some(insn.imm)),
-                ebpf::MUL64_REG | ebpf::DIV64_REG | ebpf::SDIV64_REG | ebpf::MOD64_REG  =>
-                    emit_muldivmod(self, insn.opc, src, dst, None),
-                ebpf::OR64_IMM   => emit_sanitized_alu(self, OperandSize::S64, 0x09, 1, dst, insn.imm),
-                ebpf::OR64_REG   => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x09, src, dst, 0, None)),
-                ebpf::AND64_IMM  => emit_sanitized_alu(self, OperandSize::S64, 0x21, 4, dst, insn.imm),
-                ebpf::AND64_REG  => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x21, src, dst, 0, None)),
-                ebpf::LSH64_IMM  => emit_shift(self, OperandSize::S64, 4, R11, dst, Some(insn.imm)),
-                ebpf::LSH64_REG  => emit_shift(self, OperandSize::S64, 4, src, dst, None),
-                ebpf::RSH64_IMM  => emit_shift(self, OperandSize::S64, 5, R11, dst, Some(insn.imm)),
-                ebpf::RSH64_REG  => emit_shift(self, OperandSize::S64, 5, src, dst, None),
-                ebpf::NEG64      => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xf7, 3, dst, 0, None)),
-                ebpf::XOR64_IMM  => emit_sanitized_alu(self, OperandSize::S64, 0x31, 6, dst, insn.imm),
-                ebpf::XOR64_REG  => emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x31, src, dst, 0, None)),
-                ebpf::MOV64_IMM  => {
-                    if should_sanitize_constant(self, insn.imm) {
-                        emit_sanitized_load_immediate(self, OperandSize::S64, dst, insn.imm);
-                    } else {
-                        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, dst, insn.imm));
-                    }
-                }
-                ebpf::MOV64_REG  => emit_ins(self, X86Instruction::mov(OperandSize::S64, src, dst)),
-                ebpf::ARSH64_IMM => emit_shift(self, OperandSize::S64, 7, R11, dst, Some(insn.imm)),
-                ebpf::ARSH64_REG => emit_shift(self, OperandSize::S64, 7, src, dst, None),
-
-                // BPF_JMP class
-                ebpf::JA         => {
-                    emit_validate_and_profile_instruction_count(self, false, Some(target_pc));
-                    emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
-                    let jump_offset = self.relative_to_target_pc(target_pc, 5);
-                    emit_ins(self, X86Instruction::jump_immediate(jump_offset));
-                },
-                ebpf::JEQ_IMM    => emit_conditional_branch_imm(self, 0x84, false, insn.imm, dst, target_pc),
-                ebpf::JEQ_REG    => emit_conditional_branch_reg(self, 0x84, false, src, dst, target_pc),
-                ebpf::JGT_IMM    => emit_conditional_branch_imm(self, 0x87, false, insn.imm, dst, target_pc),
-                ebpf::JGT_REG    => emit_conditional_branch_reg(self, 0x87, false, src, dst, target_pc),
-                ebpf::JGE_IMM    => emit_conditional_branch_imm(self, 0x83, false, insn.imm, dst, target_pc),
-                ebpf::JGE_REG    => emit_conditional_branch_reg(self, 0x83, false, src, dst, target_pc),
-                ebpf::JLT_IMM    => emit_conditional_branch_imm(self, 0x82, false, insn.imm, dst, target_pc),
-                ebpf::JLT_REG    => emit_conditional_branch_reg(self, 0x82, false, src, dst, target_pc),
-                ebpf::JLE_IMM    => emit_conditional_branch_imm(self, 0x86, false, insn.imm, dst, target_pc),
-                ebpf::JLE_REG    => emit_conditional_branch_reg(self, 0x86, false, src, dst, target_pc),
-                ebpf::JSET_IMM   => emit_conditional_branch_imm(self, 0x85, true, insn.imm, dst, target_pc),
-                ebpf::JSET_REG   => emit_conditional_branch_reg(self, 0x85, true, src, dst, target_pc),
-                ebpf::JNE_IMM    => emit_conditional_branch_imm(self, 0x85, false, insn.imm, dst, target_pc),
-                ebpf::JNE_REG    => emit_conditional_branch_reg(self, 0x85, false, src, dst, target_pc),
-                ebpf::JSGT_IMM   => emit_conditional_branch_imm(self, 0x8f, false, insn.imm, dst, target_pc),
-                ebpf::JSGT_REG   => emit_conditional_branch_reg(self, 0x8f, false, src, dst, target_pc),
-                ebpf::JSGE_IMM   => emit_conditional_branch_imm(self, 0x8d, false, insn.imm, dst, target_pc),
-                ebpf::JSGE_REG   => emit_conditional_branch_reg(self, 0x8d, false, src, dst, target_pc),
-                ebpf::JSLT_IMM   => emit_conditional_branch_imm(self, 0x8c, false, insn.imm, dst, target_pc),
-                ebpf::JSLT_REG   => emit_conditional_branch_reg(self, 0x8c, false, src, dst, target_pc),
-                ebpf::JSLE_IMM   => emit_conditional_branch_imm(self, 0x8e, false, insn.imm, dst, target_pc),
-                ebpf::JSLE_REG   => emit_conditional_branch_reg(self, 0x8e, false, src, dst, target_pc),
-                ebpf::CALL_IMM   => {
-                    // For JIT, syscalls MUST be registered at compile time. They can be
-                    // updated later, but not created after compiling (we need the address of the
-                    // syscall function in the JIT-compiled program).
-
-                    let mut resolved = false;
-                    let (syscalls, calls) = if self.config.static_syscalls {
-                        (insn.src == 0, insn.src != 0)
-                    } else {
-                        (true, true)
-                    };
-
-                    if syscalls {
-                        if let Some(syscall) = executable.get_syscall_registry().lookup_syscall(insn.imm as u32) {
-                            if self.config.enable_instruction_meter {
-                                emit_validate_and_profile_instruction_count(self, true, Some(0));
-                            }
-                            emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, syscall.function as *const u8 as i64));
-                            emit_ins(self, X86Instruction::load(OperandSize::S64, R10, RAX, X86IndirectAccess::Offset((SYSCALL_CONTEXT_OBJECTS_OFFSET + syscall.context_object_slot) as i32 * 8 + self.program_argument_key)));
-                            emit_ins(self, X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_SYSCALL, 5)));
-                            if self.config.enable_instruction_meter {
-                                emit_undo_profile_instruction_count(self, 0);
-                            }
-                            // Throw error if the result indicates one
-                            emit_ins(self, X86Instruction::cmp_immediate(OperandSize::S64, R11, 0, Some(X86IndirectAccess::Offset(0))));
-                            emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, self.pc as i64));
-                            emit_ins(self, X86Instruction::conditional_jump_immediate(0x85, self.relative_to_anchor(ANCHOR_RUST_EXCEPTION, 6)));
-
-                            resolved = true;
-                        }
-                    }
-
-                    if calls {
-                        if let Some(target_pc) = executable.lookup_bpf_function(insn.imm as u32) {
-                            emit_bpf_call(self, Value::Constant64(target_pc as i64, false));
-                            resolved = true;
-                        }
-                    }
-
-                    if !resolved {
-                        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, self.pc as i64));
-                        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 5)));
-                    }
-                },
-                ebpf::CALL_REG  => {
-                    emit_bpf_call(self, Value::Register(REGISTER_MAP[insn.imm as usize]));
-                },
-                ebpf::EXIT      => {
-                    let call_depth_access = X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::CallDepth));
-                    emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], call_depth_access));
-
-                    // If CallDepth == 0, we've reached the exit instruction of the entry point
-                    emit_ins(self, X86Instruction::cmp_immediate(OperandSize::S32, REGISTER_MAP[FRAME_PTR_REG], 0, None));
-                    if self.config.enable_instruction_meter {
-                        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, self.pc as i64));
-                    }
-                    // we're done
-                    emit_ins(self, X86Instruction::conditional_jump_immediate(0x84, self.relative_to_anchor(ANCHOR_EXIT, 6)));
-
-                    // else decrement and update CallDepth
-                    emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 5, REGISTER_MAP[FRAME_PTR_REG], 1, None));
-                    emit_ins(self, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RBP, call_depth_access));
-
-                    // and return
-                    emit_validate_and_profile_instruction_count(self, false, Some(0));
-                    emit_ins(self, X86Instruction::return_near());
-                },
-
-                _               => return Err(EbpfError::UnsupportedInstruction(self.pc + ebpf::ELF_INSN_DUMP_OFFSET)),
-            }
-
-            self.pc += 1;
+            jit.pc += 1;
         }
         // Bumper so that the linear search of ANCHOR_TRANSLATE_PC can not run off
-        self.result.pc_section[self.pc] = unsafe { text_section_base.add(self.offset_in_text_section) } as usize;
+        jit.result.pc_section[jit.pc] = unsafe { text_section_base.add(jit.offset_in_text_section) } as usize;
 
         // Bumper in case there was no final exit
-        if self.offset_in_text_section + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION > self.result.text_section.len() {
-            return Err(EbpfError::ExhaustedTextSegment(self.pc));
-        }        
-        emit_validate_and_profile_instruction_count(self, true, Some(self.pc + 2));
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, self.pc as i64));
-        emit_set_exception_kind::<E>(self, EbpfError::ExecutionOverrun(0));
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+        if jit.offset_in_text_section + Self::get_max_machine_code_per_instruction() > jit.result.text_section.len() {
+            return Err(EbpfError::ExhaustedTextSegment(jit.pc));
+        }
 
-        self.resolve_jumps();
-        self.result.seal(self.offset_in_text_section)?;
+        // Bumper in case there was no final exit
+        Self::emit_overrun::<E>(jit);
+        Self::fixup_text_jumps(jit);
+        jit.resolve_jumps();
+        jit.result.seal(jit.offset_in_text_section)?;
 
         // Delete secrets
-        self.environment_stack_key = 0;
-        self.program_argument_key = 0;
+        jit.environment_stack_key = 0;
+        jit.program_argument_key = 0;
 
         Ok(())
     }
 
-    fn generate_prologue<E: UserDefinedError, I: InstructionMeter>(&mut self, executable: &Pin<Box<Executable<E, I>>>) -> Result<(), EbpfError<E>> {
-        // Place the environment on the stack according to EnvironmentStackSlot
+}
 
-        // Save registers
-        for reg in CALLEE_SAVED_REGISTERS.iter() {
-            emit_ins(self, X86Instruction::push(*reg, None));
-        }
-
-        // Initialize CallDepth to 0
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], 0));
-        emit_ins(self, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
-
-        // Initialize the BPF frame and stack pointers (BpfFramePtr and BpfStackPtr)
-        if self.config.dynamic_stack_frames {
-            // The stack is fully descending from MM_STACK_START + stack_size to MM_STACK_START
-            emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], MM_STACK_START as i64 + self.config.stack_size() as i64));
-            // Push BpfFramePtr
-            emit_ins(self, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
-            // Push BpfStackPtr
-            emit_ins(self, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
-        } else {
-            // The frames are ascending from MM_STACK_START to MM_STACK_START + stack_size. The stack within the frames is descending.
-            emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], MM_STACK_START as i64 + self.config.stack_frame_size as i64));
-            // Push BpfFramePtr
-            emit_ins(self, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
-            // When using static frames BpfStackPtr is not used
-            emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, RBP, 0));
-            emit_ins(self, X86Instruction::push(RBP, None));
-        }
-
-        // Save pointer to optional typed return value
-        emit_ins(self, X86Instruction::push(ARGUMENT_REGISTERS[0], None));
-
-        // Save initial value of instruction_meter.get_remaining()
-        emit_rust_call(self, Value::Constant64(I::get_remaining as *const u8 as i64, false), &[
-            Argument { index: 0, value: Value::Register(ARGUMENT_REGISTERS[3]) },
-        ], Some(ARGUMENT_REGISTERS[0]), false);
-        emit_ins(self, X86Instruction::push(ARGUMENT_REGISTERS[0], None));
-
-        // Save instruction meter
-        emit_ins(self, X86Instruction::push(ARGUMENT_REGISTERS[3], None));
-
-        // Initialize stop watch
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x31, R11, R11, 0, None)); // R11 ^= R11;
-        emit_ins(self, X86Instruction::push(R11, None));
-        emit_ins(self, X86Instruction::push(R11, None));
-
-        // Initialize frame pointer
-        emit_ins(self, X86Instruction::mov(OperandSize::S64, RSP, RBP));
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, 8 * (EnvironmentStackSlot::SlotCount as i64 - 1 + self.environment_stack_key as i64), None));
-
-        // Save JitProgramArgument
-        emit_ins(self, X86Instruction::lea(OperandSize::S64, ARGUMENT_REGISTERS[2], R10, Some(X86IndirectAccess::Offset(-self.program_argument_key))));
-
-        // Zero BPF registers
-        for reg in REGISTER_MAP.iter() {
-            if *reg != REGISTER_MAP[1] && *reg != REGISTER_MAP[FRAME_PTR_REG] {
-                emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, *reg, 0));
-            }
-        }
-
-        // Jump to entry point
-        let entry = executable.get_entrypoint_instruction_offset().unwrap_or(0);
-        if self.config.enable_instruction_meter {
-            emit_profile_instruction_count(self, Some(entry + 1));
-        }
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, entry as i64));
-        let jump_offset = self.relative_to_target_pc(entry, 5);
-        emit_ins(self, X86Instruction::jump_immediate(jump_offset));
-
-        Ok(())
-    }
-
-    fn generate_subroutines<E: UserDefinedError, I: InstructionMeter>(&mut self) -> Result<(), EbpfError<E>> {
-        // Epilogue
-        self.set_anchor(ANCHOR_EPILOGUE);
-        // Print stop watch value
-        fn stopwatch_result(numerator: u64, denominator: u64) {
-            println!("Stop watch: {} / {} = {}", numerator, denominator, if denominator == 0 { 0.0 } else { numerator as f64 / denominator as f64 });
-        }
-        if self.stopwatch_is_active {
-            emit_rust_call(self, Value::Constant64(stopwatch_result as *const u8 as i64, false), &[
-                Argument { index: 1, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(self, EnvironmentStackSlot::StopwatchDenominator), false) },
-                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(self, EnvironmentStackSlot::StopwatchNumerator), false) },
-            ], None, false);
-        }
-        // Store instruction_meter in RAX
-        emit_ins(self, X86Instruction::mov(OperandSize::S64, ARGUMENT_REGISTERS[0], RAX));
-        // Restore stack pointer in case the BPF stack was used
-        emit_ins(self, X86Instruction::lea(OperandSize::S64, RBP, RSP, Some(X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::LastSavedRegister)))));
-        // Restore registers
-        for reg in CALLEE_SAVED_REGISTERS.iter().rev() {
-            emit_ins(self, X86Instruction::pop(*reg));
-        }
-        emit_ins(self, X86Instruction::return_near());
-
-        // Routine for instruction tracing
-        if self.config.enable_instruction_tracing {
-            self.set_anchor(ANCHOR_TRACE);
-            // Save registers on stack
-            emit_ins(self, X86Instruction::push(R11, None));
-            for reg in REGISTER_MAP.iter().rev() {
-                emit_ins(self, X86Instruction::push(*reg, None));
-            }
-            emit_ins(self, X86Instruction::mov(OperandSize::S64, RSP, REGISTER_MAP[0]));
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, - 8 * 3, None)); // RSP -= 8 * 3;
-            emit_rust_call(self, Value::Constant64(Tracer::trace as *const u8 as i64, false), &[
-                Argument { index: 1, value: Value::Register(REGISTER_MAP[0]) }, // registers
-                Argument { index: 0, value: Value::RegisterIndirect(R10, mem::size_of::<MemoryMapping>() as i32 + self.program_argument_key, false) }, // jit.tracer
-            ], None, false);
-            // Pop stack and return
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, 8 * 3, None)); // RSP += 8 * 3;
-            emit_ins(self, X86Instruction::pop(REGISTER_MAP[0]));
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, 8 * (REGISTER_MAP.len() - 1) as i64, None)); // RSP += 8 * (REGISTER_MAP.len() - 1);
-            emit_ins(self, X86Instruction::pop(R11));
-            emit_ins(self, X86Instruction::return_near());
-        }
-
-        // Handler for syscall exceptions
-        self.set_anchor(ANCHOR_RUST_EXCEPTION);
-        emit_profile_instruction_count_finalize(self, false);
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
-
-        // Handler for EbpfError::ExceededMaxInstructions
-        self.set_anchor(ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS);
-        emit_set_exception_kind::<E>(self, EbpfError::ExceededMaxInstructions(0, 0));
-        emit_ins(self, X86Instruction::mov(OperandSize::S64, ARGUMENT_REGISTERS[0], R11)); // R11 = instruction_meter;
-        emit_profile_instruction_count_finalize(self, true);
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
-
-        // Handler for exceptions which report their pc
-        self.set_anchor(ANCHOR_EXCEPTION_AT);
-        // Validate that we did not reach the instruction meter limit before the exception occured
-        if self.config.enable_instruction_meter {
-            emit_validate_instruction_count(self, false, None);
-        }
-        emit_profile_instruction_count_finalize(self, true);
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
-
-        // Handler for EbpfError::CallDepthExceeded
-        self.set_anchor(ANCHOR_CALL_DEPTH_EXCEEDED);
-        emit_set_exception_kind::<E>(self, EbpfError::CallDepthExceeded(0, 0));
-        emit_ins(self, X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(24), self.config.max_call_depth as i64)); // depth = jit.config.max_call_depth;
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
-
-        // Handler for EbpfError::CallOutsideTextSegment
-        self.set_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT);
-        emit_set_exception_kind::<E>(self, EbpfError::CallOutsideTextSegment(0, 0));
-        emit_ins(self, X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], R10, X86IndirectAccess::Offset(24))); // target_address = RAX;
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
-
-        // Handler for EbpfError::DivideByZero
-        self.set_anchor(ANCHOR_DIV_BY_ZERO);
-        emit_set_exception_kind::<E>(self, EbpfError::DivideByZero(0));
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
-
-        // Handler for EbpfError::DivideOverflow
-        self.set_anchor(ANCHOR_DIV_OVERFLOW);
-        emit_set_exception_kind::<E>(self, EbpfError::DivideOverflow(0));
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
-
-        // Handler for EbpfError::UnsupportedInstruction
-        self.set_anchor(ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION);
-        // Load BPF target pc from stack (which was saved in ANCHOR_BPF_CALL_REG)
-        emit_ins(self, X86Instruction::load(OperandSize::S64, RSP, R11, X86IndirectAccess::OffsetIndexShift(-16, RSP, 0))); // R11 = RSP[-16];
-        // emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 5))); // Fall-through
-
-        // Handler for EbpfError::UnsupportedInstruction
-        self.set_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION);
-        if self.config.enable_instruction_tracing {
-            emit_ins(self, X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_TRACE, 5)));
-        }
-        emit_set_exception_kind::<E>(self, EbpfError::UnsupportedInstruction(0));
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
-
-        // Quit gracefully
-        self.set_anchor(ANCHOR_EXIT);
-        emit_validate_instruction_count(self, false, None);
-        emit_profile_instruction_count_finalize(self, false);
-        emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::OptRetValPtr))));
-        emit_ins(self, X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], R10, X86IndirectAccess::Offset(8))); // result.return_value = R0;
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[0], 0));
-        emit_ins(self, X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], R10, X86IndirectAccess::Offset(0)));  // result.is_error = false;
-        emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
-
-        // Routine for syscall
-        self.set_anchor(ANCHOR_SYSCALL);
-        emit_ins(self, X86Instruction::push(R11, None)); // Padding for stack alignment
-        if self.config.enable_instruction_meter {
-            // RDI = *PrevInsnMeter - RDI;
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x2B, ARGUMENT_REGISTERS[0], RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::PrevInsnMeter))))); // RDI -= *PrevInsnMeter;
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xf7, 3, ARGUMENT_REGISTERS[0], 0, None)); // RDI = -RDI;
-            emit_rust_call(self, Value::Constant64(I::consume as *const u8 as i64, false), &[
-                Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[0]) },
-                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(self, EnvironmentStackSlot::InsnMeterPtr), false) },
-            ], None, false);
-        }
-        emit_rust_call(self, Value::Register(R11), &[
-            Argument { index: 7, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(self, EnvironmentStackSlot::OptRetValPtr), false) },
-            Argument { index: 6, value: Value::RegisterPlusConstant32(R10, self.program_argument_key, false) }, // jit_program_argument.memory_mapping
-            Argument { index: 5, value: Value::Register(ARGUMENT_REGISTERS[5]) },
-            Argument { index: 4, value: Value::Register(ARGUMENT_REGISTERS[4]) },
-            Argument { index: 3, value: Value::Register(ARGUMENT_REGISTERS[3]) },
-            Argument { index: 2, value: Value::Register(ARGUMENT_REGISTERS[2]) },
-            Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[1]) },
-            Argument { index: 0, value: Value::Register(RAX) }, // "&mut self" in the "call" method of the SyscallObject
-        ], None, false);
-        if self.config.enable_instruction_meter {
-            emit_rust_call(self, Value::Constant64(I::get_remaining as *const u8 as i64, false), &[
-                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(self, EnvironmentStackSlot::InsnMeterPtr), false) },
-            ], Some(ARGUMENT_REGISTERS[0]), false);
-            emit_ins(self, X86Instruction::store(OperandSize::S64, ARGUMENT_REGISTERS[0], RBP, X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::PrevInsnMeter))));
-        }
-        emit_ins(self, X86Instruction::pop(R11));
-        // Store Ok value in result register
-        emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, R11, X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::OptRetValPtr))));
-        emit_ins(self, X86Instruction::load(OperandSize::S64, R11, REGISTER_MAP[0], X86IndirectAccess::Offset(8)));
-        emit_ins(self, X86Instruction::return_near());
-
-        // Routine for prologue of emit_bpf_call()
-        self.set_anchor(ANCHOR_BPF_CALL_PROLOGUE);
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 5, RSP, 8 * (SCRATCH_REGS + 1) as i64, None)); // alloca
-        emit_ins(self, X86Instruction::store(OperandSize::S64, R11, RSP, X86IndirectAccess::OffsetIndexShift(0, RSP, 0))); // Save original R11
-        emit_ins(self, X86Instruction::load(OperandSize::S64, RSP, R11, X86IndirectAccess::OffsetIndexShift(8 * (SCRATCH_REGS + 1) as i32, RSP, 0))); // Load return address
-        for (i, reg) in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).enumerate() {
-            emit_ins(self, X86Instruction::store(OperandSize::S64, *reg, RSP, X86IndirectAccess::OffsetIndexShift(8 * (SCRATCH_REGS - i + 1) as i32, RSP, 0))); // Push SCRATCH_REG
-        }
-        // Push the caller's frame pointer. The code to restore it is emitted at the end of emit_bpf_call().
-        emit_ins(self, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RSP, X86IndirectAccess::OffsetIndexShift(8, RSP, 0)));
-        emit_ins(self, X86Instruction::xchg(OperandSize::S64, R11, RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Push return address and restore original R11
-
-        // Increase CallDepth
-        let call_depth_access = X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::CallDepth));
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, 1, Some(call_depth_access)));
-        emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], call_depth_access));
-        // If CallDepth == self.config.max_call_depth, stop and return CallDepthExceeded
-        emit_ins(self, X86Instruction::cmp_immediate(OperandSize::S32, REGISTER_MAP[FRAME_PTR_REG], self.config.max_call_depth as i64, None));
-        emit_ins(self, X86Instruction::conditional_jump_immediate(0x83, self.relative_to_anchor(ANCHOR_CALL_DEPTH_EXCEEDED, 6)));
-
-        // Setup the frame pointer for the new frame. What we do depends on whether we're using dynamic or fixed frames.
-        let frame_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::BpfFramePtr));
-        if self.config.dynamic_stack_frames {
-            // When dynamic frames are on, the next frame starts at the end of the current frame
-            let stack_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::BpfStackPtr));
-            emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], stack_ptr_access));
-            emit_ins(self, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RBP, frame_ptr_access));
-        } else {
-            // With fixed frames we start the new frame at the next fixed offset
-            let stack_frame_size = self.config.stack_frame_size as i64 * if self.config.enable_stack_frame_gaps { 2 } else { 1 };
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, stack_frame_size, Some(frame_ptr_access))); // frame_ptr += stack_frame_size;
-            emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], frame_ptr_access)); // Load BpfFramePtr
-        }
-        emit_ins(self, X86Instruction::return_near());
-
-        // Routine for emit_bpf_call(Value::Register())
-        self.set_anchor(ANCHOR_BPF_CALL_REG);
-        // Force alignment of RAX
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i64 - 1), None)); // RAX &= !(INSN_SIZE - 1);
-        // Upper bound check
-        // if(RAX >= self.program_vm_addr + number_of_instructions * INSN_SIZE) throw CALL_OUTSIDE_TEXT_SEGMENT;
-        let number_of_instructions = self.result.pc_section.len() - 1;
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], self.program_vm_addr as i64 + (number_of_instructions * INSN_SIZE) as i64));
-        emit_ins(self, X86Instruction::cmp(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], None));
-        emit_ins(self, X86Instruction::conditional_jump_immediate(0x83, self.relative_to_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT, 6)));
-        // Lower bound check
-        // if(RAX < self.program_vm_addr) throw CALL_OUTSIDE_TEXT_SEGMENT;
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], self.program_vm_addr as i64));
-        emit_ins(self, X86Instruction::cmp(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], None));
-        emit_ins(self, X86Instruction::conditional_jump_immediate(0x82, self.relative_to_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT, 6)));
-        // Calculate offset relative to instruction_addresses
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], 0, None)); // RAX -= self.program_vm_addr;
-        // Calculate the target_pc (dst / INSN_SIZE) to update the instruction_meter
-        let shift_amount = INSN_SIZE.trailing_zeros();
-        debug_assert_eq!(INSN_SIZE, 1 << shift_amount);
-        emit_ins(self, X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], R11));
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xc1, 5, R11, shift_amount as i64, None));
-        // Save BPF target pc for potential ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION
-        emit_ins(self, X86Instruction::store(OperandSize::S64, R11, RSP, X86IndirectAccess::OffsetIndexShift(-8, RSP, 0))); // RSP[-8] = R11;
-        // Load host target_address from self.result.pc_section
-        debug_assert_eq!(INSN_SIZE, 8); // Because the instruction size is also the slot size we do not need to shift the offset
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], self.result.pc_section.as_ptr() as i64));
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], 0, None)); // RAX += self.result.pc_section;
-        emit_ins(self, X86Instruction::load(OperandSize::S64, REGISTER_MAP[0], REGISTER_MAP[0], X86IndirectAccess::Offset(0))); // RAX = self.result.pc_section[RAX / 8];
-        // Load the frame pointer again since we've clobbered REGISTER_MAP[FRAME_PTR_REG]
-        emit_ins(self, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], X86IndirectAccess::Offset(slot_on_environment_stack(self, EnvironmentStackSlot::BpfFramePtr))));
-        emit_ins(self, X86Instruction::return_near());
-
-        // Translates a host pc back to a BPF pc by linear search of the pc_section table
-        self.set_anchor(ANCHOR_TRANSLATE_PC);
-        emit_ins(self, X86Instruction::push(REGISTER_MAP[0], None)); // Save REGISTER_MAP[0]
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[0], self.result.pc_section.as_ptr() as i64 - 8)); // Loop index and pointer to look up
-        self.set_anchor(ANCHOR_TRANSLATE_PC_LOOP); // Loop label
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, REGISTER_MAP[0], 8, None)); // Increase index
-        emit_ins(self, X86Instruction::cmp(OperandSize::S64, R11, REGISTER_MAP[0], Some(X86IndirectAccess::Offset(8)))); // Look up and compare against value at next index
-        emit_ins(self, X86Instruction::conditional_jump_immediate(0x86, self.relative_to_anchor(ANCHOR_TRANSLATE_PC_LOOP, 6))); // Continue while *REGISTER_MAP[0] <= R11
-        emit_ins(self, X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], R11)); // R11 = REGISTER_MAP[0];
-        emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[0], self.result.pc_section.as_ptr() as i64)); // REGISTER_MAP[0] = self.result.pc_section;
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_MAP[0], R11, 0, None)); // R11 -= REGISTER_MAP[0];
-        emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xc1, 5, R11, 3, None)); // R11 >>= 3;
-        emit_ins(self, X86Instruction::pop(REGISTER_MAP[0])); // Restore REGISTER_MAP[0]
-        emit_ins(self, X86Instruction::return_near());
-
-        // Translates a vm memory address to a host memory address
-        for (access_type, len) in &[
-            (AccessType::Load, 1i32),
-            (AccessType::Load, 2i32),
-            (AccessType::Load, 4i32),
-            (AccessType::Load, 8i32),
-            (AccessType::Store, 1i32),
-            (AccessType::Store, 2i32),
-            (AccessType::Store, 4i32),
-            (AccessType::Store, 8i32),
-        ] {
-            let target_offset = len.trailing_zeros() as usize + 4 * (*access_type as usize);
-            let stack_offset = if !self.config.dynamic_stack_frames && self.config.enable_stack_frame_gaps {
-                24
-            } else {
-                16
-            };
-
-            self.set_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset);
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x31, R11, R11, 0, None)); // R11 = 0;
-            emit_ins(self, X86Instruction::load(OperandSize::S64, RSP, R11, X86IndirectAccess::OffsetIndexShift(stack_offset, R11, 0)));
-            emit_rust_call(self, Value::Constant64(MemoryMapping::generate_access_violation::<UserError> as *const u8 as i64, false), &[
-                Argument { index: 3, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
-                Argument { index: 4, value: Value::Constant64(*len as i64, false) },
-                Argument { index: 2, value: Value::Constant64(*access_type as i64, false) },
-                Argument { index: 1, value: Value::RegisterPlusConstant32(R10, self.program_argument_key, false) }, // jit_program_argument.memory_mapping
-                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(self, EnvironmentStackSlot::OptRetValPtr), false) }, // Pointer to optional typed return value
-            ], None, true);
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, stack_offset as i64 + 8, None)); // Drop R11, RAX, RCX, RDX from stack
-            emit_ins(self, X86Instruction::pop(R11)); // Put callers PC in R11
-            emit_ins(self, X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_TRANSLATE_PC, 5)));
-            emit_ins(self, X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
-
-            self.set_anchor(ANCHOR_TRANSLATE_MEMORY_ADDRESS + target_offset);
-            emit_ins(self, X86Instruction::push(R11, None));
-            emit_ins(self, X86Instruction::push(RAX, None));
-            emit_ins(self, X86Instruction::push(RCX, None));
-            if !self.config.dynamic_stack_frames && self.config.enable_stack_frame_gaps {
-                emit_ins(self, X86Instruction::push(RDX, None));
-            }
-            emit_ins(self, X86Instruction::mov(OperandSize::S64, R11, RAX)); // RAX = vm_addr;
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xc1, 5, RAX, ebpf::VIRTUAL_ADDRESS_BITS as i64, None)); // RAX >>= ebpf::VIRTUAL_ADDRESS_BITS;
-            emit_ins(self, X86Instruction::cmp(OperandSize::S64, RAX, R10, Some(X86IndirectAccess::Offset(self.program_argument_key + 8)))); // region_index >= jit_program_argument.memory_mapping.regions.len()
-            emit_ins(self, X86Instruction::conditional_jump_immediate(0x86, self.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
-            debug_assert_eq!(1 << 5, mem::size_of::<MemoryRegion>());
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xc1, 4, RAX, 5, None)); // RAX *= mem::size_of::<MemoryRegion>();
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x03, RAX, R10, 0, Some(X86IndirectAccess::Offset(self.program_argument_key)))); // region = &jit_program_argument.memory_mapping.regions[region_index];
-            if *access_type == AccessType::Store {
-                emit_ins(self, X86Instruction::cmp_immediate(OperandSize::S8, RAX, 0, Some(X86IndirectAccess::Offset(MemoryRegion::IS_WRITABLE_OFFSET)))); // region.is_writable == 0
-                emit_ins(self, X86Instruction::conditional_jump_immediate(0x84, self.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
-            }
-            emit_ins(self, X86Instruction::load(OperandSize::S64, RAX, RCX, X86IndirectAccess::Offset(MemoryRegion::VM_ADDR_OFFSET))); // RCX = region.vm_addr
-            emit_ins(self, X86Instruction::cmp(OperandSize::S64, RCX, R11, None)); // vm_addr < region.vm_addr
-            emit_ins(self, X86Instruction::conditional_jump_immediate(0x82, self.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x29, RCX, R11, 0, None)); // vm_addr -= region.vm_addr
-            if !self.config.dynamic_stack_frames && self.config.enable_stack_frame_gaps {
-                emit_ins(self, X86Instruction::load(OperandSize::S8, RAX, RCX, X86IndirectAccess::Offset(MemoryRegion::VM_GAP_SHIFT_OFFSET))); // RCX = region.vm_gap_shift;
-                emit_ins(self, X86Instruction::mov(OperandSize::S64, R11, RDX)); // RDX = R11;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xd3, 5, RDX, 0, None)); // RDX = R11 >> region.vm_gap_shift;
-                emit_ins(self, X86Instruction::test_immediate(OperandSize::S64, RDX, 1, None)); // (RDX & 1) != 0
-                emit_ins(self, X86Instruction::conditional_jump_immediate(0x85, self.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
-                emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, RDX, -1)); // RDX = -1;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xd3, 4, RDX, 0, None)); // gap_mask = -1 << region.vm_gap_shift;
-                emit_ins(self, X86Instruction::mov(OperandSize::S64, RDX, RCX)); // RCX = RDX;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xf7, 2, RCX, 0, None)); // inverse_gap_mask = !gap_mask;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x21, R11, RCX, 0, None)); // below_gap = R11 & inverse_gap_mask;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x21, RDX, R11, 0, None)); // above_gap = R11 & gap_mask;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0xc1, 5, R11, 1, None)); // above_gap >>= 1;
-                emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x09, RCX, R11, 0, None)); // gapped_offset = above_gap | below_gap;
-            }
-            emit_ins(self, X86Instruction::lea(OperandSize::S64, R11, RCX, Some(X86IndirectAccess::Offset(*len)))); // RCX = R11 + len;
-            emit_ins(self, X86Instruction::cmp(OperandSize::S64, RCX, RAX, Some(X86IndirectAccess::Offset(MemoryRegion::LEN_OFFSET)))); // region.len < R11 + len
-            emit_ins(self, X86Instruction::conditional_jump_immediate(0x82, self.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x03, R11, RAX, 0, Some(X86IndirectAccess::Offset(MemoryRegion::HOST_ADDR_OFFSET)))); // R11 += region.host_addr;
-            if !self.config.dynamic_stack_frames && self.config.enable_stack_frame_gaps {
-                emit_ins(self, X86Instruction::pop(RDX));
-            }
-            emit_ins(self, X86Instruction::pop(RCX));
-            emit_ins(self, X86Instruction::pop(RAX));
-            emit_ins(self, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, 8, None));
-            emit_ins(self, X86Instruction::return_near());
-        }
-        Ok(())
-    }
-
-    fn set_anchor(&mut self, anchor: usize) {
+impl JitCompilerCore {
+    pub(crate) fn set_anchor(&mut self, anchor: usize) {
         self.anchors[anchor] = unsafe { self.result.text_section.as_ptr().add(self.offset_in_text_section) };
     }
 
-    // instruction_length = 5 (Unconditional jump / call)
-    // instruction_length = 6 (Conditional jump)
+    // x86 instruction_length = 5 (Unconditional jump / call)
+    // x86 instruction_length = 6 (Conditional jump)
+    // arm64 instruction length should always be 0 since relative jumps are relative to current pc
     #[inline]
-    fn relative_to_anchor(&self, anchor: usize, instruction_length: usize) -> i32 {
+    pub(crate) fn relative_to_anchor(&self, anchor: usize, instruction_length: usize) -> i32 {
         let instruction_end = unsafe { self.result.text_section.as_ptr().add(self.offset_in_text_section).add(instruction_length) };
         let destination = self.anchors[anchor];
-        debug_assert!(!destination.is_null());
+        debug_assert!(!destination.is_null(), "{:?}", anchor);
         (unsafe { destination.offset_from(instruction_end) } as i32) // Relative jump
     }
 
     #[inline]
-    fn relative_to_target_pc(&mut self, target_pc: usize, instruction_length: usize) -> i32 {
+    pub(crate) fn relative_to_target_pc(&mut self, target_pc: usize, instruction_length: usize, fixup_type: u8) -> i32 {
         let instruction_end = unsafe { self.result.text_section.as_ptr().add(self.offset_in_text_section).add(instruction_length) };
         let destination = if self.result.pc_section[target_pc] != 0 {
             // Backward jump
             self.result.pc_section[target_pc] as *const u8
         } else {
             // Forward jump, needs relocation
-            self.text_section_jumps.push(Jump { location: unsafe { instruction_end.sub(4) }, target_pc });
+            self.text_section_jumps.push(Jump { location: unsafe { instruction_end.sub(4) }, target_pc, fixup_type });
             return 0;
         };
         debug_assert!(!destination.is_null());
         (unsafe { destination.offset_from(instruction_end) } as i32) // Relative jump
     }
 
+    #[inline]
+    pub(crate) fn relative_to_target_pc_arm64(&mut self, target_pc: usize, fixup_type: u8) -> i32 {
+        let instruction_start = unsafe { self.result.text_section.as_ptr().add(self.offset_in_text_section) };
+        let destination = if self.result.pc_section[target_pc] != 0 {
+            // Backward jump
+            self.result.pc_section[target_pc] as *const u8
+        } else {
+            // Forward jump, needs relocation
+            self.text_section_jumps.push(Jump { location: instruction_start, target_pc, fixup_type });
+            return 0;
+        };
+        debug_assert!(!destination.is_null());
+        (unsafe { destination.offset_from(instruction_start) } as i32) // Relative jump
+    }
+
     fn resolve_jumps(&mut self) {
-        // Relocate forward jumps
-        for jump in &self.text_section_jumps {
-            let destination = self.result.pc_section[jump.target_pc] as *const u8;
-            let offset_value = 
-                unsafe { destination.offset_from(jump.location) } as i32 // Relative jump
-                - mem::size_of::<i32>() as i32; // Jump from end of instruction
-            unsafe { ptr::write_unaligned(jump.location as *mut i32, offset_value); }
-        }
         // There is no `VerifierError::JumpToMiddleOfLDDW` for `call imm` so patch it here
         let call_unsupported_instruction = self.anchors[ANCHOR_CALL_UNSUPPORTED_INSTRUCTION] as usize;
         let callx_unsupported_instruction = self.anchors[ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION] as usize;
+        // Fixups need to happen here, before result.pc_section is made non-relative
         for offset in self.result.pc_section.iter_mut() {
             if *offset == call_unsupported_instruction {
                 *offset = callx_unsupported_instruction;
@@ -1743,12 +582,13 @@ impl JitCompiler {
     }
 }
 
-#[cfg(all(test, target_arch = "x86_64", not(target_os = "windows")))]
+#[cfg(all(test, any(target_arch = "x86_64", target_arch = "aarch64"), not(target_os = "windows")))]
 mod tests {
     use super::*;
     use crate::{syscalls, vm::{SyscallRegistry, SyscallObject, TestInstructionMeter}, elf::register_bpf_function};
     use std::collections::BTreeMap;
     use byteorder::{LittleEndian, ByteOrder};
+    use crate::user_error::UserError;
 
     fn create_mockup_executable(program: &[u8]) -> Pin<Box<Executable::<UserError, TestInstructionMeter>>> {
         let config = Config {
@@ -1781,20 +621,20 @@ mod tests {
         )
         .unwrap()
     }
-    
+
     #[test]
     fn test_code_length_estimate() {
         const INSTRUCTION_COUNT: usize = 256;
         let mut prog = [0; ebpf::INSN_SIZE * INSTRUCTION_COUNT];
-    
+
         let empty_program_machine_code_length = {
             prog[0] = ebpf::EXIT;
             let mut executable = create_mockup_executable(&[]);
             Executable::<UserError, TestInstructionMeter>::jit_compile(&mut executable).unwrap();
             executable.get_compiled_program().unwrap().machine_code_length()
         };
-        assert!(empty_program_machine_code_length <= MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH);
-    
+        assert!(empty_program_machine_code_length <= JitCompilerNative::get_max_empty_machine_code_length());
+
         for opcode in 0..255 {
             for pc in 0..INSTRUCTION_COUNT {
                 prog[pc * ebpf::INSN_SIZE] = opcode;
@@ -1816,7 +656,7 @@ mod tests {
             let machine_code_length = executable.get_compiled_program().unwrap().machine_code_length() - empty_program_machine_code_length;
             let instruction_count = if opcode == 0x18 { INSTRUCTION_COUNT / 2 } else { INSTRUCTION_COUNT };
             let machine_code_length_per_instruction = (machine_code_length as f64 / instruction_count as f64 + 0.5) as usize;
-            assert!(machine_code_length_per_instruction <= MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION);
+            assert!(machine_code_length_per_instruction <= JitCompilerNative::get_max_machine_code_per_instruction());
         }
     }
 }

--- a/src/jit_arm64.rs
+++ b/src/jit_arm64.rs
@@ -1,0 +1,1414 @@
+// Derived from uBPF <https://github.com/iovisor/ubpf>
+// Copyright 2015 Big Switch Networks, Inc
+//      (uBPF: JIT algorithm, originally in C)
+// Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
+//      (Translation to Rust, MetaBuff addition)
+// Copyright 2020 Solana Maintainers <maintainers@solana.com>
+//
+// Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or
+// the MIT license <http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::deprecated_cfg_attr)]
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unreachable_code)]
+
+use std::{
+    mem,
+    pin::Pin, ptr,
+};
+
+use rand::{Rng};
+
+use crate::{
+    elf::Executable,
+    vm::{InstructionMeter, Tracer, SYSCALL_CONTEXT_OBJECTS_OFFSET},
+    ebpf::{self, INSN_SIZE, FIRST_SCRATCH_REG, SCRATCH_REGS, FRAME_PTR_REG, MM_STACK_START, STACK_PTR_REG, Insn},
+    error::{UserDefinedError, EbpfError},
+    memory_region::{AccessType, MemoryMapping, MemoryRegion},
+    user_error::UserError,
+    arm64::*,
+    jit::*
+};
+
+pub struct JitCompilerARM64 {
+    core: JitCompilerCore
+}
+
+impl JitCompilerImpl for JitCompilerARM64 {
+    fn get_max_empty_machine_code_length() -> usize {
+        8192
+    }
+    fn get_max_machine_code_per_instruction() -> usize {
+        153
+    }
+    fn get_core(&mut self) -> &mut JitCompilerCore {
+        &mut self.core
+    }
+    fn get_result(self) -> JitProgramSections {
+        self.core.result
+    }
+    fn new<E: UserDefinedError>(jit: JitCompilerCore) -> Result<Self, EbpfError<E>> {
+        Ok(Self {
+            core: jit
+        })
+    }
+    fn handle_insn<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore, mut insn: Insn, executable: &Pin<Box<Executable<E, I>>>, program: &[u8]) -> Result<(), EbpfError<E>> {
+        if jit.config.enable_instruction_tracing {
+            emit_load_immediate64(jit, ARM_SCRATCH[0], jit.pc as u64);
+            emit_call_anchor(jit, ANCHOR_TRACE);
+            emit_load_immediate64(jit, ARM_SCRATCH[0], 0);
+        }
+        let dst = if insn.dst == STACK_PTR_REG as u8 { u8::MAX } else { REGISTER_MAP[insn.dst as usize] };
+        let src = REGISTER_MAP[insn.src as usize];
+        let target_pc = (jit.pc as isize + insn.off as isize + 1) as usize;
+        match insn.opc {
+                _ if insn.dst == STACK_PTR_REG as u8 && jit.config.dynamic_stack_frames => {
+                    emit_load_env(jit, EnvironmentStackSlotARM64::BpfStackPtr, ARM_SCRATCH[0]);
+                    emit_load_immediate64(jit, ARM_SCRATCH[1], insn.imm as u64);
+                    match insn.opc {
+                        ebpf::SUB64_IMM => emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[1], ARM_SCRATCH[0])),
+                        ebpf::ADD64_IMM => emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[1], ARM_SCRATCH[0])),
+                        _ => {
+                            #[cfg(debug_assertions)]
+                            unreachable!("unexpected insn on r11")
+                        }
+                    }
+                    emit_store_env(jit, ARM_SCRATCH[0], EnvironmentStackSlotARM64::BpfStackPtr, ARM_SCRATCH[1]);
+                }
+
+                ebpf::LD_DW_IMM  => {
+                    Self::emit_validate_and_profile_instruction_count(jit, true, Some(jit.pc + 2));
+                    jit.pc += 1;
+                    jit.result.pc_section[jit.pc] = jit.anchors[ANCHOR_CALL_UNSUPPORTED_INSTRUCTION] as usize;
+                    ebpf::augment_lddw_unchecked(program, &mut insn);
+                    emit_load_immediate64(jit, dst, insn.imm as u64);
+                },
+
+                // BPF_LDX class
+                ebpf::LD_B_REG   => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(src, insn.off as u64, true), 1, AccessType::Load);
+                    emit_ins(jit, ARM64Instruction::load(OperandSize::S8, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0), dst));
+                },
+                ebpf::LD_H_REG   => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(src, insn.off as u64, true), 2, AccessType::Load);
+                    emit_ins(jit, ARM64Instruction::load(OperandSize::S16, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0), dst));
+                },
+                ebpf::LD_W_REG   => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(src, insn.off as u64, true), 4, AccessType::Load);
+                    emit_ins(jit, ARM64Instruction::load(OperandSize::S32, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0), dst));
+                },
+                ebpf::LD_DW_REG  => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(src, insn.off as u64, true), 8, AccessType::Load);
+                    emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0), dst));
+                },
+
+                // BPF_ST class
+                ebpf::ST_B_IMM   => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 1, AccessType::Store);
+                    emit_load_immediate64(jit, ARM_SCRATCH[1], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S8, ARM_SCRATCH[1], ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+                ebpf::ST_H_IMM   => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 2, AccessType::Store);
+                    emit_load_immediate64(jit, ARM_SCRATCH[1], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S16, ARM_SCRATCH[1], ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+                ebpf::ST_W_IMM   => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 4, AccessType::Store);
+                    emit_load_immediate64(jit, ARM_SCRATCH[1], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S32, ARM_SCRATCH[1], ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+                ebpf::ST_DW_IMM  => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 8, AccessType::Store);
+                    emit_load_immediate64(jit, ARM_SCRATCH[1], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[1], ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+
+                // BPF_STX class
+                ebpf::ST_B_REG  => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 1, AccessType::Store);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S8, src, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+                ebpf::ST_H_REG  => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 2, AccessType::Store);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S16, src, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+                ebpf::ST_W_REG  => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 4, AccessType::Store);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S32, src, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+                ebpf::ST_DW_REG  => {
+                    emit_address_translation(jit, ARM_SCRATCH[0], Value::RegisterPlusConstant64(dst, insn.off as u64, true), 8, AccessType::Store);
+                    emit_ins(jit, ARM64Instruction::store(OperandSize::S64, src, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0)));
+                },
+
+                // BPF_ALU class
+                ebpf::ADD32_IMM  => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::add(OperandSize::S32, dst, ARM_SCRATCH[0], dst));
+                    emit_ins(jit, ARM64Instruction::sign_extend_to_i64(OperandSize::S32, dst, dst));
+                },
+                ebpf::ADD32_REG  => {
+                    emit_ins(jit, ARM64Instruction::add(OperandSize::S32, dst, src, dst));
+                    emit_ins(jit, ARM64Instruction::sign_extend_to_i64(OperandSize::S32, dst, dst));
+                },
+                ebpf::SUB32_IMM  => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::sub(OperandSize::S32, dst, ARM_SCRATCH[0], dst));
+                    emit_ins(jit, ARM64Instruction::sign_extend_to_i64(OperandSize::S32, dst, dst));
+                },
+                ebpf::SUB32_REG  => {
+                    emit_ins(jit, ARM64Instruction::sub(OperandSize::S32, dst, src, dst));
+                    emit_ins(jit, ARM64Instruction::sign_extend_to_i64(OperandSize::S32, dst, dst));
+                },
+                ebpf::MUL32_IMM | ebpf::DIV32_IMM | ebpf::SDIV32_IMM | ebpf::MOD32_IMM  =>
+                    emit_muldivmod(jit, insn.opc, dst, dst, Some(insn.imm)),
+                ebpf::MUL32_REG | ebpf::DIV32_REG | ebpf::SDIV32_REG | ebpf::MOD32_REG  =>
+                    emit_muldivmod(jit, insn.opc, src, dst, None),
+                ebpf::OR32_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::orr(OperandSize::S32, ARM_SCRATCH[0], dst));
+                },
+                ebpf::OR32_REG   => {
+                    emit_ins(jit, ARM64Instruction::orr(OperandSize::S32, src, dst));
+                },
+                ebpf::AND32_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::and(OperandSize::S32, ARM_SCRATCH[0], dst, dst));
+                },
+                ebpf::AND32_REG   => {
+                    emit_ins(jit, ARM64Instruction::and(OperandSize::S32, src, dst, dst));
+                },
+                ebpf::LSH32_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::lsl_reg(OperandSize::S32, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::LSH32_REG   => {
+                    emit_ins(jit, ARM64Instruction::lsl_reg(OperandSize::S32, dst, src, dst));
+                },
+                ebpf::RSH32_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::lsr_reg(OperandSize::S32, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::RSH32_REG   => {
+                    emit_ins(jit, ARM64Instruction::lsr_reg(OperandSize::S32, dst, src, dst));
+                },
+                ebpf::NEG32      => emit_ins(jit, ARM64Instruction::sub(OperandSize::S32, SP_XZR, dst, dst)),
+                ebpf::XOR32_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::eor(OperandSize::S32, ARM_SCRATCH[0], dst));
+                },
+                ebpf::XOR32_REG   => {
+                    emit_ins(jit, ARM64Instruction::eor(OperandSize::S32, src, dst));
+                },
+                ebpf::MOV32_IMM  => { emit_load_immediate64(jit, dst, (insn.imm as u32) as u64); }
+                ebpf::MOV32_REG  => emit_ins(jit, ARM64Instruction::mov(OperandSize::S32, src, dst)),
+                ebpf::ARSH32_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::asr_reg(OperandSize::S32, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::ARSH32_REG   => {
+                    emit_ins(jit, ARM64Instruction::asr_reg(OperandSize::S32, dst, src, dst));
+                },
+                ebpf::LE         => {
+                    match insn.imm {
+                        16 => {
+                            emit_ins(jit, ARM64Instruction::zero_extend_to_u64(OperandSize::S16, dst, dst));
+                        },
+                        32 => {
+                            emit_ins(jit, ARM64Instruction::zero_extend_to_u64(OperandSize::S32, dst, dst));
+                        },
+                        64 => {}
+                        _ => {
+                            return Err(EbpfError::InvalidInstruction(jit.pc + ebpf::ELF_INSN_DUMP_OFFSET));
+                        }
+                    }
+                },
+                ebpf::BE         => {
+                    match insn.imm {
+                        16 => {
+                            emit_ins(jit, ARM64Instruction::rev(OperandSize::S16, dst, dst));
+                            emit_ins(jit, ARM64Instruction::zero_extend_to_u64(OperandSize::S16, dst, dst));
+                        },
+                        32 => emit_ins(jit, ARM64Instruction::rev(OperandSize::S32, dst, dst)),
+                        64 => emit_ins(jit, ARM64Instruction::rev(OperandSize::S64, dst, dst)),
+                        _ => {
+                            return Err(EbpfError::InvalidInstruction(jit.pc + ebpf::ELF_INSN_DUMP_OFFSET));
+                        }
+                    }
+                },
+
+                // BPF_ALU64 class
+                ebpf::ADD64_IMM  => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::add(OperandSize::S64, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::ADD64_REG  => {
+                    emit_ins(jit, ARM64Instruction::add(OperandSize::S64, dst, src, dst));
+                },
+                ebpf::SUB64_IMM  => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::SUB64_REG  => {
+                    emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, dst, src, dst));
+                },
+                ebpf::MUL64_IMM | ebpf::DIV64_IMM | ebpf::SDIV64_IMM | ebpf::MOD64_IMM  =>
+                    emit_muldivmod(jit, insn.opc, dst, dst, Some(insn.imm)),
+                ebpf::MUL64_REG | ebpf::DIV64_REG | ebpf::SDIV64_REG | ebpf::MOD64_REG  =>
+                    emit_muldivmod(jit, insn.opc, src, dst, None),
+                ebpf::OR64_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::orr(OperandSize::S64, ARM_SCRATCH[0], dst));
+                },
+                ebpf::OR64_REG   => {
+                    emit_ins(jit, ARM64Instruction::orr(OperandSize::S64, src, dst));
+                },
+                ebpf::AND64_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::and(OperandSize::S64, ARM_SCRATCH[0], dst, dst));
+                },
+                ebpf::AND64_REG   => {
+                    emit_ins(jit, ARM64Instruction::and(OperandSize::S64, src, dst, dst));
+                },
+                ebpf::LSH64_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::lsl_reg(OperandSize::S64, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::LSH64_REG   => {
+                    emit_ins(jit, ARM64Instruction::lsl_reg(OperandSize::S64, dst, src, dst));
+                },
+                ebpf::RSH64_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::lsr_reg(OperandSize::S64, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::RSH64_REG   => {
+                    emit_ins(jit, ARM64Instruction::lsr_reg(OperandSize::S64, dst, src, dst));
+                },
+                ebpf::NEG64      => emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, SP_XZR, dst, dst)),
+                ebpf::XOR64_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::eor(OperandSize::S64, ARM_SCRATCH[0], dst));
+                },
+                ebpf::XOR64_REG   => {
+                    emit_ins(jit, ARM64Instruction::eor(OperandSize::S64, src, dst));
+                },
+                ebpf::MOV64_IMM  => { emit_load_immediate64(jit, dst, insn.imm as u64); }
+                ebpf::MOV64_REG  => emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, src, dst)),
+                ebpf::ARSH64_IMM   => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_ins(jit, ARM64Instruction::asr_reg(OperandSize::S64, dst, ARM_SCRATCH[0], dst));
+                },
+                ebpf::ARSH64_REG   => {
+                    emit_ins(jit, ARM64Instruction::asr_reg(OperandSize::S64, dst, src, dst));
+                },
+
+                // BPF_JMP class
+                ebpf::JA         => {
+                    Self::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
+                    // emit_load_immediate64(jit, ARM_SCRATCH[0], target_pc as u64);
+                    emit_load_immediate64(jit, CUR_JIT_PC, target_pc as u64);
+                    let jmp_off = jit.relative_to_target_pc_arm64(target_pc, FixupType::JUMP as u8);
+                    emit_jmp(jit, jmp_off);
+                },
+                ebpf::JEQ_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::EQ, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JEQ_REG    => emit_conditional_branch_reg(jit, Condition::EQ, false, src, dst, target_pc),
+                ebpf::JGT_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::HI, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JGT_REG    => emit_conditional_branch_reg(jit, Condition::HI, false, src, dst, target_pc),
+                ebpf::JGE_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::HS, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JGE_REG    => emit_conditional_branch_reg(jit, Condition::HS, false, src, dst, target_pc),
+                ebpf::JLT_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::LO, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JLT_REG    => emit_conditional_branch_reg(jit, Condition::LO, false, src, dst, target_pc),
+                ebpf::JLE_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::LS, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JLE_REG    => emit_conditional_branch_reg(jit, Condition::LS, false, src, dst, target_pc),
+                ebpf::JSET_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::NE, true, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JSET_REG    => emit_conditional_branch_reg(jit, Condition::NE, true, src, dst, target_pc),
+                ebpf::JNE_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::NE, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JNE_REG    => emit_conditional_branch_reg(jit, Condition::NE, false, src, dst, target_pc),
+                ebpf::JSGT_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::GT, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JSGT_REG    => emit_conditional_branch_reg(jit, Condition::GT, false, src, dst, target_pc),
+                ebpf::JSGE_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::GE, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JSGE_REG    => emit_conditional_branch_reg(jit, Condition::GE, false, src, dst, target_pc),
+                ebpf::JSLT_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::LT, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JSLT_REG    => emit_conditional_branch_reg(jit, Condition::LT, false, src, dst, target_pc),
+                ebpf::JSLE_IMM    => {
+                    emit_load_immediate64(jit, ARM_SCRATCH[0], insn.imm as u64);
+                    emit_conditional_branch_reg(jit, Condition::LE, false, ARM_SCRATCH[0], dst, target_pc)
+                }
+                ebpf::JSLE_REG    => emit_conditional_branch_reg(jit, Condition::LE, false, src, dst, target_pc),
+                ebpf::CALL_IMM   => {
+                    // For JIT, syscalls MUST be registered at compile time. They can be
+                    // updated later, but not created after compiling (we need the address of the
+                    // syscall function in the JIT-compiled program).
+
+                    let mut resolved = false;
+                    let (syscalls, calls) = if jit.config.static_syscalls {
+                        (insn.src == 0, insn.src != 0)
+                    } else {
+                        (true, true)
+                    };
+
+                    if syscalls {
+                        if let Some(syscall) = executable.get_syscall_registry().lookup_syscall(insn.imm as u32) {
+                            if jit.config.enable_instruction_meter {
+                                Self::emit_validate_and_profile_instruction_count(jit, true, Some(0));
+                            }
+                            emit_load_immediate64(jit, ARM_SCRATCH[0], syscall.function as *const u8 as u64);
+
+                            emit_load_immediate64(jit, ARM_SCRATCH[1], (( SYSCALL_CONTEXT_OBJECTS_OFFSET + syscall.context_object_slot) as i32 * 8 + jit.program_argument_key ) as u64);
+                            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[1], false), ARM_SCRATCH[1]));
+
+                            emit_call_anchor(jit, ANCHOR_SYSCALL);
+                            if jit.config.enable_instruction_meter {
+                                emit_undo_profile_instruction_count(jit, 0);
+                            }
+                            // Throw error if the result indicates one
+                            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0), ARM_SCRATCH[0]));
+                            emit_ins(jit, ARM64Instruction::cmp_imm(OperandSize::S64, ARM_SCRATCH[0], 0));
+                            emit_load_immediate64(jit, ARM_SCRATCH[0], jit.pc as u64);
+                            emit_bcond(jit, Condition::NE, jit.relative_to_anchor(ANCHOR_RUST_EXCEPTION, 0));
+
+                            resolved = true;
+                        }
+                    }
+
+                    if calls {
+                        if let Some(target_pc) = executable.lookup_bpf_function(insn.imm as u32) {
+                            emit_bpf_call(jit, Value::Constant64(target_pc as u64, false));
+                            resolved = true;
+                        }
+                    }
+
+                    if !resolved {
+                        emit_load_immediate64(jit, CUR_JIT_PC, jit.pc as u64);
+                        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 0));
+                    }
+                },
+                ebpf::CALL_REG  => {
+                    emit_bpf_call(jit, Value::Register(REGISTER_MAP[insn.imm as usize]));
+                },
+                ebpf::EXIT      => {
+                    emit_load_env(jit, EnvironmentStackSlotARM64::CallDepth, REGISTER_MAP[FRAME_PTR_REG]);
+
+                    // If CallDepth == 0, we've reached the exit instruction of the entry point
+                    emit_ins(jit, ARM64Instruction::cmp_imm(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], 0));
+                    if jit.config.enable_instruction_meter {
+                        emit_load_immediate64(jit, CUR_JIT_PC, jit.pc as u64);
+                    }
+                    // we're done
+                    emit_bcond(jit, Condition::EQ, jit.relative_to_anchor(ANCHOR_EXIT, 0));
+
+                    // else decrement and update CallDepth
+                    emit_ins(jit, ARM64Instruction::sub_imm(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], 1, REGISTER_MAP[FRAME_PTR_REG]));
+                    emit_store_env(jit, REGISTER_MAP[FRAME_PTR_REG], EnvironmentStackSlotARM64::CallDepth, ARM_SCRATCH[0]);
+
+                    // and return
+                    Self::emit_validate_and_profile_instruction_count(jit, false, Some(0));
+                    emit_ins(jit, ARM64Instruction::ret());
+                },
+
+                _               => return Err(EbpfError::UnsupportedInstruction(jit.pc + ebpf::ELF_INSN_DUMP_OFFSET)),
+            }
+        Ok(())
+    }
+    fn generate_subroutines<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore) {
+        // Epilogue
+        jit.set_anchor(ANCHOR_EPILOGUE);
+
+        // Print stop watch value
+        fn stopwatch_result(numerator: u64, denominator: u64) {
+            println!("Stop watch: {} / {} = {}", numerator, denominator, if denominator == 0 { 0.0 } else { numerator as f64 / denominator as f64 });
+        }
+        if jit.stopwatch_is_active {
+            emit_rust_call(jit, Value::Constant64(stopwatch_result as *const u8 as u64, false), &[
+                Argument { index: 1, value: Value::EnvironmentStackSlotARM64(EnvironmentStackSlotARM64::StopwatchDenominator) },
+                Argument { index: 0, value: Value::EnvironmentStackSlotARM64(EnvironmentStackSlotARM64::StopwatchNumerator) },
+            ], None, false);
+        }
+
+        // Restore stack pointer in case the BPF stack was used
+        emit_load_immediate64(jit, ARM_SCRATCH[0], slot_on_environment_stack(jit, EnvironmentStackSlotARM64::LastSavedRegister) as u64);
+
+        emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], ENV_REG, ARM_SCRATCH[0]));
+        emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, ARM_SCRATCH[0], 0, SP_XZR)); // have to use add_imm to write to SP
+
+        // Restore registers
+        for (lowest_slot, reg) in CALLEE_SAVED_REGISTERS.iter().rev().enumerate() {
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(8 * lowest_slot as i16), *reg));
+        }
+        debug_assert!(CALLEE_SAVED_REGISTERS.len() % 2 == 0);
+        emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, CALLEE_SAVED_REGISTERS.len() as u16 * 8, SP_XZR));
+
+        emit_ins(jit, ARM64Instruction::ret());
+
+        // Routine for instruction tracing
+        if jit.config.enable_instruction_tracing {
+            jit.set_anchor(ANCHOR_TRACE);
+            //emit_ins(jit, ARM64Instruction::push64(ARM_SCRATCH[1]));
+            debug_assert!(REGISTER_MAP.len() % 2 == 1);
+            emit_ins(jit, ARM64Instruction::sub_imm(OperandSize::S64, SP_XZR, 8 * ( REGISTER_MAP.len() as u16 + 1 ), SP_XZR));
+            for (i, reg) in REGISTER_MAP.iter().enumerate() {
+                emit_ins(jit, ARM64Instruction::store(OperandSize::S64, *reg, SP_XZR, ARM64MemoryOperand::Offset((i * 8) as i16)));
+            }
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], SP_XZR, ARM64MemoryOperand::Offset(REGISTER_MAP.len() as i16 * 8)));
+            emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, 0, REGISTER_MAP[0])); // must use add_imm because mov uses XZR instead of SP
+            emit_ins(jit, ARM64Instruction::sub_imm(OperandSize::S64, SP_XZR, 8 * 4, SP_XZR));
+            emit_load_immediate64(jit, ARM_SCRATCH[1], (mem::size_of::<MemoryMapping>() as i32 + jit.program_argument_key) as u64);
+            emit_rust_call(jit, Value::Constant64(Tracer::trace as *const u8 as u64, false), &[
+                Argument { index: 1, value: Value::Register(REGISTER_MAP[0]) }, // registers
+                Argument { index: 0, value: Value::RegisterIndirect(JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[1], false), false) }, // jit.tracer
+            ], None, false);
+            // Pop stack and return
+            emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, 8 * 4, SP_XZR));
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(0), REGISTER_MAP[0]));
+            emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, (8 * (REGISTER_MAP.len() + 1)) as u16, SP_XZR)); // RSP += 8 * (REGISTER_MAP.len() + 1);
+
+            //emit_ins(jit, ARM64Instruction::pop64(ARM_SCRATCH[1]));
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(-8), ARM_SCRATCH[0]));
+            emit_ins(jit, ARM64Instruction::ret());
+        }
+
+        // Handler for EbpfError::ExceededMaxInstructions
+        jit.set_anchor(ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS);
+        emit_set_exception_kind::<E>(jit, EbpfError::ExceededMaxInstructions(0, 0));
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, BPF_PROGRAM_COUNTER, ARM_SCRATCH[0])); // R11 = instruction_meter;
+        emit_profile_instruction_count_finalize(jit, true);
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EPILOGUE, 0));
+
+        // Handler for exceptions which report their pc
+        jit.set_anchor(ANCHOR_EXCEPTION_AT);
+        // Validate that we did not reach the instruction meter limit before the exception occured
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, CUR_JIT_PC, ARM_SCRATCH[0]));
+        if jit.config.enable_instruction_meter {
+            Self::emit_validate_instruction_count(jit, false, None);
+        }
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, CUR_JIT_PC, ARM_SCRATCH[0]));
+        emit_profile_instruction_count_finalize(jit, true);
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EPILOGUE, 0));
+
+
+        // Handler for EbpfError::CallDepthExceeded
+        jit.set_anchor(ANCHOR_CALL_DEPTH_EXCEEDED);
+        emit_set_exception_kind::<E>(jit, EbpfError::CallDepthExceeded(0, 0));
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.config.max_call_depth as u64);
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[1], JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(24))); // depth = jit.config.max_call_depth;
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+
+        // Handler for EbpfError::CallOutsideTextSegment
+        jit.set_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT);
+        emit_set_exception_kind::<E>(jit, EbpfError::CallOutsideTextSegment(0, 0));
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[0], JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(24))); // target_address = RAX;
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+
+        // Handler for EbpfError::DivideByZero
+        jit.set_anchor(ANCHOR_DIV_BY_ZERO);
+        emit_set_exception_kind::<E>(jit, EbpfError::DivideByZero(0));
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+
+        // Handler for EbpfError::DivideOverflow
+        jit.set_anchor(ANCHOR_DIV_OVERFLOW);
+        emit_set_exception_kind::<E>(jit, EbpfError::DivideOverflow(0));
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+
+        // Handler for EbpfError::UnsupportedInstruction
+        jit.set_anchor(ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION);
+        // Load BPF target pc from stack (which was saved in ANCHOR_BPF_CALL_REG)
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(-24), CUR_JIT_PC)); // R11 = RSP[-16];
+        // Self::emit_jmp(jit, ANCHOR_CALL_UNSUPPORTED_INSTRUCTION); // Fall-through
+
+        // Handler for EbpfError::UnsupportedInstruction
+        jit.set_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION);
+        if jit.config.enable_instruction_tracing {
+            emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, CUR_JIT_PC, ARM_SCRATCH[0]));
+            emit_call_anchor(jit, ANCHOR_TRACE);
+        }
+        emit_set_exception_kind::<E>(jit, EbpfError::UnsupportedInstruction(0));
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+
+        // Quit gracefully
+        jit.set_anchor(ANCHOR_EXIT);
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, CUR_JIT_PC, ARM_SCRATCH[0]));
+        Self::emit_validate_instruction_count(jit, false, None);
+        emit_profile_instruction_count_finalize(jit, false);
+
+        emit_load_immediate64(jit, ARM_SCRATCH[0], slot_on_environment_stack(jit, EnvironmentStackSlotARM64::OptRetValPtr) as u64);
+
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ENV_REG, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[0], false), JIT_PROGRAM_ARGUMENT));
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[0], JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(8))); // result.return_value = R0;
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, SP_XZR, JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(0)));  // result.is_error = false;
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EPILOGUE, 0));
+
+
+        // Handler for syscall exceptions
+        jit.set_anchor(ANCHOR_RUST_EXCEPTION);
+        emit_profile_instruction_count_finalize(jit, false);
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EPILOGUE, 0));
+
+
+        // Routine for syscall
+        jit.set_anchor(ANCHOR_SYSCALL);
+        emit_ins(jit, ARM64Instruction::push64(ARM_SCRATCH[0])); // Padding for stack alignment
+        if jit.config.enable_instruction_meter {
+            // RDI = *PrevInsnMeter - RDI;
+            emit_load_env(jit, EnvironmentStackSlotARM64::PrevInsnMeter, ARM_SCRATCH[2]);
+            emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, ARM_SCRATCH[2], BPF_PROGRAM_COUNTER, BPF_PROGRAM_COUNTER));
+            emit_rust_call(jit, Value::Constant64(I::consume as *const u8 as u64, false), &[
+                Argument { index: 1, value: Value::Register(BPF_PROGRAM_COUNTER) },
+                Argument { index: 0, value: Value::EnvironmentStackSlotARM64(EnvironmentStackSlotARM64::InsnMeterPtr) },
+            ], None, false);
+        }
+        // emit_load_env(jit, EnvironmentStackSlotARM64::OptRetValPtr, XR);
+        emit_rust_call(jit, Value::Register(ARM_SCRATCH[0]), &[
+            Argument { index: 7, value: Value::EnvironmentStackSlotARM64(EnvironmentStackSlotARM64::OptRetValPtr) },
+            Argument { index: 6, value: Value::RegisterPlusConstant64(JIT_PROGRAM_ARGUMENT, jit.program_argument_key as u64, false) }, // jit_program_argument.memory_mapping
+            Argument { index: 5, value: Value::Register(ARGUMENT_REGISTERS[5]) },
+            Argument { index: 4, value: Value::Register(ARGUMENT_REGISTERS[4]) },
+            Argument { index: 3, value: Value::Register(ARGUMENT_REGISTERS[3]) },
+            Argument { index: 2, value: Value::Register(ARGUMENT_REGISTERS[2]) },
+            Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[1]) },
+            Argument { index: 0, value: Value::Register(ARM_SCRATCH[1]) }, // "&mut jit" in the "call" method of the SyscallObject
+        ], None, false);
+        if jit.config.enable_instruction_meter {
+            emit_rust_call(jit, Value::Constant64(I::get_remaining as *const u8 as u64, false), &[
+                Argument { index: 0, value: Value::EnvironmentStackSlotARM64(EnvironmentStackSlotARM64::InsnMeterPtr) },
+            ], Some(BPF_PROGRAM_COUNTER), false);
+            emit_store_env(jit, BPF_PROGRAM_COUNTER, EnvironmentStackSlotARM64::PrevInsnMeter, ARM_SCRATCH[0]);
+        }
+        emit_ins(jit, ARM64Instruction::pop64(ARM_SCRATCH[0]));
+        // Store Ok value in result register
+        emit_load_env(jit, EnvironmentStackSlotARM64::OptRetValPtr, ARM_SCRATCH[0]);
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(8), REGISTER_MAP[0]));
+        emit_ins(jit, ARM64Instruction::ret());
+        // Routine for prologue of emit_bpf_call()
+        // ARM_SCRATCH[0] holds current BPF pc
+        jit.set_anchor(ANCHOR_BPF_CALL_PROLOGUE);
+        emit_ins(jit, ARM64Instruction::sub_imm(OperandSize::S64, SP_XZR, 8 * (SCRATCH_REGS + 2) as u16, SP_XZR)); // alloca
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, LR, SP_XZR, ARM64MemoryOperand::Offset(0)));
+        //emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], SP_XZR, ARM64MemoryOperand::Offset(0)));
+        //emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(8 * (SCRATCH_REGS + 1) as i16), ARM_SCRATCH[0])); // load return address
+        // The original x86 implementation trashes the old return address location (lol), and then
+        // moves rsp accordingly.
+        for (i, reg) in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).enumerate() {
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, *reg, SP_XZR, ARM64MemoryOperand::Offset(8 * (SCRATCH_REGS - i + 1) as i16))); // Push SCRATCH_REG
+        }
+        // Push the caller's frame pointer. The code to restore it is emitted at the end of emit_bpf_call().
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], SP_XZR, ARM64MemoryOperand::Offset(8)));
+        //X86Instruction::xchg(OperandSize::S64, ARM_SCRATCH[0], RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))).emit(jit); // Push return address and restore original ARM_SCRATCH[0]
+
+        // Increase CallDepth
+        emit_load_env(jit, EnvironmentStackSlotARM64::CallDepth, ARM_SCRATCH[0]);
+        emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, ARM_SCRATCH[0], 1, ARM_SCRATCH[0]));
+        emit_store_env(jit, ARM_SCRATCH[0], EnvironmentStackSlotARM64::CallDepth, ARM_SCRATCH[1]);
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.config.max_call_depth as u64);
+        emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[1], ARM_SCRATCH[0]));
+        // If CallDepth >= jit.config.max_call_depth, stop and return CallDepthExceeded
+        emit_bcond(jit, Condition::HS, jit.relative_to_anchor(ANCHOR_CALL_DEPTH_EXCEEDED, 0));
+
+        // Setup the frame pointer for the new frame. What we do depends on whether we're using dynamic or fixed frames.
+        if jit.config.dynamic_stack_frames {
+            // When dynamic frames are on, the next frame starts at the end of the current frame
+            emit_load_env(jit, EnvironmentStackSlotARM64::BpfStackPtr, REGISTER_MAP[FRAME_PTR_REG]);
+            emit_store_env(jit, REGISTER_MAP[FRAME_PTR_REG], EnvironmentStackSlotARM64::BpfFramePtr, ARM_SCRATCH[0]);
+        } else {
+            // With fixed frames we start the new frame at the next fixed offset
+            let stack_frame_size = jit.config.stack_frame_size as i64 * if jit.config.enable_stack_frame_gaps { 2 } else { 1 };
+            emit_load_env(jit, EnvironmentStackSlotARM64::BpfFramePtr, REGISTER_MAP[FRAME_PTR_REG]);
+            emit_load_immediate64(jit, ARM_SCRATCH[1], stack_frame_size as u64);
+            emit_ins(jit, ARM64Instruction::add(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], ARM_SCRATCH[1], REGISTER_MAP[FRAME_PTR_REG]));
+            emit_store_env(jit, REGISTER_MAP[FRAME_PTR_REG], EnvironmentStackSlotARM64::BpfFramePtr, ARM_SCRATCH[0]);
+        }
+        emit_ins(jit, ARM64Instruction::ret());
+
+        // Routine for emit_bpf_call(Value::Register())
+        // REGISTER_MAP[0] holds target BPF pc
+        jit.set_anchor(ANCHOR_BPF_CALL_REG);
+        // Force alignment of RAX
+        emit_load_immediate64(jit, ARM_SCRATCH[0], !(INSN_SIZE as i64 -1) as u64);
+        emit_ins(jit, ARM64Instruction::and(OperandSize::S64, REGISTER_MAP[0], ARM_SCRATCH[0], REGISTER_MAP[0])); // RAX &= !(INSN_SIZE - 1);
+        // Upper bound check
+        // if(RAX >= jit.program_vm_addr + number_of_instructions * INSN_SIZE) throw CALL_OUTSIDE_TEXT_SEGMENT;
+        let number_of_instructions = jit.result.pc_section.len() - 1;
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.program_vm_addr as u64 + (number_of_instructions * INSN_SIZE) as u64);
+        emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[1], REGISTER_MAP[0]));
+        emit_bcond(jit, Condition::HS, jit.relative_to_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT, 0));
+        // Lower bound check
+        // if(RAX < jit.program_vm_addr) throw CALL_OUTSIDE_TEXT_SEGMENT;
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.program_vm_addr as u64);
+        emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[1], REGISTER_MAP[0]));
+        emit_bcond(jit, Condition::LO, jit.relative_to_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT, 0));
+        // Calculate offset relative to instruction_addresses
+        emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, REGISTER_MAP[0], ARM_SCRATCH[1], REGISTER_MAP[0]));
+        // Calculate the target_pc (dst / INSN_SIZE) to update the instruction_meter
+        let shift_amount = INSN_SIZE.trailing_zeros();
+        debug_assert_eq!(INSN_SIZE, 1 << shift_amount);
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, REGISTER_MAP[0], ARM_SCRATCH[0]));
+        emit_ins(jit, ARM64Instruction::lsr_imm(ARM_SCRATCH[0], shift_amount as u8, ARM_SCRATCH[0]));
+        // Save BPF target pc for potential ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], SP_XZR, ARM64MemoryOperand::Offset(-8))); // RSP[-8] = ARM_SCRATCH[0];
+        // Load host target_address from jit.result.pc_section
+        debug_assert_eq!(INSN_SIZE, 8); // Because the instruction size is also the slot size we do not need to shift the offset
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.result.pc_section.as_ptr() as u64);
+        emit_ins(jit, ARM64Instruction::add(OperandSize::S64, REGISTER_MAP[0], ARM_SCRATCH[1], REGISTER_MAP[0]));
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, REGISTER_MAP[0], ARM64MemoryOperand::Offset(0), REGISTER_MAP[0])); // RAX = jit.result.pc_section[RAX / 8];
+        emit_ins(jit, ARM64Instruction::ret());
+
+        // Translates a host pc back to a BPF pc by linear search of the pc_section table
+        jit.set_anchor(ANCHOR_TRANSLATE_PC);
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.result.pc_section.as_ptr() as u64 - 8); // Loop index and pointer to look up
+        jit.set_anchor(ANCHOR_TRANSLATE_PC_LOOP); // Loop label
+        emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, ARM_SCRATCH[1], 8, ARM_SCRATCH[1])); // Increase index
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[1], ARM64MemoryOperand::Offset(8), ARM_SCRATCH[2]));
+        emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[2])); // Look up and compare against value at next index
+        emit_bcond(jit, Condition::LS, jit.relative_to_anchor(ANCHOR_TRANSLATE_PC_LOOP, 0)); // Continue while *ARM_SCRATCH[1] <= ARM_SCRATCH[0]
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, ARM_SCRATCH[1], CUR_JIT_PC)); // CUR_JIT_PC = ARM_SCRATCH[1];
+        emit_load_immediate64(jit, ARM_SCRATCH[1], jit.result.pc_section.as_ptr() as u64); // ARM_SCRATCH[1] = jit.result.pc_section
+        emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, CUR_JIT_PC, ARM_SCRATCH[1], CUR_JIT_PC));
+        emit_ins(jit, ARM64Instruction::lsr_imm(CUR_JIT_PC, 3, CUR_JIT_PC)); // CUR_JIT_PC >>= 3; divide by 8 to get the instruction index
+        emit_ins(jit, ARM64Instruction::ret());
+
+        // Translates a vm memory address to a host memory address
+        for (access_type, len) in &[
+            (AccessType::Load, 1i32),
+            (AccessType::Load, 2i32),
+            (AccessType::Load, 4i32),
+            (AccessType::Load, 8i32),
+            (AccessType::Store, 1i32),
+            (AccessType::Store, 2i32),
+            (AccessType::Store, 4i32),
+            (AccessType::Store, 8i32),
+        ] {
+            let target_offset = len.trailing_zeros() as usize + 4 * (*access_type as usize);
+            let stack_offset = if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                16
+            } else {
+                0
+            };
+
+            jit.set_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset);
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(stack_offset), ARM_SCRATCH[0]));
+
+            // This is relying on the return value optimization
+            emit_load_env(jit, EnvironmentStackSlotARM64::OptRetValPtr, XR);
+            emit_rust_call(jit, Value::Constant64(MemoryMapping::generate_access_violation::<UserError> as *const u8 as u64, false), &[
+                Argument { index: 2, value: Value::Register(ARM_SCRATCH[0]) }, // Specify first as the src register could be overwritten by other arguments
+                Argument { index: 3, value: Value::Constant64(*len as u64, false) },
+                Argument { index: 1, value: Value::Constant64(*access_type as u64, false) },
+                Argument { index: 0, value: Value::RegisterPlusConstant64(JIT_PROGRAM_ARGUMENT, jit.program_argument_key as u64, false) }, // jit_program_argument.memory_mapping
+            ], None, true);
+            emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, stack_offset as u16 + 16, SP_XZR));
+            emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, LR, ARM_SCRATCH[0])); // Put callers PC in ARM_SCRATCH[0]
+            emit_call_anchor(jit, ANCHOR_TRANSLATE_PC);
+            emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+
+
+
+            jit.set_anchor(ANCHOR_TRANSLATE_MEMORY_ADDRESS + target_offset);
+            emit_ins(jit, ARM64Instruction::push64(ARM_SCRATCH[0]));
+            if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                emit_ins(jit, ARM64Instruction::push64(ARM_SCRATCH[1]));
+            }
+            emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[1])); // ARM_SCRATCH[1] = vm_addr;
+            emit_ins(jit, ARM64Instruction::lsr_imm(ARM_SCRATCH[1], ebpf::VIRTUAL_ADDRESS_BITS as u8, ARM_SCRATCH[1]));// ARM_SCRATCH[1] >>= ebpf::VIRTUAL_ADDRESS_BITS;
+
+            emit_load_immediate64(jit, ARM_SCRATCH[2], (jit.program_argument_key + 8) as u64);
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[2], false), ARM_SCRATCH[2]));
+            emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[1], ARM_SCRATCH[2])); // region_index >= jit_program_argument.memory_mapping.regions.len()
+            emit_bcond(jit, Condition::LS, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 0));
+            debug_assert_eq!(1 << 5, mem::size_of::<MemoryRegion>());
+            emit_ins(jit, ARM64Instruction::lsl_imm(ARM_SCRATCH[1], 5, ARM_SCRATCH[1]));// ARM_SCRATCH[1] *= mem::size_of::<MemoryRegion>();
+
+            emit_load_immediate64(jit, ARM_SCRATCH[2], (jit.program_argument_key) as u64);
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[2], false), ARM_SCRATCH[2]));
+            emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[1], ARM_SCRATCH[2], ARM_SCRATCH[1]));
+            if *access_type == AccessType::Store {
+                emit_ins(jit, ARM64Instruction::load(OperandSize::S8, ARM_SCRATCH[1], ARM64MemoryOperand::Offset(MemoryRegion::IS_WRITABLE_OFFSET as i16), ARM_SCRATCH[2]));
+                emit_ins(jit, ARM64Instruction::cmp(OperandSize::S8, ARM_SCRATCH[2], SP_XZR));
+                emit_bcond(jit, Condition::EQ, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 0));
+            }
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[1], ARM64MemoryOperand::Offset(MemoryRegion::VM_ADDR_OFFSET as i16), ARM_SCRATCH[2])); // ARM_SCRATCH[2] = region.vm_addr
+            emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[2], ARM_SCRATCH[0])); // vm_addr < region.vm_addr
+            emit_bcond(jit, Condition::LO, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 0));
+            emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[2], ARM_SCRATCH[0]));
+            if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                emit_ins(jit, ARM64Instruction::load(OperandSize::S8, ARM_SCRATCH[1], ARM64MemoryOperand::Offset(MemoryRegion::VM_GAP_SHIFT_OFFSET as i16), ARM_SCRATCH[2])); // ARM_SCRATCH[2] = region.vm_gap_shift;
+                emit_ins(jit, ARM64Instruction::lsr_reg(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[2], ARM_SCRATCH[3])); // ARM_SCRATCH[3] = ARM_SCRATCH[0] >> region.vm_gap_shift;
+                emit_ins(jit, ARM64Instruction::tst_imm(ARM_SCRATCH[3], ARM64BitwiseImm::ONE)); // (ARM_SCRATCH[3] & 1) != 0
+                emit_bcond(jit, Condition::NE, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 0));
+                emit_ins(jit, ARM64Instruction::movn(ARM_SCRATCH[3], 0, 0)); // ARM_SCRATCH[3] = -1;
+
+                emit_ins(jit, ARM64Instruction::lsl_reg(OperandSize::S64, ARM_SCRATCH[3], ARM_SCRATCH[2], ARM_SCRATCH[3])); // gap_mask = -1 << region.vm_gap_shift;
+
+                emit_ins(jit, ARM64Instruction::mvn(OperandSize::S64, ARM_SCRATCH[3], ARM_SCRATCH[2])); // inverse_gap_mask = !gap_mask;
+                emit_ins(jit, ARM64Instruction::and(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[2], ARM_SCRATCH[2])); // below_gap = ARM_SCRATCH[0] & inverse_gap
+                emit_ins(jit, ARM64Instruction::and(OperandSize::S64, ARM_SCRATCH[3], ARM_SCRATCH[0], ARM_SCRATCH[0])); // above_gap = ARM_SCRATCH[0] & gap_mask;
+                emit_ins(jit, ARM64Instruction::lsr_imm(ARM_SCRATCH[0], 1, ARM_SCRATCH[0]));
+                emit_ins(jit, ARM64Instruction::orr(OperandSize::S64, ARM_SCRATCH[2], ARM_SCRATCH[0])); // gapped_offset = above_gap | below_gap;
+            }
+            emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, ARM_SCRATCH[0], *len as u16, ARM_SCRATCH[2]));
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[1], ARM64MemoryOperand::Offset(MemoryRegion::LEN_OFFSET as i16), ARM_SCRATCH[3]));
+            emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[2], ARM_SCRATCH[3])); // region.len < ARM_SCRATCH[0] + len
+            emit_bcond(jit, Condition::LO, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 0));
+            emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[1], ARM64MemoryOperand::Offset(MemoryRegion::HOST_ADDR_OFFSET as i16), ARM_SCRATCH[3]));
+
+            emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[3], ARM_SCRATCH[0]));
+            emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, 16 + stack_offset as u16, SP_XZR));
+            emit_ins(jit, ARM64Instruction::ret());
+        }
+    }
+
+    fn generate_prologue<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore, executable: &Pin<Box<Executable<E, I>>>) {
+        debug_assert!(EnvironmentStackSlotARM64::SlotCount as u16 % 2 == 0);
+        emit_ins(jit, ARM64Instruction::sub_imm(OperandSize::S64, SP_XZR, 8 * EnvironmentStackSlotARM64::SlotCount as u16, SP_XZR));
+        let mut last_slot = EnvironmentStackSlotARM64::SlotCount as i16 - 1;
+
+        debug_assert!(CALLEE_SAVED_REGISTERS.len() == EnvironmentStackSlotARM64::LastSavedRegister as usize + 1);
+        // Save registers
+        for reg in CALLEE_SAVED_REGISTERS.iter() {
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, *reg, SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+            last_slot -= 1;
+        }
+
+        // Initialize CallDepth to 0
+        emit_load_immediate64(jit, REGISTER_MAP[FRAME_PTR_REG], 0);
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+        last_slot -= 1;
+
+        // Initialize the BPF frame and stack pointers (BpfFramePtr and BpfStackPtr)
+        if jit.config.dynamic_stack_frames {
+            // The stack is fully descending from MM_STACK_START + stack_size to MM_STACK_START
+            emit_load_immediate64(jit, REGISTER_MAP[FRAME_PTR_REG], MM_STACK_START as u64 + jit.config.stack_size() as u64);
+            // Push BpfFramePtr
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+            last_slot -= 1;
+            // Push BpfStackPtr
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+            last_slot -= 1;
+        } else {
+            // The frames are ascending from MM_STACK_START to MM_STACK_START + stack_size. The stack within the frames is descending.
+            emit_load_immediate64(jit, REGISTER_MAP[FRAME_PTR_REG], MM_STACK_START as u64 + jit.config.stack_frame_size as u64);
+            // Push BpfFramePtr
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+            last_slot -= 1;
+            // When using static frames BpfStackPtr is not used
+            emit_load_immediate64(jit, ENV_REG, 0);
+            emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ENV_REG, SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+            last_slot -= 1;
+        }
+
+        // Save pointer to optional typed return value
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARGUMENT_REGISTERS[0], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+        last_slot -= 1;
+
+        // Save initial value of instruction_meter.get_remaining()
+        emit_rust_call(jit, Value::Constant64(I::get_remaining as *const u8 as u64, false), &[
+            Argument { index: 0, value: Value::Register(ARGUMENT_REGISTERS[3]) },
+        ], Some(ARGUMENT_REGISTERS[0]), false);
+
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARGUMENT_REGISTERS[0], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+        last_slot -= 1;
+
+        // Save instruction meter
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARGUMENT_REGISTERS[3], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+        last_slot -= 1;
+
+        // Initialize stop watch
+        emit_ins(jit, ARM64Instruction::eor(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[0]));
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+        last_slot -= 1;
+
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], SP_XZR, ARM64MemoryOperand::Offset(8 * last_slot)));
+        debug_assert!(last_slot == 0);
+
+        // Initialize frame pointer
+        // NOTE: ORR is the default used for MOV. ORR uses XZR. Here we use ADD (imm) instead, which uses
+        // SP
+        emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, 0, ENV_REG));
+        emit_load_immediate64(jit, ARM_SCRATCH[0], (8 * (EnvironmentStackSlotARM64::SlotCount as i64 - 1 + jit.environment_stack_key as i64)) as u64);
+        emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ENV_REG, ARM_SCRATCH[0], ENV_REG)); // ENV_REG += ARM_SCRATCH[0]
+
+        // Save JitProgramArgument
+        emit_load_immediate64(jit, ARM_SCRATCH[0], (-jit.program_argument_key) as u64);
+        emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], ARGUMENT_REGISTERS[2], JIT_PROGRAM_ARGUMENT));
+
+        // Zero BPF registers
+        for reg in REGISTER_MAP.iter() {
+            if *reg != REGISTER_MAP[1] && *reg != REGISTER_MAP[FRAME_PTR_REG] {
+                emit_load_immediate64(jit, *reg, 0);
+            }
+        }
+
+        // Jump to entry point
+        let entry = executable.get_entrypoint_instruction_offset().unwrap_or(0);
+        if jit.config.enable_instruction_meter {
+            Self::emit_profile_instruction_count(jit, Some(entry + 1));
+        }
+        emit_load_immediate64(jit, ARM_SCRATCH[0], entry as u64);
+        let jump_offset = jit.relative_to_target_pc_arm64(entry, FixupType::JUMP as u8);
+        emit_jmp(jit, jump_offset);
+    }
+
+    #[inline]
+    fn emit_validate_instruction_count(jit: &mut JitCompilerCore, exclusive: bool, pc: Option<usize>) {
+        if let Some(pc) = pc {
+            jit.last_instruction_meter_validation_pc = pc;
+            emit_load_immediate64(jit, ARM_SCRATCH[1], pc as u64 + 1);
+            emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[1], BPF_PROGRAM_COUNTER));
+        } else {
+            emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[0], BPF_PROGRAM_COUNTER));
+        }
+        emit_bcond(jit, if exclusive { Condition::LO } else { Condition::LS }, jit.relative_to_anchor(ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS, 0));
+    }
+
+    #[inline]
+    fn emit_profile_instruction_count(jit: &mut JitCompilerCore, target_pc: Option<usize>) {
+        match target_pc {
+            Some(target_pc) => {
+                emit_load_immediate64(jit, ARM_SCRATCH[0], (target_pc as i64 - jit.pc as i64 - 1) as u64);
+                emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], BPF_PROGRAM_COUNTER, BPF_PROGRAM_COUNTER));
+            },
+            None => {
+                emit_load_immediate64(jit, ARM_SCRATCH[1], jit.pc as u64 + 1);
+                emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, BPF_PROGRAM_COUNTER, ARM_SCRATCH[1], BPF_PROGRAM_COUNTER)); // instruction_meter -= jit.pc + 1;
+
+                emit_ins(jit, ARM64Instruction::add(OperandSize::S64, BPF_PROGRAM_COUNTER, ARM_SCRATCH[0], BPF_PROGRAM_COUNTER)); // instruction_meter += target_pc;
+            },
+        }
+    }
+    #[inline]
+    fn emit_overrun<E: UserDefinedError>(jit: &mut JitCompilerCore) {
+        emit_set_exception_kind::<E>(jit, EbpfError::ExecutionOverrun(0));
+        emit_load_immediate64(jit, CUR_JIT_PC, jit.pc as u64);
+        emit_jmp(jit, jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 0));
+    }
+
+    fn fixup_text_jumps(jit: &mut JitCompilerCore) {
+        for jump in &jit.text_section_jumps {
+            let destination = jit.result.pc_section[jump.target_pc] as *const u8;
+            let offset_value =
+                ( unsafe { destination.offset_from(jump.location) } as i32 ) / 4; // Relative jump
+            let mut inst = unsafe { ptr::read_unaligned(jump.location as *const u32) };
+            match jump.fixup_type {
+                x if x == FixupType::IMM26 as u8 => {
+                    assert!((-(1 << 25)..(1 << 25)).contains(&offset_value));
+                    // b or bl with an imm26
+                    inst |= (offset_value as u32) & ((1u32 << 26) - 1);
+                },
+                x if x == FixupType::IMM19 as u8 => {
+                    assert!((-(1 << 18)..(1 << 18)).contains(&offset_value));
+                    // b.cond with a imm19
+                    inst |= ((offset_value as u32) & ((1u32 << 19) - 1)) << 5;
+                },
+                _ => unreachable!()
+            }
+            unsafe {
+                ptr::write_unaligned(
+                    jump.location as *mut u32,
+                    inst,
+                );
+            }
+        }
+    }
+
+
+}
+
+const REGISTER_MAP: [u8; 11] = [
+    CALLER_SAVED_REGISTERS[0],
+    ARGUMENT_REGISTERS[1],
+    ARGUMENT_REGISTERS[2],
+    ARGUMENT_REGISTERS[3],
+    ARGUMENT_REGISTERS[4],
+    ARGUMENT_REGISTERS[5],
+    ARGUMENT_REGISTERS[6],
+    ARGUMENT_REGISTERS[7],
+    CALLEE_SAVED_REGISTERS[4],
+    CALLEE_SAVED_REGISTERS[5],
+    CALLEE_SAVED_REGISTERS[1],
+];
+
+const ARM_SCRATCH: [u8; 4] = [
+    CALLER_SAVED_REGISTERS[1],
+    CALLER_SAVED_REGISTERS[2],
+    CALLER_SAVED_REGISTERS[3],
+    CALLER_SAVED_REGISTERS[4]
+];
+
+// Special registers:
+//   X0  BPF program counter limit (used by instruction meter)
+//   X10, X11, X12 Scratch register
+//   X13 Constant pointer to JitProgramArgument (also scratch register for exception handling)
+//   X19 Constant pointer to inital RSP - 8
+const ENV_REG: u8 = CALLEE_SAVED_REGISTERS[0];
+const JIT_PROGRAM_ARGUMENT: u8 = CALLER_SAVED_REGISTERS[5];
+const BPF_PROGRAM_COUNTER: u8 = ARGUMENT_REGISTERS[0];
+const CUR_JIT_PC: u8 = CALLER_SAVED_REGISTERS[6];
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+enum FixupType {
+    IMM26 = 1, // for B, BL
+    IMM19 = 2 // for B.cond
+}
+impl FixupType {
+    pub const CALL: FixupType = FixupType::IMM26;
+    pub const JUMP: FixupType = FixupType::IMM26;
+    pub const COND_JUMP: FixupType = FixupType::IMM19;
+}
+
+struct Argument {
+    index: usize,
+    value: Value,
+}
+
+enum Value {
+    Register(u8),
+    RegisterIndirect(u8, ARM64MemoryOperand, bool),
+    EnvironmentStackSlotARM64(EnvironmentStackSlotARM64),
+    RegisterPlusConstant64(u8, u64, bool),
+    Constant64(u64, bool),
+}
+
+impl Argument {
+    fn is_stack_argument(&self) -> bool {
+        debug_assert!(self.index < ARGUMENT_REGISTERS.len());
+        self.index >= ARGUMENT_REGISTERS.len()
+    }
+
+    fn get_argument_register(&self) -> u8 {
+        ARGUMENT_REGISTERS[self.index]
+    }
+
+    fn emit_pass(&self, jit: &mut JitCompilerCore) {
+        let is_stack_argument = self.is_stack_argument();
+        let dst = if is_stack_argument {
+            ARM_SCRATCH[0]
+        } else {
+            self.get_argument_register()
+        };
+        match self.value {
+            Value::Register(reg) => {
+                if is_stack_argument {
+                    emit_ins(jit, ARM64Instruction::push64(reg));
+                } else if reg != dst {
+                    emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, reg, dst));
+                }
+            },
+            Value::RegisterIndirect(reg, mem_op, user_provided) => {
+                debug_assert!(!user_provided);
+                emit_ins(jit, ARM64Instruction::load(OperandSize::S64, reg, mem_op, dst));
+                if is_stack_argument {
+                    emit_ins(jit, ARM64Instruction::push64(dst));
+                }
+            },
+            Value::EnvironmentStackSlotARM64(slot) => {
+                emit_load_immediate64(jit, ARM_SCRATCH[0], slot_on_environment_stack(jit, slot) as u64);
+                emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ENV_REG, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[0], false), dst));
+                if is_stack_argument {
+                    emit_ins(jit, ARM64Instruction::push64(dst));
+                }
+            },
+            Value::RegisterPlusConstant64(reg, offset, user_provided) => {
+                debug_assert!(!user_provided);
+                emit_load_immediate64(jit, dst, offset);
+                emit_ins(jit, ARM64Instruction::add(OperandSize::S64, dst, reg, dst));
+                if is_stack_argument {
+                    emit_ins(jit, ARM64Instruction::push64(dst));
+                }
+            },
+            Value::Constant64(value, user_provided) => {
+                debug_assert!(!user_provided && !is_stack_argument);
+                emit_load_immediate64(jit, dst, value);
+            },
+        }
+    }
+}
+
+#[inline]
+fn emit_bpf_call(jit: &mut JitCompilerCore, dst: Value) {
+    // Store PC in case the bounds check fails
+    emit_load_immediate64(jit, CUR_JIT_PC, jit.pc as u64);
+    emit_ins(jit, ARM64Instruction::push64(LR));
+    emit_call_nosavelr(jit, jit.relative_to_anchor(ANCHOR_BPF_CALL_PROLOGUE, 0));
+    emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(8 * ( SCRATCH_REGS+2 ) as i16), LR));
+
+    match dst {
+        Value::Register(reg) => {
+            // Move vm target_address into RAX
+            emit_ins(jit, ARM64Instruction::push64(REGISTER_MAP[0]));
+            if reg != REGISTER_MAP[0] {
+                emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, reg, REGISTER_MAP[0]));
+            }
+            emit_call_anchor(jit, ANCHOR_BPF_CALL_REG);
+
+            JitCompilerARM64::emit_validate_and_profile_instruction_count(jit, false, None);
+            emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, REGISTER_MAP[0], ARM_SCRATCH[0])); // Save jump target vaddar
+            emit_ins(jit, ARM64Instruction::pop64(REGISTER_MAP[0])); // Restore RAX
+            emit_ins(jit, ARM64Instruction::push64(LR));
+            emit_ins(jit, ARM64Instruction::blr(ARM_SCRATCH[0])); // the actual call
+            emit_ins(jit, ARM64Instruction::pop64(LR));
+        },
+        Value::Constant64(target_pc, user_provided) => {
+            debug_assert!(!user_provided);
+            JitCompilerARM64::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc as usize));
+            emit_load_immediate64(jit, CUR_JIT_PC, target_pc as u64);
+            emit_call_targetpc(jit, target_pc as usize);
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        }
+    }
+
+    emit_undo_profile_instruction_count(jit, 0);
+
+    // Restore the previous frame pointer
+    emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(8), REGISTER_MAP[FRAME_PTR_REG]));
+    emit_store_env(jit, REGISTER_MAP[FRAME_PTR_REG], EnvironmentStackSlotARM64::BpfFramePtr, ARM_SCRATCH[0]);
+    for (i, reg) in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).rev().enumerate() {
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, SP_XZR, ARM64MemoryOperand::Offset(16 + (i as i16 * 8)), *reg));
+    }
+    emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, 8 * (SCRATCH_REGS as u16 + 2) + 16, SP_XZR)); // consume everything that was pushed in the prologue, and consume the saved LR slot
+}
+
+
+#[inline]
+fn emit_load_immediate64(jit: &mut JitCompilerCore, reg: u8, mut imm: u64) {
+    emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, SP_XZR, reg));
+
+    let mut shift: u8 = 0;
+    while imm != 0 {
+        emit_ins(jit, ARM64Instruction::movk(reg, shift, imm as u16));
+        imm >>= 16;
+        shift += 1;
+    }
+}
+
+#[inline]
+fn emit_rust_call(jit: &mut JitCompilerCore, dst: Value, arguments: &[Argument], result_reg: Option<u8>, check_exception: bool) {
+    let mut saved_registers = CALLER_SAVED_REGISTERS.to_vec();
+    saved_registers.extend(ARGUMENT_REGISTERS);
+    if let Some(reg) = result_reg {
+        let dst = saved_registers.iter().position(|x| *x == reg);
+        debug_assert!(dst.is_some());
+        if let Some(dst) = dst {
+            saved_registers.remove(dst);
+        }
+    }
+
+    // Save registers on stack
+    for reg in saved_registers.iter() {
+        emit_ins(jit, ARM64Instruction::push64(*reg));
+    }
+
+    if matches!(dst, Value::Register(x) if x == ARM_SCRATCH[0]) {
+        emit_ins(jit, ARM64Instruction::push64(ARM_SCRATCH[0]));
+    }
+    // Pass arguments
+    let mut stack_arguments = 0;
+    for argument in arguments {
+        if argument.is_stack_argument() {
+            stack_arguments += 1;
+        }
+        argument.emit_pass(jit);
+    }
+
+    if matches!(dst, Value::Register(x) if x == ARM_SCRATCH[0]) {
+        emit_ins(jit, ARM64Instruction::pop64(ARM_SCRATCH[0]));
+    }
+
+    emit_ins(jit, ARM64Instruction::push64(LR));
+    match dst {
+        Value::Register(reg) => {
+            emit_ins(jit, ARM64Instruction::blr(reg));
+        },
+        Value::Constant64(value, user_provided) => {
+            debug_assert!(!user_provided);
+            emit_load_immediate64(jit, ARM_SCRATCH[0], value as u64);
+            emit_ins(jit, ARM64Instruction::blr(ARM_SCRATCH[0]));
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        }
+    }
+    emit_ins(jit, ARM64Instruction::pop64(LR));
+
+    // Save returned value in result register
+    if let Some(reg) = result_reg {
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, X0, reg));
+    }
+
+    // Restore registers from stack
+    emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, SP_XZR, stack_arguments as u16 * 16, SP_XZR));
+    for reg in saved_registers.iter().rev() {
+        emit_ins(jit, ARM64Instruction::pop64(*reg));
+    }
+
+    if check_exception {
+        // Test if result indicates that an error occured
+        emit_load_immediate64(jit, ARM_SCRATCH[0], slot_on_environment_stack(jit, EnvironmentStackSlotARM64::OptRetValPtr) as u64);
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ENV_REG, ARM64MemoryOperand::OffsetIndexShift(ARM_SCRATCH[0], false), ARM_SCRATCH[0]));
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ARM_SCRATCH[0], ARM64MemoryOperand::Offset(0), ARM_SCRATCH[0]));
+        emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, ARM_SCRATCH[0], SP_XZR));
+    }
+}
+
+#[inline]
+fn emit_profile_instruction_count_finalize(jit: &mut JitCompilerCore, store_pc_in_exception: bool) {
+    if jit.config.enable_instruction_meter || store_pc_in_exception {
+        emit_ins(jit, ARM64Instruction::add_imm(OperandSize::S64, ARM_SCRATCH[0], 1, ARM_SCRATCH[0]));
+    }
+    if jit.config.enable_instruction_meter {
+        emit_ins(jit, ARM64Instruction::sub(OperandSize::S64, BPF_PROGRAM_COUNTER, ARM_SCRATCH[0], BPF_PROGRAM_COUNTER));
+    }
+    if store_pc_in_exception {
+        emit_load_env(jit, EnvironmentStackSlotARM64::OptRetValPtr, JIT_PROGRAM_ARGUMENT);
+        emit_load_immediate64(jit, ARM_SCRATCH[1], 1);
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[1], JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(0))); // is_err = true;
+
+        emit_load_immediate64(jit, ARM_SCRATCH[1], ebpf::ELF_INSN_DUMP_OFFSET as u64 - 1);
+        emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], ARM_SCRATCH[1], ARM_SCRATCH[0]));
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(16))); // pc = jit.pc + ebpf::ELF_INSN_DUMP_OFFSET;
+    }
+}
+
+fn emit_undo_profile_instruction_count(jit: &mut JitCompilerCore, target_pc: usize) {
+    if jit.config.enable_instruction_meter {
+        emit_load_immediate64(jit, ARM_SCRATCH[3], (jit.pc as i64 + 1 - target_pc as i64) as u64);
+        emit_ins(jit, ARM64Instruction::add(OperandSize::S64, BPF_PROGRAM_COUNTER, ARM_SCRATCH[3], BPF_PROGRAM_COUNTER));  // instruction_meter += (jit.pc + 1) - target_pc;
+    }
+}
+
+#[inline]
+fn emit_load_env(jit: &mut JitCompilerCore, env: EnvironmentStackSlotARM64, dst: u8) {
+        emit_load_immediate64(jit, dst, slot_on_environment_stack(jit, env) as u64);
+        emit_ins(jit, ARM64Instruction::load(OperandSize::S64, ENV_REG, ARM64MemoryOperand::OffsetIndexShift(dst, false), dst));
+}
+
+#[inline]
+fn emit_store_env(jit: &mut JitCompilerCore, src: u8, env: EnvironmentStackSlotARM64, scratch: u8) {
+        emit_load_immediate64(jit, scratch, slot_on_environment_stack(jit, env) as u64);
+        emit_ins(jit, ARM64Instruction::store(OperandSize::S64, src, ENV_REG, ARM64MemoryOperand::OffsetIndexShift(scratch, false)));
+}
+
+#[inline]
+fn emit_call_nosavelr(jit: &mut JitCompilerCore, target_pc: i32) {
+    emit_ins(jit, ARM64Instruction::bl(target_pc / 4));
+}
+#[inline]
+fn emit_call_anchor(jit: &mut JitCompilerCore, anchor: usize) {
+    emit_ins(jit, ARM64Instruction::push64(LR));
+
+    let jump_off = jit.relative_to_anchor(anchor, 0);
+    emit_ins(jit, ARM64Instruction::bl(jump_off / 4));
+
+    emit_ins(jit, ARM64Instruction::pop64(LR));
+}
+#[inline]
+fn emit_call_targetpc(jit: &mut JitCompilerCore, target_pc: usize) {
+    emit_ins(jit, ARM64Instruction::push64(LR));
+
+    let jump_off = jit.relative_to_target_pc_arm64(target_pc, FixupType::CALL as u8);
+    emit_ins(jit, ARM64Instruction::bl(jump_off / 4));
+
+    emit_ins(jit, ARM64Instruction::pop64(LR));
+}
+
+#[inline]
+fn emit_bcond(jit: &mut JitCompilerCore, cond: Condition, target_pc: i32) {
+    emit_ins(jit, ARM64Instruction::b_cond(cond, target_pc / 4));
+}
+
+#[inline]
+fn emit_jmp(jit: &mut JitCompilerCore, target_pc: i32) {
+    emit_ins(jit, ARM64Instruction::b(target_pc / 4));
+}
+
+
+#[inline]
+fn emit_conditional_branch_reg(jit: &mut JitCompilerCore, cond: Condition, bitwise: bool, first_operand: u8, second_operand: u8, target_pc: usize) {
+    if first_operand == ARM_SCRATCH[0] {
+        emit_ins(jit, ARM64Instruction::push64(ARM_SCRATCH[0]));
+    }
+    JitCompilerARM64::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
+    if first_operand == ARM_SCRATCH[0] {
+        emit_ins(jit, ARM64Instruction::pop64(ARM_SCRATCH[0]));
+    }
+    if bitwise { // Logical
+        emit_ins(jit, ARM64Instruction::tst(OperandSize::S64, first_operand, second_operand));
+    } else { // Arithmetic
+        emit_ins(jit, ARM64Instruction::cmp(OperandSize::S64, first_operand, second_operand));
+    }
+    emit_load_immediate64(jit, CUR_JIT_PC, target_pc as u64);
+    let jump_off = jit.relative_to_target_pc_arm64(target_pc, FixupType::COND_JUMP as u8);
+    emit_bcond(jit, cond, jump_off);
+    emit_undo_profile_instruction_count(jit, target_pc);
+}
+
+#[inline]
+fn emit_set_exception_kind<E: UserDefinedError>(jit: &mut JitCompilerCore, err: EbpfError<E>) {
+    let err = Result::<u64, EbpfError<E>>::Err(err);
+    let err_kind = unsafe { *(&err as *const _ as *const u64).offset(1) };
+    emit_load_env(jit, EnvironmentStackSlotARM64::OptRetValPtr, JIT_PROGRAM_ARGUMENT);
+    emit_load_immediate64(jit, ARM_SCRATCH[0], err_kind as u64);
+    emit_ins(jit, ARM64Instruction::store(OperandSize::S64, ARM_SCRATCH[0], JIT_PROGRAM_ARGUMENT, ARM64MemoryOperand::Offset(8)));
+}
+
+#[inline]
+fn emit_address_translation(jit: &mut JitCompilerCore, host_addr: u8, vm_addr: Value, len: u64, access_type: AccessType) {
+    match vm_addr {
+        Value::RegisterPlusConstant64(reg, constant, _user_provided) => {
+            emit_load_immediate64(jit, ARM_SCRATCH[0], constant);
+            emit_ins(jit, ARM64Instruction::add(OperandSize::S64, ARM_SCRATCH[0], reg, ARM_SCRATCH[0]));
+        },
+        Value::Constant64(constant, _user_provided) => {
+            emit_load_immediate64(jit, ARM_SCRATCH[0], constant);
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        },
+    }
+    emit_call_anchor(jit, ANCHOR_TRANSLATE_MEMORY_ADDRESS + len.trailing_zeros() as usize + 4 * (access_type as usize));
+    ARM64Instruction::mov(OperandSize::S64, ARM_SCRATCH[0], host_addr).emit(jit)
+}
+
+fn emit_muldivmod(jit: &mut JitCompilerCore, opc: u8, src: u8, dst: u8, imm: Option<i64>) {
+    let mul = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MUL32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let div = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::DIV32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let sdiv = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::SDIV32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let modrm = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MOD32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let size = if (opc & ebpf::BPF_CLS_MASK) == ebpf::BPF_ALU64 { OperandSize::S64 } else { OperandSize::S32 };
+
+
+    if (div || sdiv || modrm) && imm.is_none() {
+        // Save pc
+        emit_load_immediate64(jit, CUR_JIT_PC, jit.pc as u64);
+        emit_ins(jit, ARM64Instruction::tst(size, src, src)); // src == 0
+        emit_bcond(jit, Condition::EQ, jit.relative_to_anchor(ANCHOR_DIV_BY_ZERO, 0));
+    }
+
+    // sdiv overflows with MIN / -1. If we have an immediate and it's not -1, we
+    // don't need any checks.
+    if sdiv && imm.unwrap_or(-1) == -1 {
+        emit_load_immediate64(jit, ARM_SCRATCH[1], 0);
+        emit_load_immediate64(jit, ARM_SCRATCH[0], if let OperandSize::S64 = size { i64::MIN as u64 } else { i32::MIN as u64 });
+        emit_ins(jit, ARM64Instruction::sub(size, dst, ARM_SCRATCH[0], ARM_SCRATCH[0]));
+        if imm.is_none() {
+            // if src != -1, we can skip checking dst
+            emit_ins(jit, ARM64Instruction::movn(ARM_SCRATCH[1], 0, 0)); // ARM_SCRATCH[0] = -1;
+            emit_ins(jit, ARM64Instruction::sub(size, src, ARM_SCRATCH[1], ARM_SCRATCH[1]));
+        }
+
+        // MIN / -1, raise EbpfError::DivideOverflow(pc)
+        emit_load_immediate64(jit, CUR_JIT_PC, jit.pc as u64);
+        emit_ins(jit, ARM64Instruction::orr(size, ARM_SCRATCH[0], ARM_SCRATCH[1]));
+        emit_ins(jit, ARM64Instruction::tst(size, ARM_SCRATCH[1], ARM_SCRATCH[1]));
+        emit_bcond(jit, Condition::EQ, jit.relative_to_anchor(ANCHOR_DIV_OVERFLOW, 0)); // zero flag means dst == MIN and SRC == -1
+    }
+
+    if let Some(imm) = imm {
+        emit_load_immediate64(jit, ARM_SCRATCH[0], imm as u64);
+    } else {
+        emit_ins(jit, ARM64Instruction::mov(OperandSize::S64, src, ARM_SCRATCH[0]));
+    }
+
+    if div {
+        emit_ins(jit, ARM64Instruction::udiv(size, dst, ARM_SCRATCH[0], dst));
+    } else if sdiv {
+        emit_ins(jit, ARM64Instruction::sdiv(size, dst, ARM_SCRATCH[0], dst));
+    } else if mul {
+        emit_ins(jit, ARM64Instruction::madd(size, dst, ARM_SCRATCH[0], SP_XZR, dst));
+    } else {
+        emit_ins(jit, ARM64Instruction::udiv(size, dst, ARM_SCRATCH[0], ARM_SCRATCH[1]));
+        emit_ins(jit, ARM64Instruction::msub(size, ARM_SCRATCH[1], ARM_SCRATCH[0], dst, dst));
+    }
+
+    if size == OperandSize::S32 && (mul || sdiv)  {
+        emit_ins(jit, ARM64Instruction::sign_extend_to_i64(OperandSize::S32, dst, dst));
+    }
+}
+
+// This function helps the optimizer to inline the machinecode emission while avoiding stack allocations
+#[inline(always)]
+pub fn emit_ins(jit: &mut JitCompilerCore, instruction: ARM64Instruction) {
+    instruction.emit(jit);
+    if jit.next_noop_insertion == 0 {
+        jit.next_noop_insertion = jit.diversification_rng.gen_range(0..jit.config.noop_instruction_rate * 2);
+        // X86Instruction::noop().emit(jit)?;
+        emit::<u32>(jit, 0xaa0003e0);
+    } else {
+        jit.next_noop_insertion -= 1;
+    }
+}
+
+/// Indices of slots inside the struct at inital SP
+#[derive(PartialEq, Eq, Copy, Clone)]
+#[repr(C)]
+pub enum EnvironmentStackSlotARM64 {
+    /// The 12 CALLEE_SAVED_REGISTERS
+    LastSavedRegister = 11,
+    /// The current call depth.
+    ///
+    /// Incremented on calls and decremented on exits. It's used to enforce
+    /// config.max_call_depth and to know when to terminate execution.
+    CallDepth = 12,
+    /// BPF frame pointer (REGISTER_MAP[FRAME_PTR_REG]).
+    BpfFramePtr = 13,
+    /// The BPF stack pointer (r11). Only used when config.dynamic_stack_frames=true.
+    ///
+    /// The stack pointer isn't exposed as an actual register. Only sub and add
+    /// instructions (typically generated by the LLVM backend) are allowed to
+    /// access it. Its value is only stored in this slot and therefore the
+    /// register is not tracked in REGISTER_MAP.
+    BpfStackPtr = 14,
+    /// Constant pointer to optional typed return value
+    OptRetValPtr = 15,
+    /// Last return value of instruction_meter.get_remaining()
+    PrevInsnMeter = 16,
+    /// Constant pointer to instruction_meter
+    InsnMeterPtr = 17,
+    /// CPU cycles accumulated by the stop watch
+    StopwatchNumerator = 18,
+    /// Number of times the stop watch was used
+    StopwatchDenominator = 19,
+    /// Bumper for size_of
+    SlotCount = 20,
+}
+
+pub fn slot_on_environment_stack(jit: &JitCompilerCore, slot: EnvironmentStackSlotARM64) -> i32 {
+    -8 * (slot as i32 + jit.environment_stack_key)
+}
+

--- a/src/jit_x86.rs
+++ b/src/jit_x86.rs
@@ -1,0 +1,1322 @@
+// Derived from uBPF <https://github.com/iovisor/ubpf>
+// Copyright 2015 Big Switch Networks, Inc
+//      (uBPF: JIT algorithm, originally in C)
+// Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
+//      (Translation to Rust, MetaBuff addition)
+// Copyright 2020 Solana Maintainers <maintainers@solana.com>
+//
+// Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or
+// the MIT license <http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::deprecated_cfg_attr)]
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unreachable_code)]
+
+use std::{
+    mem,
+    pin::Pin, ptr,
+};
+use rand::{Rng};
+
+use crate::{
+    elf::Executable,
+    vm::{InstructionMeter, Tracer, SYSCALL_CONTEXT_OBJECTS_OFFSET},
+    ebpf::{self, INSN_SIZE, FIRST_SCRATCH_REG, SCRATCH_REGS, FRAME_PTR_REG, MM_STACK_START, STACK_PTR_REG, Insn},
+    error::{UserDefinedError, EbpfError},
+    memory_region::{AccessType, MemoryMapping, MemoryRegion},
+    user_error::UserError,
+    x86::*,
+    jit::*
+};
+
+pub struct JitCompilerX86 {
+    core: JitCompilerCore
+}
+
+impl JitCompilerImpl for JitCompilerX86 {
+    fn get_max_empty_machine_code_length() -> usize {
+        4096
+    }
+    fn get_max_machine_code_per_instruction() -> usize {
+        110
+    }
+    fn get_core(&mut self) -> &mut JitCompilerCore {
+        &mut self.core
+    }
+    fn get_result(self) -> JitProgramSections {
+        self.core.result
+    }
+    fn new<E: UserDefinedError>(jit: JitCompilerCore) -> Result<Self, EbpfError<E>> {
+        Ok(Self {
+            core: jit
+        })
+    }
+    fn handle_insn<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore, mut insn: Insn, executable: &Pin<Box<Executable<E, I>>>, program: &[u8]) -> Result<(), EbpfError<E>> {
+        if jit.config.enable_instruction_tracing {
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+            emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_TRACE, 5)));
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, 0));
+        }
+        let dst = if insn.dst == STACK_PTR_REG as u8 { u8::MAX } else { REGISTER_MAP[insn.dst as usize] };
+        let src = REGISTER_MAP[insn.src as usize];
+        let target_pc = (jit.pc as isize + insn.off as isize + 1) as usize;
+        match insn.opc {
+            _ if insn.dst == STACK_PTR_REG as u8 && jit.config.dynamic_stack_frames => {
+                let stack_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::BpfStackPtr));
+                match insn.opc {
+                    ebpf::SUB64_IMM => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 5, RBP, insn.imm, Some(stack_ptr_access))),
+                    ebpf::ADD64_IMM => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, insn.imm, Some(stack_ptr_access))),
+                    _ => {
+                        #[cfg(debug_assertions)]
+                        unreachable!("unexpected insn on r11")
+                    }
+                }
+            }
+
+            ebpf::LD_DW_IMM  => {
+                Self::emit_validate_and_profile_instruction_count(jit, true, Some(jit.pc + 2));
+                jit.pc += 1;
+                jit.result.pc_section[jit.pc] = jit.anchors[ANCHOR_CALL_UNSUPPORTED_INSTRUCTION] as usize;
+                ebpf::augment_lddw_unchecked(program, &mut insn);
+                if should_sanitize_constant(jit, insn.imm) {
+                    emit_sanitized_load_immediate(jit, OperandSize::S64, dst, insn.imm);
+                } else {
+                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, dst, insn.imm));
+                }
+            },
+
+            // BPF_LDX class
+            ebpf::LD_B_REG   => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 1, AccessType::Load);
+                emit_ins(jit, X86Instruction::load(OperandSize::S8, R11, dst, X86IndirectAccess::Offset(0)));
+            },
+            ebpf::LD_H_REG   => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 2, AccessType::Load);
+                emit_ins(jit, X86Instruction::load(OperandSize::S16, R11, dst, X86IndirectAccess::Offset(0)));
+            },
+            ebpf::LD_W_REG   => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 4, AccessType::Load);
+                emit_ins(jit, X86Instruction::load(OperandSize::S32, R11, dst, X86IndirectAccess::Offset(0)));
+            },
+            ebpf::LD_DW_REG  => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 8, AccessType::Load);
+                emit_ins(jit, X86Instruction::load(OperandSize::S64, R11, dst, X86IndirectAccess::Offset(0)));
+            },
+
+            // BPF_ST class
+            ebpf::ST_B_IMM   => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 1, AccessType::Store);
+                emit_ins(jit, X86Instruction::store_immediate(OperandSize::S8, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
+            },
+            ebpf::ST_H_IMM   => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, AccessType::Store);
+                emit_ins(jit, X86Instruction::store_immediate(OperandSize::S16, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
+            },
+            ebpf::ST_W_IMM   => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4, AccessType::Store);
+                emit_ins(jit, X86Instruction::store_immediate(OperandSize::S32, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
+            },
+            ebpf::ST_DW_IMM  => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, AccessType::Store);
+                emit_ins(jit, X86Instruction::store_immediate(OperandSize::S64, R11, X86IndirectAccess::Offset(0), insn.imm as i64));
+            },
+
+            // BPF_STX class
+            ebpf::ST_B_REG  => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 1, AccessType::Store);
+                emit_ins(jit, X86Instruction::store(OperandSize::S8, src, R11, X86IndirectAccess::Offset(0)));
+            },
+            ebpf::ST_H_REG  => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, AccessType::Store);
+                emit_ins(jit, X86Instruction::store(OperandSize::S16, src, R11, X86IndirectAccess::Offset(0)));
+            },
+            ebpf::ST_W_REG  => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4, AccessType::Store);
+                emit_ins(jit, X86Instruction::store(OperandSize::S32, src, R11, X86IndirectAccess::Offset(0)));
+            },
+            ebpf::ST_DW_REG  => {
+                emit_address_translation(jit, R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, AccessType::Store);
+                emit_ins(jit, X86Instruction::store(OperandSize::S64, src, R11, X86IndirectAccess::Offset(0)));
+            },
+
+            // BPF_ALU class
+            ebpf::ADD32_IMM  => {
+                emit_sanitized_alu(jit, OperandSize::S32, 0x01, 0, dst, insn.imm);
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
+            },
+            ebpf::ADD32_REG  => {
+                emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x01, src, dst, 0, None));
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
+            },
+            ebpf::SUB32_IMM  => {
+                emit_sanitized_alu(jit, OperandSize::S32, 0x29, 5, dst, insn.imm);
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
+            },
+            ebpf::SUB32_REG  => {
+                emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x29, src, dst, 0, None));
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
+            },
+            ebpf::MUL32_IMM | ebpf::DIV32_IMM | ebpf::SDIV32_IMM | ebpf::MOD32_IMM  =>
+                emit_muldivmod(jit, insn.opc, dst, dst, Some(insn.imm)),
+            ebpf::MUL32_REG | ebpf::DIV32_REG | ebpf::SDIV32_REG | ebpf::MOD32_REG  =>
+                emit_muldivmod(jit, insn.opc, src, dst, None),
+            ebpf::OR32_IMM   => emit_sanitized_alu(jit, OperandSize::S32, 0x09, 1, dst, insn.imm),
+            ebpf::OR32_REG   => emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x09, src, dst, 0, None)),
+            ebpf::AND32_IMM  => emit_sanitized_alu(jit, OperandSize::S32, 0x21, 4, dst, insn.imm),
+            ebpf::AND32_REG  => emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x21, src, dst, 0, None)),
+            ebpf::LSH32_IMM  => emit_shift(jit, OperandSize::S32, 4, R11, dst, Some(insn.imm)),
+            ebpf::LSH32_REG  => emit_shift(jit, OperandSize::S32, 4, src, dst, None),
+            ebpf::RSH32_IMM  => emit_shift(jit, OperandSize::S32, 5, R11, dst, Some(insn.imm)),
+            ebpf::RSH32_REG  => emit_shift(jit, OperandSize::S32, 5, src, dst, None),
+            ebpf::NEG32      => emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0xf7, 3, dst, 0, None)),
+            ebpf::XOR32_IMM  => emit_sanitized_alu(jit, OperandSize::S32, 0x31, 6, dst, insn.imm),
+            ebpf::XOR32_REG  => emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x31, src, dst, 0, None)),
+            ebpf::MOV32_IMM  => {
+                if should_sanitize_constant(jit, insn.imm) {
+                    emit_sanitized_load_immediate(jit, OperandSize::S32, dst, insn.imm);
+                } else {
+                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S32, dst, insn.imm));
+                }
+            }
+            ebpf::MOV32_REG  => emit_ins(jit, X86Instruction::mov(OperandSize::S32, src, dst)),
+            ebpf::ARSH32_IMM => emit_shift(jit, OperandSize::S32, 7, R11, dst, Some(insn.imm)),
+            ebpf::ARSH32_REG => emit_shift(jit, OperandSize::S32, 7, src, dst, None),
+            ebpf::LE         => {
+                match insn.imm {
+                    16 => {
+                        emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x81, 4, dst, 0xffff, None)); // Mask to 16 bit
+                    }
+                    32 => {
+                        emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x81, 4, dst, -1, None)); // Mask to 32 bit
+                    }
+                    64 => {}
+                    _ => {
+                        return Err(EbpfError::InvalidInstruction(jit.pc + ebpf::ELF_INSN_DUMP_OFFSET));
+                    }
+                }
+            },
+            ebpf::BE         => {
+                match insn.imm {
+                    16 => {
+                        emit_ins(jit, X86Instruction::bswap(OperandSize::S16, dst));
+                        emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x81, 4, dst, 0xffff, None)); // Mask to 16 bit
+                    }
+                    32 => emit_ins(jit, X86Instruction::bswap(OperandSize::S32, dst)),
+                    64 => emit_ins(jit, X86Instruction::bswap(OperandSize::S64, dst)),
+                    _ => {
+                        return Err(EbpfError::InvalidInstruction(jit.pc + ebpf::ELF_INSN_DUMP_OFFSET));
+                    }
+                }
+            },
+
+            // BPF_ALU64 class
+            ebpf::ADD64_IMM  => emit_sanitized_alu(jit, OperandSize::S64, 0x01, 0, dst, insn.imm),
+            ebpf::ADD64_REG  => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, src, dst, 0, None)),
+            ebpf::SUB64_IMM  => emit_sanitized_alu(jit, OperandSize::S64, 0x29, 5, dst, insn.imm),
+            ebpf::SUB64_REG  => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, src, dst, 0, None)),
+            ebpf::MUL64_IMM | ebpf::DIV64_IMM | ebpf::SDIV64_IMM | ebpf::MOD64_IMM  =>
+                emit_muldivmod(jit, insn.opc, dst, dst, Some(insn.imm)),
+            ebpf::MUL64_REG | ebpf::DIV64_REG | ebpf::SDIV64_REG | ebpf::MOD64_REG  =>
+                emit_muldivmod(jit, insn.opc, src, dst, None),
+            ebpf::OR64_IMM   => emit_sanitized_alu(jit, OperandSize::S64, 0x09, 1, dst, insn.imm),
+            ebpf::OR64_REG   => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x09, src, dst, 0, None)),
+            ebpf::AND64_IMM  => emit_sanitized_alu(jit, OperandSize::S64, 0x21, 4, dst, insn.imm),
+            ebpf::AND64_REG  => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x21, src, dst, 0, None)),
+            ebpf::LSH64_IMM  => emit_shift(jit, OperandSize::S64, 4, R11, dst, Some(insn.imm)),
+            ebpf::LSH64_REG  => emit_shift(jit, OperandSize::S64, 4, src, dst, None),
+            ebpf::RSH64_IMM  => emit_shift(jit, OperandSize::S64, 5, R11, dst, Some(insn.imm)),
+            ebpf::RSH64_REG  => emit_shift(jit, OperandSize::S64, 5, src, dst, None),
+            ebpf::NEG64      => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xf7, 3, dst, 0, None)),
+            ebpf::XOR64_IMM  => emit_sanitized_alu(jit, OperandSize::S64, 0x31, 6, dst, insn.imm),
+            ebpf::XOR64_REG  => emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x31, src, dst, 0, None)),
+            ebpf::MOV64_IMM  => {
+                if should_sanitize_constant(jit, insn.imm) {
+                    emit_sanitized_load_immediate(jit, OperandSize::S64, dst, insn.imm);
+                } else {
+                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, dst, insn.imm));
+                }
+            }
+            ebpf::MOV64_REG  => emit_ins(jit, X86Instruction::mov(OperandSize::S64, src, dst)),
+            ebpf::ARSH64_IMM => emit_shift(jit, OperandSize::S64, 7, R11, dst, Some(insn.imm)),
+            ebpf::ARSH64_REG => emit_shift(jit, OperandSize::S64, 7, src, dst, None),
+
+            // BPF_JMP class
+            ebpf::JA         => {
+                Self::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
+                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
+                let jump_offset = jit.relative_to_target_pc(target_pc, 5, FixupType::JumpImm as u8);
+                emit_ins(jit, X86Instruction::jump_immediate(jump_offset));
+            },
+            ebpf::JEQ_IMM    => emit_conditional_branch_imm(jit, 0x84, false, insn.imm, dst, target_pc),
+            ebpf::JEQ_REG    => emit_conditional_branch_reg(jit, 0x84, false, src, dst, target_pc),
+            ebpf::JGT_IMM    => emit_conditional_branch_imm(jit, 0x87, false, insn.imm, dst, target_pc),
+            ebpf::JGT_REG    => emit_conditional_branch_reg(jit, 0x87, false, src, dst, target_pc),
+            ebpf::JGE_IMM    => emit_conditional_branch_imm(jit, 0x83, false, insn.imm, dst, target_pc),
+            ebpf::JGE_REG    => emit_conditional_branch_reg(jit, 0x83, false, src, dst, target_pc),
+            ebpf::JLT_IMM    => emit_conditional_branch_imm(jit, 0x82, false, insn.imm, dst, target_pc),
+            ebpf::JLT_REG    => emit_conditional_branch_reg(jit, 0x82, false, src, dst, target_pc),
+            ebpf::JLE_IMM    => emit_conditional_branch_imm(jit, 0x86, false, insn.imm, dst, target_pc),
+            ebpf::JLE_REG    => emit_conditional_branch_reg(jit, 0x86, false, src, dst, target_pc),
+            ebpf::JSET_IMM   => emit_conditional_branch_imm(jit, 0x85, true, insn.imm, dst, target_pc),
+            ebpf::JSET_REG   => emit_conditional_branch_reg(jit, 0x85, true, src, dst, target_pc),
+            ebpf::JNE_IMM    => emit_conditional_branch_imm(jit, 0x85, false, insn.imm, dst, target_pc),
+            ebpf::JNE_REG    => emit_conditional_branch_reg(jit, 0x85, false, src, dst, target_pc),
+            ebpf::JSGT_IMM   => emit_conditional_branch_imm(jit, 0x8f, false, insn.imm, dst, target_pc),
+            ebpf::JSGT_REG   => emit_conditional_branch_reg(jit, 0x8f, false, src, dst, target_pc),
+            ebpf::JSGE_IMM   => emit_conditional_branch_imm(jit, 0x8d, false, insn.imm, dst, target_pc),
+            ebpf::JSGE_REG   => emit_conditional_branch_reg(jit, 0x8d, false, src, dst, target_pc),
+            ebpf::JSLT_IMM   => emit_conditional_branch_imm(jit, 0x8c, false, insn.imm, dst, target_pc),
+            ebpf::JSLT_REG   => emit_conditional_branch_reg(jit, 0x8c, false, src, dst, target_pc),
+            ebpf::JSLE_IMM   => emit_conditional_branch_imm(jit, 0x8e, false, insn.imm, dst, target_pc),
+            ebpf::JSLE_REG   => emit_conditional_branch_reg(jit, 0x8e, false, src, dst, target_pc),
+            ebpf::CALL_IMM   => {
+                // For JIT, syscalls MUST be registered at compile time. They can be
+                // updated later, but not created after compiling (we need the address of the
+                // syscall function in the JIT-compiled program).
+
+                let mut resolved = false;
+                let (syscalls, calls) = if jit.config.static_syscalls {
+                    (insn.src == 0, insn.src != 0)
+                } else {
+                    (true, true)
+                };
+
+                if syscalls {
+                    if let Some(syscall) = executable.get_syscall_registry().lookup_syscall(insn.imm as u32) {
+                        if jit.config.enable_instruction_meter {
+                            Self::emit_validate_and_profile_instruction_count(jit, true, Some(0));
+                        }
+                        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, syscall.function as *const u8 as i64));
+                        emit_ins(jit, X86Instruction::load(OperandSize::S64, R10, RAX, X86IndirectAccess::Offset((SYSCALL_CONTEXT_OBJECTS_OFFSET + syscall.context_object_slot) as i32 * 8 + jit.program_argument_key)));
+                        emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_SYSCALL, 5)));
+                        if jit.config.enable_instruction_meter {
+                            emit_undo_profile_instruction_count(jit, 0);
+                        }
+                        // Throw error if the result indicates one
+                        // NOTE: If we do not throw this error now, we might cause a memory leak (ie.
+                        // the error and any of its fields will not be free'd)
+                        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, R11, 0, Some(X86IndirectAccess::Offset(0))));
+                        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+                        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x85, jit.relative_to_anchor(ANCHOR_RUST_EXCEPTION, 6)));
+
+                        resolved = true;
+                    }
+                }
+
+                if calls {
+                    if let Some(target_pc) = executable.lookup_bpf_function(insn.imm as u32) {
+                        emit_bpf_call(jit, Value::Constant64(target_pc as i64, false));
+                        resolved = true;
+                    }
+                }
+
+                if !resolved {
+                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+                    emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 5)));
+                }
+            },
+            ebpf::CALL_REG  => {
+                emit_bpf_call(jit, Value::Register(REGISTER_MAP[insn.imm as usize]));
+            },
+            ebpf::EXIT      => {
+                let call_depth_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::CallDepth));
+                emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], call_depth_access));
+
+                // If CallDepth == 0, we've reached the exit instruction of the entry point
+                emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S32, REGISTER_MAP[FRAME_PTR_REG], 0, None));
+                if jit.config.enable_instruction_meter {
+                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+                }
+                // we're done
+                emit_ins(jit, X86Instruction::conditional_jump_immediate(0x84, jit.relative_to_anchor(ANCHOR_EXIT, 6)));
+
+                // else decrement and update CallDepth
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 5, REGISTER_MAP[FRAME_PTR_REG], 1, None));
+                emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RBP, call_depth_access));
+
+                // and return
+                Self::emit_validate_and_profile_instruction_count(jit, false, Some(0));
+                emit_ins(jit, X86Instruction::return_near());
+            },
+
+            _               => return Err(EbpfError::UnsupportedInstruction(jit.pc + ebpf::ELF_INSN_DUMP_OFFSET)),
+            }
+        Ok(())
+    }
+
+    // When we call into the JIT-ed code, the code emitted here is the first thing to run.
+    //
+    // ARGUMENT_REGISTERS[0] - &ProgramResult<E>
+    // ARGUMENT_REGISTERS[1] (alias: REGISTER_MAP[1]) - input start address
+    // ARGUMENT_REGISTERS[2] - *JITProgramArgument
+    // ARGUMENT_REGISTERS[3] - &InstructionMeter
+    fn generate_prologue<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore, executable: &Pin<Box<Executable<E, I>>>) {
+        // Place the environment on the stack according to EnvironmentStackSlotX86
+
+        // Save registers
+        for reg in CALLEE_SAVED_REGISTERS.iter() {
+            emit_ins(jit, X86Instruction::push(*reg, None));
+        }
+
+        // Initialize CallDepth to 0
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], 0));
+        emit_ins(jit, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
+
+        // Initialize the BPF frame and stack pointers (BpfFramePtr and BpfStackPtr)
+        if jit.config.dynamic_stack_frames {
+            // The stack is fully descending from MM_STACK_START + stack_size to MM_STACK_START
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], MM_STACK_START as i64 + jit.config.stack_size() as i64));
+            // Push BpfFramePtr
+            emit_ins(jit, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
+            // Push BpfStackPtr
+            emit_ins(jit, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
+        } else {
+            // The frames are ascending from MM_STACK_START to MM_STACK_START + stack_size. The stack within the frames is descending.
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], MM_STACK_START as i64 + jit.config.stack_frame_size as i64));
+            // Push BpfFramePtr
+            emit_ins(jit, X86Instruction::push(REGISTER_MAP[FRAME_PTR_REG], None));
+            // When using static frames BpfStackPtr is not used
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, RBP, 0));
+            emit_ins(jit, X86Instruction::push(RBP, None));
+        }
+
+        // Save pointer to optional typed return value
+        emit_ins(jit, X86Instruction::push(ARGUMENT_REGISTERS[0], None));
+
+        // Save initial value of instruction_meter.get_remaining()
+        emit_rust_call(jit, Value::Constant64(I::get_remaining as *const u8 as i64, false), &[
+            Argument { index: 0, value: Value::Register(ARGUMENT_REGISTERS[3]) },
+        ], Some(ARGUMENT_REGISTERS[0]), false);
+        emit_ins(jit, X86Instruction::push(ARGUMENT_REGISTERS[0], None));
+
+        // Save instruction meter
+        emit_ins(jit, X86Instruction::push(ARGUMENT_REGISTERS[3], None));
+
+        // Initialize stop watch
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x31, R11, R11, 0, None)); // R11 ^= R11;
+        emit_ins(jit, X86Instruction::push(R11, None));
+        emit_ins(jit, X86Instruction::push(R11, None));
+
+        // Initialize frame pointer
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, RSP, RBP));
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, 8 * (EnvironmentStackSlotX86::SlotCount as i64 - 1 + jit.environment_stack_key as i64), None));
+
+        // Save JitProgramArgument
+        emit_ins(jit, X86Instruction::lea(OperandSize::S64, ARGUMENT_REGISTERS[2], R10, Some(X86IndirectAccess::Offset(-jit.program_argument_key))));
+
+        // Zero BPF registers
+        for reg in REGISTER_MAP.iter() {
+            if *reg != REGISTER_MAP[1] && *reg != REGISTER_MAP[FRAME_PTR_REG] {
+                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, *reg, 0));
+            }
+        }
+
+        // Jump to entry point
+        let entry = executable.get_entrypoint_instruction_offset().unwrap_or(0);
+        if jit.config.enable_instruction_meter {
+            Self::emit_profile_instruction_count(jit, Some(entry + 1));
+        }
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, entry as i64));
+        let jump_offset = jit.relative_to_target_pc(entry, 5, FixupType::JumpImm as u8);
+        emit_ins(jit, X86Instruction::jump_immediate(jump_offset));
+    }
+
+    fn emit_overrun<E: UserDefinedError>(jit: &mut JitCompilerCore) {
+        Self::emit_validate_and_profile_instruction_count(jit, true, Some(jit.pc + 2));
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+        emit_set_exception_kind::<E>(jit, EbpfError::ExecutionOverrun(0));
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+    }
+
+    fn generate_subroutines<E: UserDefinedError, I: InstructionMeter>(jit: &mut JitCompilerCore) {
+        // Epilogue
+        jit.set_anchor(ANCHOR_EPILOGUE);
+        // Print stop watch value
+        fn stopwatch_result(numerator: u64, denominator: u64) {
+            println!("Stop watch: {} / {} = {}", numerator, denominator, if denominator == 0 { 0.0 } else { numerator as f64 / denominator as f64 });
+        }
+        if jit.stopwatch_is_active {
+            emit_rust_call(jit, Value::Constant64(stopwatch_result as *const u8 as i64, false), &[
+                Argument { index: 1, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(jit, EnvironmentStackSlotX86::StopwatchDenominator), false) },
+                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(jit, EnvironmentStackSlotX86::StopwatchNumerator), false) },
+            ], None, false);
+        }
+        // Store instruction_meter in RAX
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, ARGUMENT_REGISTERS[0], RAX));
+        // Restore stack pointer in case the BPF stack was used
+        emit_ins(jit, X86Instruction::lea(OperandSize::S64, RBP, RSP, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::LastSavedRegister)))));
+        // Restore registers
+        for reg in CALLEE_SAVED_REGISTERS.iter().rev() {
+            emit_ins(jit, X86Instruction::pop(*reg));
+        }
+        emit_ins(jit, X86Instruction::return_near());
+
+        // Routine for instruction tracing
+        if jit.config.enable_instruction_tracing {
+            jit.set_anchor(ANCHOR_TRACE);
+            // Save registers on stack
+            emit_ins(jit, X86Instruction::push(R11, None));
+            for reg in REGISTER_MAP.iter().rev() {
+                emit_ins(jit, X86Instruction::push(*reg, None));
+            }
+            emit_ins(jit, X86Instruction::mov(OperandSize::S64, RSP, REGISTER_MAP[0]));
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, - 8 * 3, None)); // RSP -= 8 * 3;
+            emit_rust_call(jit, Value::Constant64(Tracer::trace as *const u8 as i64, false), &[
+                Argument { index: 1, value: Value::Register(REGISTER_MAP[0]) }, // registers
+                Argument { index: 0, value: Value::RegisterIndirect(R10, mem::size_of::<MemoryMapping>() as i32 + jit.program_argument_key, false) }, // jit.tracer
+            ], None, false);
+            // Pop stack and return
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, 8 * 3, None)); // RSP += 8 * 3;
+            emit_ins(jit, X86Instruction::pop(REGISTER_MAP[0]));
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, 8 * (REGISTER_MAP.len() - 1) as i64, None)); // RSP += 8 * (REGISTER_MAP.len() - 1);
+            emit_ins(jit, X86Instruction::pop(R11));
+            emit_ins(jit, X86Instruction::return_near());
+        }
+
+        // Handler for syscall exceptions
+        jit.set_anchor(ANCHOR_RUST_EXCEPTION);
+        emit_profile_instruction_count_finalize(jit, false);
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
+
+        // Handler for EbpfError::ExceededMaxInstructions
+        jit.set_anchor(ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS);
+        emit_set_exception_kind::<E>(jit, EbpfError::ExceededMaxInstructions(0, 0));
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, ARGUMENT_REGISTERS[0], R11)); // R11 = instruction_meter;
+        emit_profile_instruction_count_finalize(jit, true);
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
+
+        // Handler for exceptions which report their pc
+        jit.set_anchor(ANCHOR_EXCEPTION_AT);
+        // Validate that we did not reach the instruction meter limit before the exception occured
+        if jit.config.enable_instruction_meter {
+            Self::emit_validate_instruction_count(jit, false, None);
+        }
+        emit_profile_instruction_count_finalize(jit, true);
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
+
+        // Handler for EbpfError::CallDepthExceeded
+        jit.set_anchor(ANCHOR_CALL_DEPTH_EXCEEDED);
+        emit_set_exception_kind::<E>(jit, EbpfError::CallDepthExceeded(0, 0));
+        emit_ins(jit, X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(24), jit.config.max_call_depth as i64)); // depth = jit.config.max_call_depth;
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+
+        // Handler for EbpfError::CallOutsideTextSegment
+        jit.set_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT);
+        emit_set_exception_kind::<E>(jit, EbpfError::CallOutsideTextSegment(0, 0));
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], R10, X86IndirectAccess::Offset(24))); // target_address = RAX;
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+
+        // Handler for EbpfError::DivideByZero
+        jit.set_anchor(ANCHOR_DIV_BY_ZERO);
+        emit_set_exception_kind::<E>(jit, EbpfError::DivideByZero(0));
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+
+        // Handler for EbpfError::DivideOverflow
+        jit.set_anchor(ANCHOR_DIV_OVERFLOW);
+        emit_set_exception_kind::<E>(jit, EbpfError::DivideOverflow(0));
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+
+        // Handler for EbpfError::UnsupportedInstruction
+        jit.set_anchor(ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION);
+        // Load BPF target pc from stack (which was saved in ANCHOR_BPF_CALL_REG)
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RSP, R11, X86IndirectAccess::OffsetIndexShift(-16, RSP, 0))); // R11 = RSP[-16];
+        // emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 5))); // Fall-through
+
+        // Handler for EbpfError::UnsupportedInstruction
+        jit.set_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION);
+        if jit.config.enable_instruction_tracing {
+            emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_TRACE, 5)));
+        }
+        emit_set_exception_kind::<E>(jit, EbpfError::UnsupportedInstruction(0));
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+
+        // Quit gracefully
+        jit.set_anchor(ANCHOR_EXIT);
+        Self::emit_validate_instruction_count(jit, false, None);
+        emit_profile_instruction_count_finalize(jit, false);
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr))));
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], R10, X86IndirectAccess::Offset(8))); // result.return_value = R0;
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[0], 0));
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], R10, X86IndirectAccess::Offset(0)));  // result.is_error = false;
+        emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
+
+        // Routine for syscall
+        jit.set_anchor(ANCHOR_SYSCALL);
+        emit_ins(jit, X86Instruction::push(R11, None)); // Padding for stack alignment
+        if jit.config.enable_instruction_meter {
+            // RDI = *PrevInsnMeter - RDI;
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x2B, ARGUMENT_REGISTERS[0], RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::PrevInsnMeter))))); // RDI -= *PrevInsnMeter;
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xf7, 3, ARGUMENT_REGISTERS[0], 0, None)); // RDI = -RDI;
+            emit_rust_call(jit, Value::Constant64(I::consume as *const u8 as i64, false), &[
+                Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[0]) },
+                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(jit, EnvironmentStackSlotX86::InsnMeterPtr), false) },
+            ], None, false);
+        }
+        emit_rust_call(jit, Value::Register(R11), &[
+            Argument { index: 7, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr), false) },
+            Argument { index: 6, value: Value::RegisterPlusConstant32(R10, jit.program_argument_key, false) }, // jit_program_argument.memory_mapping
+            Argument { index: 5, value: Value::Register(ARGUMENT_REGISTERS[5]) },
+            Argument { index: 4, value: Value::Register(ARGUMENT_REGISTERS[4]) },
+            Argument { index: 3, value: Value::Register(ARGUMENT_REGISTERS[3]) },
+            Argument { index: 2, value: Value::Register(ARGUMENT_REGISTERS[2]) },
+            Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[1]) },
+            Argument { index: 0, value: Value::Register(RAX) }, // "&mut jit" in the "call" method of the SyscallObject
+        ], None, false);
+        if jit.config.enable_instruction_meter {
+            emit_rust_call(jit, Value::Constant64(I::get_remaining as *const u8 as i64, false), &[
+                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(jit, EnvironmentStackSlotX86::InsnMeterPtr), false) },
+            ], Some(ARGUMENT_REGISTERS[0]), false);
+            emit_ins(jit, X86Instruction::store(OperandSize::S64, ARGUMENT_REGISTERS[0], RBP, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::PrevInsnMeter))));
+        }
+        emit_ins(jit, X86Instruction::pop(R11));
+        // Store Ok value in result register
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R11, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr))));
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, R11, REGISTER_MAP[0], X86IndirectAccess::Offset(8)));
+        emit_ins(jit, X86Instruction::return_near());
+
+        // Routine for prologue of emit_bpf_call()
+        jit.set_anchor(ANCHOR_BPF_CALL_PROLOGUE);
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 5, RSP, 8 * (SCRATCH_REGS + 1) as i64, None)); // alloca
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, R11, RSP, X86IndirectAccess::OffsetIndexShift(0, RSP, 0))); // Save original R11
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RSP, R11, X86IndirectAccess::OffsetIndexShift(8 * (SCRATCH_REGS + 1) as i32, RSP, 0))); // Load return address
+        for (i, reg) in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).enumerate() {
+            emit_ins(jit, X86Instruction::store(OperandSize::S64, *reg, RSP, X86IndirectAccess::OffsetIndexShift(8 * (SCRATCH_REGS - i + 1) as i32, RSP, 0))); // Push SCRATCH_REG
+        }
+        // Push the caller's frame pointer. The code to restore it is emitted at the end of emit_bpf_call().
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RSP, X86IndirectAccess::OffsetIndexShift(8, RSP, 0)));
+        emit_ins(jit, X86Instruction::xchg(OperandSize::S64, R11, RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Push return address and restore original R11
+
+        // Increase CallDepth
+        let call_depth_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::CallDepth));
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, 1, Some(call_depth_access)));
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], call_depth_access));
+        // If CallDepth == jit.config.max_call_depth, stop and return CallDepthExceeded
+        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S32, REGISTER_MAP[FRAME_PTR_REG], jit.config.max_call_depth as i64, None));
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x83, jit.relative_to_anchor(ANCHOR_CALL_DEPTH_EXCEEDED, 6)));
+
+        // Setup the frame pointer for the new frame. What we do depends on whether we're using dynamic or fixed frames.
+        let frame_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::BpfFramePtr));
+        if jit.config.dynamic_stack_frames {
+            // When dynamic frames are on, the next frame starts at the end of the current frame
+            let stack_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::BpfStackPtr));
+            emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], stack_ptr_access));
+            emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RBP, frame_ptr_access));
+        } else {
+            // With fixed frames we start the new frame at the next fixed offset
+            let stack_frame_size = jit.config.stack_frame_size as i64 * if jit.config.enable_stack_frame_gaps { 2 } else { 1 };
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, stack_frame_size, Some(frame_ptr_access))); // frame_ptr += stack_frame_size;
+            emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], frame_ptr_access)); // Load BpfFramePtr
+        }
+        emit_ins(jit, X86Instruction::return_near());
+
+        // Routine for emit_bpf_call(Value::Register())
+        jit.set_anchor(ANCHOR_BPF_CALL_REG);
+        // Force alignment of RAX
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 4, REGISTER_MAP[0], !(INSN_SIZE as i64 - 1), None)); // RAX &= !(INSN_SIZE - 1);
+        // Upper bound check
+        // if(RAX >= jit.program_vm_addr + number_of_instructions * INSN_SIZE) throw CALL_OUTSIDE_TEXT_SEGMENT;
+        let number_of_instructions = jit.result.pc_section.len() - 1;
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], jit.program_vm_addr as i64 + (number_of_instructions * INSN_SIZE) as i64));
+        emit_ins(jit, X86Instruction::cmp(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], None));
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x83, jit.relative_to_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT, 6)));
+        // Lower bound check
+        // if(RAX < jit.program_vm_addr) throw CALL_OUTSIDE_TEXT_SEGMENT;
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], jit.program_vm_addr as i64));
+        emit_ins(jit, X86Instruction::cmp(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], None));
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x82, jit.relative_to_anchor(ANCHOR_CALL_OUTSIDE_TEXT_SEGMENT, 6)));
+        // Calculate offset relative to instruction_addresses
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], 0, None)); // RAX -= jit.program_vm_addr;
+        // Calculate the target_pc (dst / INSN_SIZE) to update the instruction_meter
+        let shift_amount = INSN_SIZE.trailing_zeros();
+        debug_assert_eq!(INSN_SIZE, 1 << shift_amount);
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], R11));
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 5, R11, shift_amount as i64, None));
+        // Save BPF target pc for potential ANCHOR_CALLX_UNSUPPORTED_INSTRUCTION
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, R11, RSP, X86IndirectAccess::OffsetIndexShift(-8, RSP, 0))); // RSP[-8] = R11;
+        // Load host target_address from jit.result.pc_section
+        debug_assert_eq!(INSN_SIZE, 8); // Because the instruction size is also the slot size we do not need to shift the offset
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], jit.result.pc_section.as_ptr() as i64));
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_MAP[FRAME_PTR_REG], REGISTER_MAP[0], 0, None)); // RAX += jit.result.pc_section;
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, REGISTER_MAP[0], REGISTER_MAP[0], X86IndirectAccess::Offset(0))); // RAX = jit.result.pc_section[RAX / 8];
+        // Load the frame pointer again since we've clobbered REGISTER_MAP[FRAME_PTR_REG]
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, REGISTER_MAP[FRAME_PTR_REG], X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::BpfFramePtr))));
+        emit_ins(jit, X86Instruction::return_near());
+
+        // Translates a host pc back to a BPF pc by linear search of the pc_section table
+        jit.set_anchor(ANCHOR_TRANSLATE_PC);
+        emit_ins(jit, X86Instruction::push(REGISTER_MAP[0], None)); // Save REGISTER_MAP[0]
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[0], jit.result.pc_section.as_ptr() as i64 - 8)); // Loop index and pointer to look up
+        jit.set_anchor(ANCHOR_TRANSLATE_PC_LOOP); // Loop label
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, REGISTER_MAP[0], 8, None)); // Increase index
+        emit_ins(jit, X86Instruction::cmp(OperandSize::S64, R11, REGISTER_MAP[0], Some(X86IndirectAccess::Offset(8)))); // Look up and compare against value at next index
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x86, jit.relative_to_anchor(ANCHOR_TRANSLATE_PC_LOOP, 6))); // Continue while *REGISTER_MAP[0] <= R11
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], R11)); // R11 = REGISTER_MAP[0];
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, REGISTER_MAP[0], jit.result.pc_section.as_ptr() as i64)); // REGISTER_MAP[0] = jit.result.pc_section;
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_MAP[0], R11, 0, None)); // R11 -= REGISTER_MAP[0];
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 5, R11, 3, None)); // R11 >>= 3;
+        emit_ins(jit, X86Instruction::pop(REGISTER_MAP[0])); // Restore REGISTER_MAP[0]
+        emit_ins(jit, X86Instruction::return_near());
+
+        // Translates a vm memory address to a host memory address
+        for (access_type, len) in &[
+            (AccessType::Load, 1i32),
+            (AccessType::Load, 2i32),
+            (AccessType::Load, 4i32),
+            (AccessType::Load, 8i32),
+            (AccessType::Store, 1i32),
+            (AccessType::Store, 2i32),
+            (AccessType::Store, 4i32),
+            (AccessType::Store, 8i32),
+        ] {
+            let target_offset = len.trailing_zeros() as usize + 4 * (*access_type as usize);
+            let stack_offset = if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                24
+            } else {
+                16
+            };
+
+            jit.set_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset);
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x31, R11, R11, 0, None)); // R11 = 0;
+            emit_ins(jit, X86Instruction::load(OperandSize::S64, RSP, R11, X86IndirectAccess::OffsetIndexShift(stack_offset, R11, 0)));
+            emit_rust_call(jit, Value::Constant64(MemoryMapping::generate_access_violation::<UserError> as *const u8 as i64, false), &[
+                Argument { index: 3, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
+                Argument { index: 4, value: Value::Constant64(*len as i64, false) },
+                Argument { index: 2, value: Value::Constant64(*access_type as i64, false) },
+                Argument { index: 1, value: Value::RegisterPlusConstant32(R10, jit.program_argument_key, false) }, // jit_program_argument.memory_mapping
+                Argument { index: 0, value: Value::RegisterIndirect(RBP, slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr), false) }, // Pointer to optional typed return value
+            ], None, true);
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, stack_offset as i64 + 8, None)); // Drop R11, RAX, RCX, RDX from stack
+            emit_ins(jit, X86Instruction::pop(R11)); // Put callers PC in R11
+            emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_TRANSLATE_PC, 5)));
+            emit_ins(jit, X86Instruction::jump_immediate(jit.relative_to_anchor(ANCHOR_EXCEPTION_AT, 5)));
+
+            jit.set_anchor(ANCHOR_TRANSLATE_MEMORY_ADDRESS + target_offset);
+            emit_ins(jit, X86Instruction::push(R11, None));
+            emit_ins(jit, X86Instruction::push(RAX, None));
+            emit_ins(jit, X86Instruction::push(RCX, None));
+            if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                emit_ins(jit, X86Instruction::push(RDX, None));
+            }
+            emit_ins(jit, X86Instruction::mov(OperandSize::S64, R11, RAX)); // RAX = vm_addr;
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 5, RAX, ebpf::VIRTUAL_ADDRESS_BITS as i64, None)); // RAX >>= ebpf::VIRTUAL_ADDRESS_BITS;
+            emit_ins(jit, X86Instruction::cmp(OperandSize::S64, RAX, R10, Some(X86IndirectAccess::Offset(jit.program_argument_key + 8)))); // region_index >= jit_program_argument.memory_mapping.regions.len()
+            emit_ins(jit, X86Instruction::conditional_jump_immediate(0x86, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
+            debug_assert_eq!(1 << 5, mem::size_of::<MemoryRegion>());
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 4, RAX, 5, None)); // RAX *= mem::size_of::<MemoryRegion>();
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x03, RAX, R10, 0, Some(X86IndirectAccess::Offset(jit.program_argument_key)))); // region = &jit_program_argument.memory_mapping.regions[region_index];
+            if *access_type == AccessType::Store {
+                emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S8, RAX, 0, Some(X86IndirectAccess::Offset(MemoryRegion::IS_WRITABLE_OFFSET)))); // region.is_writable == 0
+                emit_ins(jit, X86Instruction::conditional_jump_immediate(0x84, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
+            }
+            emit_ins(jit, X86Instruction::load(OperandSize::S64, RAX, RCX, X86IndirectAccess::Offset(MemoryRegion::VM_ADDR_OFFSET))); // RCX = region.vm_addr
+            emit_ins(jit, X86Instruction::cmp(OperandSize::S64, RCX, R11, None)); // vm_addr < region.vm_addr
+            emit_ins(jit, X86Instruction::conditional_jump_immediate(0x82, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, RCX, R11, 0, None)); // vm_addr -= region.vm_addr
+            if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                emit_ins(jit, X86Instruction::load(OperandSize::S8, RAX, RCX, X86IndirectAccess::Offset(MemoryRegion::VM_GAP_SHIFT_OFFSET))); // RCX = region.vm_gap_shift;
+                emit_ins(jit, X86Instruction::mov(OperandSize::S64, R11, RDX)); // RDX = R11;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xd3, 5, RDX, 0, None)); // RDX = R11 >> region.vm_gap_shift;
+                emit_ins(jit, X86Instruction::test_immediate(OperandSize::S64, RDX, 1, None)); // (RDX & 1) != 0
+                emit_ins(jit, X86Instruction::conditional_jump_immediate(0x85, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
+                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, RDX, -1)); // RDX = -1;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xd3, 4, RDX, 0, None)); // gap_mask = -1 << region.vm_gap_shift;
+                emit_ins(jit, X86Instruction::mov(OperandSize::S64, RDX, RCX)); // RCX = RDX;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xf7, 2, RCX, 0, None)); // inverse_gap_mask = !gap_mask;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x21, R11, RCX, 0, None)); // below_gap = R11 & inverse_gap_mask;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x21, RDX, R11, 0, None)); // above_gap = R11 & gap_mask;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 5, R11, 1, None)); // above_gap >>= 1;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x09, RCX, R11, 0, None)); // gapped_offset = above_gap | below_gap;
+            }
+            emit_ins(jit, X86Instruction::lea(OperandSize::S64, R11, RCX, Some(X86IndirectAccess::Offset(*len)))); // RCX = R11 + len;
+            emit_ins(jit, X86Instruction::cmp(OperandSize::S64, RCX, RAX, Some(X86IndirectAccess::Offset(MemoryRegion::LEN_OFFSET)))); // region.len < R11 + len
+            emit_ins(jit, X86Instruction::conditional_jump_immediate(0x82, jit.relative_to_anchor(ANCHOR_MEMORY_ACCESS_VIOLATION + target_offset, 6)));
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x03, R11, RAX, 0, Some(X86IndirectAccess::Offset(MemoryRegion::HOST_ADDR_OFFSET)))); // R11 += region.host_addr;
+            if !jit.config.dynamic_stack_frames && jit.config.enable_stack_frame_gaps {
+                emit_ins(jit, X86Instruction::pop(RDX));
+            }
+            emit_ins(jit, X86Instruction::pop(RCX));
+            emit_ins(jit, X86Instruction::pop(RAX));
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, 8, None));
+            emit_ins(jit, X86Instruction::return_near());
+        }
+    }
+
+    #[inline]
+    fn emit_validate_instruction_count(jit: &mut JitCompilerCore, exclusive: bool, pc: Option<usize>) {
+        if let Some(pc) = pc {
+            jit.last_instruction_meter_validation_pc = pc;
+            emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, ARGUMENT_REGISTERS[0], pc as i64 + 1, None));
+        } else {
+            emit_ins(jit, X86Instruction::cmp(OperandSize::S64, R11, ARGUMENT_REGISTERS[0], None));
+        }
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(if exclusive { 0x82 } else { 0x86 }, jit.relative_to_anchor(ANCHOR_CALL_EXCEEDED_MAX_INSTRUCTIONS, 6)));
+    }
+
+    #[inline]
+    fn emit_profile_instruction_count(jit: &mut JitCompilerCore, target_pc: Option<usize>) {
+        match target_pc {
+            Some(target_pc) => {
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], target_pc as i64 - jit.pc as i64 - 1, None)); // instruction_meter += target_pc - (jit.pc + 1);
+            },
+            None => {
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 5, ARGUMENT_REGISTERS[0], jit.pc as i64 + 1, None)); // instruction_meter -= jit.pc + 1;
+                emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, R11, ARGUMENT_REGISTERS[0], jit.pc as i64, None)); // instruction_meter += target_pc;
+            },
+        }
+    }
+
+    fn fixup_text_jumps(jit: &mut JitCompilerCore) {
+        // Relocate forward jumps
+        for jump in &jit.text_section_jumps {
+            debug_assert!(jump.fixup_type == FixupType::JumpImm as u8);
+            let destination = jit.result.pc_section[jump.target_pc] as *const u8;
+            let offset_value =
+                unsafe { destination.offset_from(jump.location) } as i32 // Relative jump
+                - mem::size_of::<i32>() as i32; // Jump from end of instruction
+            unsafe { ptr::write_unaligned(jump.location as *mut i32, offset_value); }
+        }
+    }
+}
+
+const REGISTER_MAP: [u8; 11] = [
+    CALLER_SAVED_REGISTERS[0],
+    ARGUMENT_REGISTERS[1],
+    ARGUMENT_REGISTERS[2],
+    ARGUMENT_REGISTERS[3],
+    ARGUMENT_REGISTERS[4],
+    ARGUMENT_REGISTERS[5],
+    CALLEE_SAVED_REGISTERS[2],
+    CALLEE_SAVED_REGISTERS[3],
+    CALLEE_SAVED_REGISTERS[4],
+    CALLEE_SAVED_REGISTERS[5],
+    CALLEE_SAVED_REGISTERS[1],
+];
+
+// Special registers:
+//     ARGUMENT_REGISTERS[0]  RDI  BPF program counter limit (used by instruction meter)
+// CALLER_SAVED_REGISTERS[8]  R11  Scratch register
+// CALLER_SAVED_REGISTERS[7]  R10  Constant pointer to JitProgramArgument (also scratch register for exception handling)
+// CALLEE_SAVED_REGISTERS[0]  RBP  Constant pointer to initial RSP - 8
+
+#[inline]
+fn emit_sanitized_load_immediate(jit: &mut JitCompilerCore, size: OperandSize, destination: u8, value: i64) {
+    match size {
+        OperandSize::S32 => {
+            let key: i32 = jit.diversification_rng.gen();
+            emit_ins(jit, X86Instruction::load_immediate(size, destination, (value as i32).wrapping_sub(key) as i64));
+            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, key as i64, None));
+        },
+        OperandSize::S64 if destination == R11 => {
+            let key: i64 = jit.diversification_rng.gen();
+            let lower_key = key as i32 as i64;
+            let upper_key = (key >> 32) as i32 as i64;
+            emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(lower_key).rotate_right(32).wrapping_sub(upper_key)));
+            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, upper_key, None)); // wrapping_add(upper_key)
+            emit_ins(jit, X86Instruction::alu(size, 0xc1, 1, destination, 32, None)); // rotate_right(32)
+            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, lower_key, None)); // wrapping_add(lower_key)
+        },
+        OperandSize::S64 if value >= i32::MIN as i64 && value <= i32::MAX as i64 => {
+            let key = jit.diversification_rng.gen::<i32>() as i64;
+            emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(key)));
+            emit_ins(jit, X86Instruction::alu(size, 0x81, 0, destination, key, None));
+        },
+        OperandSize::S64 => {
+            let key: i64 = jit.diversification_rng.gen();
+            emit_ins(jit, X86Instruction::load_immediate(size, destination, value.wrapping_sub(key)));
+            emit_ins(jit, X86Instruction::load_immediate(size, R11, key));
+            emit_ins(jit, X86Instruction::alu(size, 0x01, R11, destination, 0, None));
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        }
+    }
+}
+
+#[inline]
+fn should_sanitize_constant(jit: &JitCompilerCore, value: i64) -> bool {
+    if !jit.config.sanitize_user_provided_values {
+        return false;
+    }
+
+    match value as u64 {
+        0xFFFF
+        | 0xFFFFFF
+        | 0xFFFFFFFF
+        | 0xFFFFFFFFFF
+        | 0xFFFFFFFFFFFF
+        | 0xFFFFFFFFFFFFFF
+        | 0xFFFFFFFFFFFFFFFF => false,
+        v if v <= 0xFF => false,
+        v if !v <= 0xFF => false,
+        _ => true
+    }
+}
+
+#[inline]
+fn emit_sanitized_alu(jit: &mut JitCompilerCore, size: OperandSize, opcode: u8, opcode_extension: u8, destination: u8, immediate: i64) {
+    if should_sanitize_constant(jit, immediate) {
+        emit_sanitized_load_immediate(jit, size, R11, immediate);
+        emit_ins(jit, X86Instruction::alu(size, opcode, R11, destination, immediate, None));
+    } else {
+        emit_ins(jit, X86Instruction::alu(size, 0x81, opcode_extension, destination, immediate, None));
+    }
+}
+
+#[inline]
+fn emit_undo_profile_instruction_count(jit: &mut JitCompilerCore, target_pc: usize) {
+    if jit.config.enable_instruction_meter {
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, ARGUMENT_REGISTERS[0], jit.pc as i64 + 1 - target_pc as i64, None)); // instruction_meter += (jit.pc + 1) - target_pc;
+    }
+}
+
+
+#[inline]
+fn emit_profile_instruction_count_finalize(jit: &mut JitCompilerCore, store_pc_in_exception: bool) {
+    if jit.config.enable_instruction_meter || store_pc_in_exception {
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, R11, 1, None)); // R11 += 1;
+    }
+    if jit.config.enable_instruction_meter {
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, R11, ARGUMENT_REGISTERS[0], 0, None)); // instruction_meter -= pc + 1;
+    }
+    if store_pc_in_exception {
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr))));
+        emit_ins(jit, X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(0), 1)); // is_err = true;
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, R11, ebpf::ELF_INSN_DUMP_OFFSET as i64 - 1, None));
+        emit_ins(jit, X86Instruction::store(OperandSize::S64, R11, R10, X86IndirectAccess::Offset(16))); // pc = jit.pc + ebpf::ELF_INSN_DUMP_OFFSET;
+    }
+}
+
+
+#[inline]
+fn emit_conditional_branch_reg(jit: &mut JitCompilerCore, op: u8, bitwise: bool, first_operand: u8, second_operand: u8, target_pc: usize) {
+    JitCompilerX86::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
+    if bitwise { // Logical
+        emit_ins(jit, X86Instruction::test(OperandSize::S64, first_operand, second_operand, None));
+    } else { // Arithmetic
+        emit_ins(jit, X86Instruction::cmp(OperandSize::S64, first_operand, second_operand, None));
+    }
+    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
+    let jump_offset = jit.relative_to_target_pc(target_pc, 6, FixupType::JumpImm as u8);
+    emit_ins(jit, X86Instruction::conditional_jump_immediate(op, jump_offset));
+    emit_undo_profile_instruction_count(jit, target_pc);
+}
+
+#[inline]
+fn emit_conditional_branch_imm(jit: &mut JitCompilerCore, op: u8, bitwise: bool, immediate: i64, second_operand: u8, target_pc: usize) {
+    JitCompilerX86::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc));
+    if should_sanitize_constant(jit, immediate) {
+        emit_sanitized_load_immediate(jit, OperandSize::S64, R11, immediate);
+        if bitwise { // Logical
+            emit_ins(jit, X86Instruction::test(OperandSize::S64, R11, second_operand, None));
+        } else { // Arithmetic
+            emit_ins(jit, X86Instruction::cmp(OperandSize::S64, R11, second_operand, None));
+        }
+    } else if bitwise { // Logical
+        emit_ins(jit, X86Instruction::test_immediate(OperandSize::S64, second_operand, immediate, None));
+    } else { // Arithmetic
+        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, second_operand, immediate, None));
+    }
+    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
+    let jump_offset = jit.relative_to_target_pc(target_pc, 6, FixupType::JumpImm as u8);
+    emit_ins(jit, X86Instruction::conditional_jump_immediate(op, jump_offset));
+    emit_undo_profile_instruction_count(jit, target_pc);
+}
+
+enum Value {
+    Register(u8),
+    RegisterIndirect(u8, i32, bool),
+    RegisterPlusConstant32(u8, i32, bool),
+    RegisterPlusConstant64(u8, i64, bool),
+    Constant64(i64, bool),
+}
+
+#[inline]
+fn emit_bpf_call(jit: &mut JitCompilerCore, dst: Value) {
+    // Store PC in case the bounds check fails
+    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+
+    emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_BPF_CALL_PROLOGUE, 5)));
+
+    match dst {
+        Value::Register(reg) => {
+            // Move vm target_address into RAX
+            emit_ins(jit, X86Instruction::push(REGISTER_MAP[0], None));
+            if reg != REGISTER_MAP[0] {
+                emit_ins(jit, X86Instruction::mov(OperandSize::S64, reg, REGISTER_MAP[0]));
+            }
+
+            emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(ANCHOR_BPF_CALL_REG, 5)));
+
+            JitCompilerX86::emit_validate_and_profile_instruction_count(jit, false, None);
+            emit_ins(jit, X86Instruction::mov(OperandSize::S64, REGISTER_MAP[0], R11)); // Save target_pc
+            emit_ins(jit, X86Instruction::pop(REGISTER_MAP[0])); // Restore RAX
+            emit_ins(jit, X86Instruction::call_reg(R11, None)); // callq *%r11
+        },
+        Value::Constant64(target_pc, user_provided) => {
+            debug_assert!(!user_provided);
+            JitCompilerX86::emit_validate_and_profile_instruction_count(jit, false, Some(target_pc as usize));
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, target_pc as i64));
+            let jump_offset = jit.relative_to_target_pc(target_pc as usize, 5, FixupType::JumpImm as u8);
+            emit_ins(jit, X86Instruction::call_immediate(jump_offset));
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        }
+    }
+
+    emit_undo_profile_instruction_count(jit, 0);
+
+    // Restore the previous frame pointer
+    emit_ins(jit, X86Instruction::pop(REGISTER_MAP[FRAME_PTR_REG]));
+    let frame_ptr_access = X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::BpfFramePtr));
+    emit_ins(jit, X86Instruction::store(OperandSize::S64, REGISTER_MAP[FRAME_PTR_REG], RBP, frame_ptr_access));
+    for reg in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).rev() {
+        emit_ins(jit, X86Instruction::pop(*reg));
+    }
+}
+
+struct Argument {
+    index: usize,
+    value: Value,
+}
+
+// Restores: all registers
+fn emit_rust_call(jit: &mut JitCompilerCore, dst: Value, arguments: &[Argument], result_reg: Option<u8>, check_exception: bool) {
+    let mut saved_registers = CALLER_SAVED_REGISTERS.to_vec();
+    if let Some(reg) = result_reg {
+        let dst = saved_registers.iter().position(|x| *x == reg);
+        debug_assert!(dst.is_some());
+        if let Some(dst) = dst {
+            saved_registers.remove(dst);
+        }
+    }
+
+    // Save registers on stack
+    for reg in saved_registers.iter() {
+        emit_ins(jit, X86Instruction::push(*reg, None));
+    }
+
+    // Pass arguments
+    let mut stack_arguments = 0;
+    for argument in arguments {
+        let is_stack_argument = argument.index >= ARGUMENT_REGISTERS.len();
+        let dst = if is_stack_argument {
+            stack_arguments += 1;
+            R11
+        } else {
+            ARGUMENT_REGISTERS[argument.index]
+        };
+        match argument.value {
+            Value::Register(reg) => {
+                if is_stack_argument {
+                    emit_ins(jit, X86Instruction::push(reg, None));
+                } else if reg != dst {
+                    emit_ins(jit, X86Instruction::mov(OperandSize::S64, reg, dst));
+                }
+            },
+            Value::RegisterIndirect(reg, offset, user_provided) => {
+                debug_assert!(!user_provided);
+                if is_stack_argument {
+                    emit_ins(jit, X86Instruction::push(reg, Some(X86IndirectAccess::Offset(offset))));
+                } else {
+                    emit_ins(jit, X86Instruction::load(OperandSize::S64, reg, dst, X86IndirectAccess::Offset(offset)));
+                }
+            },
+            Value::RegisterPlusConstant32(reg, offset, user_provided) => {
+                debug_assert!(!user_provided);
+                if is_stack_argument {
+                    emit_ins(jit, X86Instruction::push(reg, None));
+                    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, offset as i64, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))));
+                } else {
+                    emit_ins(jit, X86Instruction::lea(OperandSize::S64, reg, dst, Some(X86IndirectAccess::Offset(offset))));
+                }
+            },
+            Value::RegisterPlusConstant64(reg, offset, user_provided) => {
+                debug_assert!(!user_provided);
+                if is_stack_argument {
+                    emit_ins(jit, X86Instruction::push(reg, None));
+                    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, offset, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))));
+                } else {
+                    emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, dst, offset));
+                    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, reg, dst, 0, None));
+                }
+            },
+            Value::Constant64(value, user_provided) => {
+                debug_assert!(!user_provided && !is_stack_argument);
+                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, dst, value));
+            },
+        }
+    }
+
+    match dst {
+        Value::Register(reg) => {
+            emit_ins(jit, X86Instruction::call_reg(reg, None));
+        },
+        Value::Constant64(value, user_provided) => {
+            debug_assert!(!user_provided);
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, RAX, value));
+            emit_ins(jit, X86Instruction::call_reg(RAX, None));
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        }
+    }
+
+    // Save returned value in result register
+    if let Some(reg) = result_reg {
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, RAX, reg));
+    }
+
+    // Restore registers from stack
+    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RSP, stack_arguments * 8, None));
+    for reg in saved_registers.iter().rev() {
+        emit_ins(jit, X86Instruction::pop(*reg));
+    }
+
+    if check_exception {
+        // Test if result indicates that an error occured
+        emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R11, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr))));
+        emit_ins(jit, X86Instruction::cmp_immediate(OperandSize::S64, R11, 0, Some(X86IndirectAccess::Offset(0))));
+    }
+}
+
+
+#[inline]
+fn emit_address_translation(jit: &mut JitCompilerCore, host_addr: u8, vm_addr: Value, len: u64, access_type: AccessType) {
+    match vm_addr {
+        Value::RegisterPlusConstant64(reg, constant, user_provided) => {
+            if user_provided && should_sanitize_constant(jit, constant) {
+                emit_sanitized_load_immediate(jit, OperandSize::S64, R11, constant);
+            } else {
+                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, constant));
+            }
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, reg, R11, 0, None));
+        },
+        Value::Constant64(constant, user_provided) => {
+            if user_provided && should_sanitize_constant(jit, constant) {
+                emit_sanitized_load_immediate(jit, OperandSize::S64, R11, constant);
+            } else {
+                emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, constant));
+            }
+        },
+        _ => {
+            #[cfg(debug_assertions)]
+            unreachable!();
+        },
+    }
+    let anchor = ANCHOR_TRANSLATE_MEMORY_ADDRESS + len.trailing_zeros() as usize + 4 * (access_type as usize);
+    emit_ins(jit, X86Instruction::call_immediate(jit.relative_to_anchor(anchor, 5)));
+    emit_ins(jit, X86Instruction::mov(OperandSize::S64, R11, host_addr));
+}
+
+fn emit_shift(jit: &mut JitCompilerCore, size: OperandSize, opcode_extension: u8, source: u8, destination: u8, immediate: Option<i64>) {
+    if let Some(immediate) = immediate {
+        if should_sanitize_constant(jit, immediate) {
+            emit_sanitized_load_immediate(jit, OperandSize::S32, source, immediate);
+        } else {
+            emit_ins(jit, X86Instruction::alu(size, 0xc1, opcode_extension, destination, immediate, None));
+            return;
+        }
+    }
+    if let OperandSize::S32 = size {
+        emit_ins(jit, X86Instruction::alu(OperandSize::S32, 0x81, 4, destination, -1, None)); // Mask to 32 bit
+    }
+    if source == RCX {
+        if destination == RCX {
+            emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, destination, 0, None));
+        } else {
+            emit_ins(jit, X86Instruction::push(RCX, None));
+            emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, destination, 0, None));
+            emit_ins(jit, X86Instruction::pop(RCX));
+        }
+    } else if destination == RCX {
+        if source != R11 {
+            emit_ins(jit, X86Instruction::push(source, None));
+        }
+        emit_ins(jit, X86Instruction::xchg(OperandSize::S64, source, RCX, None));
+        emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, source, 0, None));
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, source, RCX));
+        if source != R11 {
+            emit_ins(jit, X86Instruction::pop(source));
+        }
+    } else {
+        emit_ins(jit, X86Instruction::push(RCX, None));
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, source, RCX));
+        emit_ins(jit, X86Instruction::alu(size, 0xd3, opcode_extension, destination, 0, None));
+        emit_ins(jit, X86Instruction::pop(RCX));
+    }
+}
+
+fn emit_muldivmod(jit: &mut JitCompilerCore, opc: u8, src: u8, dst: u8, imm: Option<i64>) {
+    let mul = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MUL32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let div = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::DIV32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let sdiv = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::SDIV32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let modrm = (opc & ebpf::BPF_ALU_OP_MASK) == (ebpf::MOD32_IMM & ebpf::BPF_ALU_OP_MASK);
+    let size = if (opc & ebpf::BPF_CLS_MASK) == ebpf::BPF_ALU64 { OperandSize::S64 } else { OperandSize::S32 };
+
+    if !mul && imm.is_none() {
+        // Save pc
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+        emit_ins(jit, X86Instruction::test(size, src, src, None)); // src == 0
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x84, jit.relative_to_anchor(ANCHOR_DIV_BY_ZERO, 6)));
+    }
+
+    // sdiv overflows with MIN / -1. If we have an immediate and it's not -1, we
+    // don't need any checks.
+    if sdiv && imm.unwrap_or(-1) == -1 {
+        emit_ins(jit, X86Instruction::load_immediate(size, R11, if let OperandSize::S64 = size { i64::MIN } else { i32::MIN as i64 }));
+        emit_ins(jit, X86Instruction::cmp(size, dst, R11, None)); // dst == MIN
+
+        if imm.is_none() {
+            // The exception case is: dst == MIN && src == -1
+            // Via De Morgan's law becomes: !(dst != MIN || src != -1)
+            // Also, we know that src != 0 in here, so we can use it to set R11 to something not zero
+            emit_ins(jit, X86Instruction::load_immediate(size, R11, 0)); // No XOR here because we need to keep the status flags
+            emit_ins(jit, X86Instruction::cmov(size, 0x45, src, R11)); // if dst != MIN { r11 = src; }
+            emit_ins(jit, X86Instruction::cmp_immediate(size, src, -1, None)); // src == -1
+            emit_ins(jit, X86Instruction::cmov(size, 0x45, src, R11)); // if src != -1 { r11 = src; }
+            emit_ins(jit, X86Instruction::test(size, R11, R11, None)); // r11 == 0
+        }
+
+        // MIN / -1, raise EbpfError::DivideOverflow(pc)
+        emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, jit.pc as i64));
+        emit_ins(jit, X86Instruction::conditional_jump_immediate(0x84, jit.relative_to_anchor(ANCHOR_DIV_OVERFLOW, 6)));
+    }
+
+    if dst != RAX {
+        emit_ins(jit, X86Instruction::push(RAX, None));
+    }
+    if dst != RDX {
+        emit_ins(jit, X86Instruction::push(RDX, None));
+    }
+
+    if let Some(imm) = imm {
+        if should_sanitize_constant(jit, imm) {
+            emit_sanitized_load_immediate(jit, OperandSize::S64, R11, imm);
+        } else {
+            emit_ins(jit, X86Instruction::load_immediate(OperandSize::S64, R11, imm));
+        }
+    } else {
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, src, R11));
+    }
+
+    if dst != RAX {
+        emit_ins(jit, X86Instruction::mov(OperandSize::S64, dst, RAX));
+    }
+
+    if div || modrm {
+        emit_ins(jit, X86Instruction::alu(size, 0x31, RDX, RDX, 0, None)); // RDX = 0
+    } else if sdiv {
+        emit_ins(jit, X86Instruction::dividend_sign_extension(size)); // (RAX, RDX) = RAX as i128
+    }
+
+    emit_ins(jit, X86Instruction::alu(size, 0xf7, if mul { 4 } else if sdiv { 7 } else { 6 }, R11, 0, None));
+
+    if dst != RDX {
+        if modrm {
+            emit_ins(jit, X86Instruction::mov(OperandSize::S64, RDX, dst));
+        }
+        emit_ins(jit, X86Instruction::pop(RDX));
+    }
+    if dst != RAX {
+        if !modrm {
+            emit_ins(jit, X86Instruction::mov(OperandSize::S64, RAX, dst));
+        }
+        emit_ins(jit, X86Instruction::pop(RAX));
+    }
+
+    if let OperandSize::S32 = size {
+        if mul || sdiv {
+            emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, 0, None)); // sign extend i32 to i64
+        }
+    }
+}
+
+
+#[inline]
+fn emit_set_exception_kind<E: UserDefinedError>(jit: &mut JitCompilerCore, err: EbpfError<E>) {
+    let err = Result::<u64, EbpfError<E>>::Err(err);
+    let err_kind = unsafe { *(&err as *const _ as *const u64).offset(1) };
+    emit_ins(jit, X86Instruction::load(OperandSize::S64, RBP, R10, X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::OptRetValPtr))));
+    emit_ins(jit, X86Instruction::store_immediate(OperandSize::S64, R10, X86IndirectAccess::Offset(8), err_kind as i64));
+}
+
+#[allow(dead_code)]
+#[inline]
+fn emit_stopwatch(jit: &mut JitCompilerCore, begin: bool) {
+    jit.stopwatch_is_active = true;
+    emit_ins(jit, X86Instruction::push(RDX, None));
+    emit_ins(jit, X86Instruction::push(RAX, None));
+    emit_ins(jit, X86Instruction::fence(FenceType::Load)); // lfence
+    emit_ins(jit, X86Instruction::cycle_count()); // rdtsc
+    emit_ins(jit, X86Instruction::fence(FenceType::Load)); // lfence
+    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0xc1, 4, RDX, 32, None)); // RDX <<= 32;
+    emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x09, RDX, RAX, 0, None)); // RAX |= RDX;
+    if begin {
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x29, RAX, RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::StopwatchNumerator))))); // *numerator -= RAX;
+    } else {
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x01, RAX, RBP, 0, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::StopwatchNumerator))))); // *numerator += RAX;
+        emit_ins(jit, X86Instruction::alu(OperandSize::S64, 0x81, 0, RBP, 1, Some(X86IndirectAccess::Offset(slot_on_environment_stack(jit, EnvironmentStackSlotX86::StopwatchDenominator))))); // *denominator += 1;
+    }
+    emit_ins(jit, X86Instruction::pop(RAX));
+    emit_ins(jit, X86Instruction::pop(RDX));
+}
+
+// This function helps the optimizer to inline the machinecode emission while avoiding stack allocations
+#[inline(always)]
+pub fn emit_ins(jit: &mut JitCompilerCore, instruction: X86Instruction) {
+    instruction.emit(jit);
+    if jit.next_noop_insertion == 0 {
+        jit.next_noop_insertion = jit.diversification_rng.gen_range(0..jit.config.noop_instruction_rate * 2);
+        // X86Instruction::noop().emit(jit)?;
+        emit::<u8>(jit, 0x90);
+    } else {
+        jit.next_noop_insertion -= 1;
+    }
+}
+
+enum FixupType {
+    JumpImm = 0
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+#[repr(C)]
+pub enum EnvironmentStackSlotX86 {
+    /// The 6 CALLEE_SAVED_REGISTERS
+    LastSavedRegister = 5,
+    /// The current call depth.
+    ///
+    /// Incremented on calls and decremented on exits. It's used to enforce
+    /// config.max_call_depth and to know when to terminate execution.
+    CallDepth = 6,
+    /// BPF frame pointer (REGISTER_MAP[FRAME_PTR_REG]).
+    BpfFramePtr = 7,
+    /// The BPF stack pointer (r11). Only used when config.dynamic_stack_frames=true.
+    ///
+    /// The stack pointer isn't exposed as an actual register. Only sub and add
+    /// instructions (typically generated by the LLVM backend) are allowed to
+    /// access it. Its value is only stored in this slot and therefore the
+    /// register is not tracked in REGISTER_MAP.
+    BpfStackPtr = 8,
+    /// Constant pointer to optional typed return value
+    OptRetValPtr = 9,
+    /// Last return value of instruction_meter.get_remaining()
+    PrevInsnMeter = 10,
+    /// Constant pointer to instruction_meter
+    InsnMeterPtr = 11,
+    /// CPU cycles accumulated by the stop watch
+    StopwatchNumerator = 12,
+    /// Number of times the stop watch was used
+    StopwatchDenominator = 13,
+    /// Bumper for size_of
+    SlotCount = 14,
+}
+
+pub fn slot_on_environment_stack(jit: &JitCompilerCore, slot: EnvironmentStackSlotX86) -> i32 {
+    -8 * (slot as i32 + jit.environment_stack_key)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ extern crate rand;
 extern crate thiserror;
 
 pub mod aligned_memory;
+mod arm64;
 mod asm_parser;
 pub mod assembler;
 pub mod call_frames;
@@ -35,6 +36,8 @@ pub mod fuzz;
 pub mod insn_builder;
 pub mod interpreter;
 mod jit;
+mod jit_arm64;
+mod jit_x86;
 pub mod memory_region;
 pub mod static_analysis;
 pub mod syscalls;

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
-use crate::jit::{emit, emit_variable_length, JitCompiler, OperandSize};
+use crate::jit::{emit, emit_variable_length, JitCompilerCore, OperandSize};
 
 pub const RAX: u8 = 0;
 pub const RCX: u8 = 1;
@@ -58,6 +58,8 @@ pub enum X86IndirectAccess {
     /// [second_operand + offset]
     Offset(i32),
     /// [second_operand + offset + index << shift]
+    /// NOTE: this is fragile and some values for index have a special meaning in the instruction
+    /// encodings.
     OffsetIndexShift(i32, u8, u8),
 }
 
@@ -99,7 +101,7 @@ impl X86Instruction {
     };
 
     #[inline]
-    pub fn emit(&self, jit: &mut JitCompiler) {
+    pub fn emit(&self, jit: &mut JitCompilerCore) {
         debug_assert!(!matches!(self.size, OperandSize::S0));
         let mut rex = X86Rex {
             w: matches!(self.size, OperandSize::S64),

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -12,7 +12,7 @@ extern crate test_utils;
 extern crate thiserror;
 
 use byteorder::{ByteOrder, LittleEndian};
-#[cfg(all(not(windows), target_arch = "x86_64"))]
+#[cfg(all(not(windows), any(target_arch = "x86_64", target_arch = "aarch64")))]
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use solana_rbpf::{
     assembler::assemble,
@@ -61,7 +61,7 @@ macro_rules! test_interpreter_and_jit {
             assert!(check_closure(&vm, result));
             (vm.get_total_instruction_count(), vm.get_tracer().clone())
         };
-        #[cfg(all(not(windows), target_arch = "x86_64"))]
+        #[cfg(all(not(windows), any(target_arch = "x86_64", target_arch = "aarch64")))]
         {
             #[allow(unused_mut)]
             let mut check_closure = $check;
@@ -4160,7 +4160,7 @@ fn test_tcp_sack_nomatch() {
 
 // Fuzzy
 
-#[cfg(all(not(windows), target_arch = "x86_64"))]
+#[cfg(all(not(windows), any(target_arch = "x86_64", target_arch = "aarch64")))]
 fn execute_generated_program(prog: &[u8]) -> bool {
     let max_instruction_count = 1024;
     let mem_size = 1024 * 1024;
@@ -4250,7 +4250,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     true
 }
 
-#[cfg(all(not(windows), target_arch = "x86_64"))]
+#[cfg(all(not(windows), any(target_arch = "x86_64", target_arch = "aarch64")))]
 #[test]
 fn test_total_chaos() {
     let instruction_count = 6;


### PR DESCRIPTION
This contribution is on behalf of Trail of Bits.

This adds support for aarch64 code generation to the JIT. This refactors the architecture-specific code emission parts of the existing x86 JIT into a new JitCompilerX86 struct, which adopts a new JitCompilerImpl trait. 

The aarch64 JIT was modeled closely after the x86 JIT. Although all tests pass, the new aarch64 JIT is **not** ready for production use, and is gated behind a feature flag: `jit-aarch64-not-safe-for-production`.
