### PR TITLE
Allow one pass memory allocation for AlignedMemory

### DIFF
--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -1,108 +1,119 @@
 #![allow(clippy::integer_arithmetic)]
 //! Aligned memory
 
+use std::alloc;
 use std::mem;
 
 /// Provides u8 slices at a specified alignment
 #[derive(Debug, PartialEq, Eq)]
 pub struct AlignedMemory<const ALIGN: usize> {
     max_len: usize,
-    align_offset: usize,
     mem: Vec<u8>,
     zero_up_to_max_len: bool,
 }
 
 impl<const ALIGN: usize> AlignedMemory<ALIGN> {
-    fn get_mem(max_len: usize) -> (Vec<u8>, usize) {
-        let mut mem: Vec<u8> = Vec::with_capacity(max_len + ALIGN);
-        mem.push(0);
-        let align_offset = mem.as_ptr().align_offset(ALIGN);
-        mem.resize(align_offset, 0);
-        (mem, align_offset)
+    fn get_mem(max_len: usize) -> Vec<u8> {
+        unsafe {
+            let layout = alloc::Layout::from_size_align(max_len, ALIGN).unwrap();
+            let ptr = alloc::alloc_zeroed(layout);
+            Vec::from_raw_parts(ptr, 0, max_len)
+        }
     }
-    fn get_mem_zeroed(max_len: usize) -> (Vec<u8>, usize) {
+
+    fn get_mem_zeroed(max_len: usize) -> Vec<u8> {
         // use calloc() to get zeroed memory from the OS instead of using
         // malloc() + memset(), see
         // https://github.com/rust-lang/rust/issues/54628
-        let mut mem = vec![0; max_len];
-        let align_offset = mem.as_ptr().align_offset(ALIGN);
-        mem.resize(align_offset + max_len, 0);
-        (mem, align_offset)
+        unsafe {
+            let layout = alloc::Layout::from_size_align(max_len, ALIGN).unwrap();
+            let ptr = alloc::alloc_zeroed(layout);
+            Vec::from_raw_parts(ptr, max_len, max_len)
+        }
     }
+
     /// Returns a filled AlignedMemory by copying the given slice
     pub fn from_slice(data: &[u8]) -> Self {
         let max_len = data.len();
-        let (mut mem, align_offset) = Self::get_mem(max_len);
+        let mut mem = Self::get_mem(max_len);
         mem.extend_from_slice(data);
         Self {
             max_len,
-            align_offset,
             mem,
             zero_up_to_max_len: false,
         }
     }
+
     /// Returns a new empty AlignedMemory with uninitialized preallocated memory
     pub fn with_capacity(max_len: usize) -> Self {
-        let (mem, align_offset) = Self::get_mem(max_len);
+        let mem = Self::get_mem(max_len);
         Self {
             max_len,
-            align_offset,
             mem,
             zero_up_to_max_len: false,
         }
     }
+
     /// Returns a new empty AlignedMemory with zero initialized preallocated memory
     pub fn with_capacity_zeroed(max_len: usize) -> Self {
-        let (mut mem, align_offset) = Self::get_mem_zeroed(max_len);
-        mem.truncate(align_offset);
+        let mut mem = Self::get_mem_zeroed(max_len);
+        mem.truncate(0);
         Self {
             max_len,
-            align_offset,
             mem,
             zero_up_to_max_len: true,
         }
     }
+
     /// Returns a new filled AlignedMemory with zero initialized preallocated memory
     pub fn zero_filled(max_len: usize) -> Self {
-        let (mem, align_offset) = Self::get_mem_zeroed(max_len);
+        let mem = Self::get_mem_zeroed(max_len);
         Self {
             max_len,
-            align_offset,
             mem,
             zero_up_to_max_len: true,
         }
     }
+
     /// Calculate memory size
+    #[inline(always)]
     pub fn mem_size(&self) -> usize {
         mem::size_of::<Self>() + self.mem.capacity()
     }
+
     /// Get the length of the data
+    #[inline(always)]
     pub fn len(&self) -> usize {
-        self.mem.len() - self.align_offset
+        self.mem.len()
     }
+
     /// Is the memory empty
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.mem.len() - self.align_offset == 0
+        self.mem.len() == 0
     }
+
     /// Get the current write index
+    #[inline(always)]
     pub fn write_index(&self) -> usize {
         self.mem.len()
     }
+
     /// Get an aligned slice
+    #[inline(always)]
     pub fn as_slice(&self) -> &[u8] {
-        let start = self.align_offset;
-        let end = self.mem.len();
-        &self.mem[start..end]
+        self.mem.as_slice()
     }
+
     /// Get an aligned mutable slice
+    #[inline(always)]
     pub fn as_slice_mut(&mut self) -> &mut [u8] {
-        let start = self.align_offset;
-        let end = self.mem.len();
-        &mut self.mem[start..end]
+        self.mem.as_mut_slice()
     }
+
     /// Grows memory with `value` repeated `num` times starting at the `write_index`
     pub fn fill_write(&mut self, num: usize, value: u8) -> std::io::Result<()> {
-        if self.mem.len() + num > self.align_offset + self.max_len {
+        if self.mem.len() + num > self.max_len {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "aligned memory resize failed",
@@ -131,7 +142,7 @@ impl<const ALIGN: usize> Clone for AlignedMemory<ALIGN> {
 
 impl<const ALIGN: usize> std::io::Write for AlignedMemory<ALIGN> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if self.mem.len() + buf.len() > self.align_offset + self.max_len {
+        if self.mem.len() + buf.len() > self.max_len {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "aligned memory write failed",
@@ -140,6 +151,7 @@ impl<const ALIGN: usize> std::io::Write for AlignedMemory<ALIGN> {
         self.mem.extend_from_slice(buf);
         Ok(buf.len())
     }
+
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2143,6 +2143,6 @@ mod test {
             Executable::jit_compile(&mut executable).unwrap();
         }
 
-        assert_eq!(18656, executable.mem_size());
+        assert_eq!(18624, executable.mem_size());
     }
 }

--- a/src/elf_parser_glue.rs
+++ b/src/elf_parser_glue.rs
@@ -425,7 +425,7 @@ impl<'a> ElfParser<'a> for NewParser<'a> {
         self.elf
             .symbol_table()
             .ok()
-            .and_then(|syms| syms.map(|syms| (&syms[index]).clone()))
+            .and_then(|syms| syms.map(|syms| (syms[index]).clone()))
     }
 
     fn symbol_name(&self, st_name: Elf64Word) -> Option<&str> {


### PR DESCRIPTION
This pull request improves `AlignedMemory` and allows it to allocate memory in one pass instead of a possible `Vec` resizing in the previous approach. As a result there's also no need to keep `align_offset` and perform all the offset calculations.

P.S.: One of the tests in `elf.rs` is fixed to reflect the reduced size of `AlignedMemory`.