### PR TITLE
Cleanup - Turn `Pin<Box<Executable<E, I>>>` back to `Executable<E, I>`

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -22,10 +22,7 @@ use crate::{
     error::UserDefinedError,
     vm::{Config, InstructionMeter, SyscallRegistry},
 };
-use std::{
-    collections::{BTreeMap, HashMap},
-    pin::Pin,
-};
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum InstructionType {
@@ -222,7 +219,7 @@ pub fn assemble<E: UserDefinedError, I: 'static + InstructionMeter>(
     src: &str,
     config: Config,
     syscall_registry: SyscallRegistry,
-) -> Result<Pin<Box<Executable<E, I>>>, String> {
+) -> Result<Executable<E, I>, String> {
     fn resolve_label(
         insn_ptr: usize,
         labels: &HashMap<&str, usize>,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -25,6 +25,8 @@ use crate::{
     vm::{Config, InstructionMeter, SyscallRegistry},
 };
 
+#[cfg(feature = "jit")]
+use crate::jit::JitProgram;
 use byteorder::{ByteOrder, LittleEndian};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
@@ -34,8 +36,6 @@ use std::{
     ops::Range,
     str,
 };
-#[cfg(feature = "jit")]
-use {crate::jit::JitProgram, std::pin::Pin};
 
 /// Error definitions
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -350,8 +350,7 @@ impl<E: UserDefinedError, I: InstructionMeter> Executable<E, I> {
 
     /// JIT compile the executable
     #[cfg(feature = "jit")]
-    pub fn jit_compile(executable: &mut Pin<Box<Self>>) -> Result<(), EbpfError<E>> {
-        // TODO: Turn back to `executable: &mut self` once Self::report_unresolved_symbol() is gone
+    pub fn jit_compile(executable: &mut Self) -> Result<(), EbpfError<E>> {
         executable.compiled_program = Some(JitProgram::<E, I>::new(executable)?);
         Ok(())
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -20,7 +20,7 @@ use std::{
     fmt::{Debug, Error as FormatterError, Formatter},
     mem,
     ops::{Index, IndexMut},
-    pin::Pin, ptr,
+    ptr,
 };
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 
@@ -163,7 +163,7 @@ impl<E: UserDefinedError, I: InstructionMeter> PartialEq for JitProgram<E, I> {
 }
 
 impl<E: UserDefinedError, I: InstructionMeter> JitProgram<E, I> {
-    pub fn new(executable: &Pin<Box<Executable<E, I>>>) -> Result<Self, EbpfError<E>> {
+    pub fn new(executable: &Executable<E, I>) -> Result<Self, EbpfError<E>> {
         let program = executable.get_text_bytes().1;
         let mut jit = JitCompiler::new::<E>(program, executable.get_config())?;
         jit.compile::<E, I>(executable)?;
@@ -963,7 +963,7 @@ impl JitCompiler {
     }
 
     fn compile<E: UserDefinedError, I: InstructionMeter>(&mut self,
-            executable: &Pin<Box<Executable<E, I>>>) -> Result<(), EbpfError<E>> {
+            executable: &Executable<E, I>) -> Result<(), EbpfError<E>> {
         let text_section_base = self.result.text_section.as_ptr();
         let (program_vm_addr, program) = executable.get_text_bytes();
         self.program_vm_addr = program_vm_addr;
@@ -1299,7 +1299,7 @@ impl JitCompiler {
         Ok(())
     }
 
-    fn generate_prologue<E: UserDefinedError, I: InstructionMeter>(&mut self, executable: &Pin<Box<Executable<E, I>>>) -> Result<(), EbpfError<E>> {
+    fn generate_prologue<E: UserDefinedError, I: InstructionMeter>(&mut self, executable: &Executable<E, I>) -> Result<(), EbpfError<E>> {
         // Place the environment on the stack according to EnvironmentStackSlot
 
         // Save registers
@@ -1742,7 +1742,7 @@ mod tests {
     use std::collections::BTreeMap;
     use byteorder::{LittleEndian, ByteOrder};
 
-    fn create_mockup_executable(program: &[u8]) -> Pin<Box<Executable::<UserError, TestInstructionMeter>>> {
+    fn create_mockup_executable(program: &[u8]) -> Executable::<UserError, TestInstructionMeter> {
         let config = Config {
             noop_instruction_rate: 0,
             ..Config::default()


### PR DESCRIPTION
Solves:
> // TODO: Turn back to `executable: &mut self` once Self::report_unresolved_symbol() is gone