### PR TITLE
Refactor the way memory mapping, syscalls and instruction tracer are passed to programs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,9 @@ pub enum EbpfError<E: UserDefinedError> {
     /// Syscall already has a bound context object
     #[error("syscall #{0} already has a bound context object")]
     SyscallAlreadyBound(usize),
+    /// Too many syscalls, increase SyscallRegistry::MAX_SYSCALLS.
+    #[error("too many syscalls")]
+    TooManySyscalls,
     /// Exceeded max BPF to BPF call depth
     #[error("exceeded max BPF to BPF call depth of {1} at instruction #{0}")]
     CallDepthExceeded(usize, usize),

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -4199,7 +4199,7 @@ fn test_err_discriminant_size() {
 
         // Check that all 64-bits of the discriminant were changed
         let err_kind = *(&test_err as *const _ as *const u64);
-        assert_eq!(err_kind, 7u64);
+        assert_eq!(err_kind, 8u64);
     }
 }
 


### PR DESCRIPTION
Use a concrete type (ProgramEnvironment) instead opaquely storing everything in a vector.