### PR TITLE
Fix #355: Do not use `PhantomData` if the JIT feature is active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "byteorder"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +87,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c95766e0414f8bfc1d07055574c621b67739466d6ba516c4fef8e99d30d2e6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,10 +153,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "plain"
@@ -226,6 +273,7 @@ dependencies = [
  "byteorder 1.4.3",
  "combine",
  "elf",
+ "gdbstub",
  "goblin",
  "hash32",
  "json",

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -26,10 +26,11 @@ use crate::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
+#[cfg(not(feature = "jit"))]
+use std::marker::PhantomData;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::Debug,
-    marker::PhantomData,
     mem,
     ops::Range,
     str,
@@ -274,7 +275,8 @@ pub struct Executable<E: UserDefinedError, I: InstructionMeter> {
     /// Compiled program and argument
     #[cfg(feature = "jit")]
     compiled_program: Option<JitProgram<E, I>>,
-    _marker: PhantomData<Box<(E, I)>>,
+    #[cfg(not(feature = "jit"))]
+    _marker: PhantomData<(E, I)>,
 }
 
 impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
@@ -397,6 +399,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
             syscall_registry,
             #[cfg(feature = "jit")]
             compiled_program: None,
+            #[cfg(not(feature = "jit"))]
             _marker: PhantomData,
         }
     }
@@ -520,6 +523,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
             syscall_registry,
             #[cfg(feature = "jit")]
             compiled_program: None,
+            #[cfg(not(feature = "jit"))]
             _marker: PhantomData,
         })
     }


### PR DESCRIPTION
As that breaks the Sync trait.
Also, updates `Cargo.lock` for the added `gdbstub`.