### PR TITLE
aligned_memory: use calloc to get zeroed memory

### DIFF
--- a/src/call_frames.rs
+++ b/src/call_frames.rs
@@ -33,8 +33,7 @@ impl<'a> CallFrames<'a> {
     /// New call frame, depth indicates maximum call depth
     pub fn new(config: &'a Config) -> Self {
         let stack_len = config.stack_size();
-        let mut stack = AlignedMemory::new(stack_len);
-        stack.resize(stack_len, 0).unwrap();
+        let stack = AlignedMemory::new_with_size(stack_len);
 
         let mut frames = CallFrames {
             config,


### PR DESCRIPTION
Use `calloc()` instead of using `malloc()` + `memset()`. The former gets zeroed memory straight from the OS, avoids writing the memory twice (once to clear old content, once to zero it) and avoids actually paging in the whole new allocation due to `memset`. See https://github.com/rust-lang/rust/issues/54628.

In practical terms, this halves memset usage while executing transactions, eliminating a frequente largeish memset in `CallFrames::new`.

Before:
<img width="791" alt="Screen Shot 2022-07-22 at 9 53 09 am" src="https://user-images.githubusercontent.com/62002/180402711-d9c6610c-96b8-466b-ac09-faf15b2cd0ce.png">

After:
<img width="756" alt="Screen Shot 2022-07-22 at 9 53 22 am" src="https://user-images.githubusercontent.com/62002/180402766-c599ac81-90c0-4dbf-abf1-c822bb83388c.png">

You can see that `memset_avx2_erms` is cut in half, and `CallFrames::new()` no longer shows up in profiles. (As for the other memsets, we'll probably be able to remove them when we implement unaligned memory mapping) 
