### PR TITLE
Lookup BPF function only if its not a syscall

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -464,7 +464,7 @@ impl<'a, 'b, V: Verifier, E: UserDefinedError, I: InstructionMeter> Interpreter<
                     }
                 }
 
-                if calls {
+                if calls && !resolved {
                     if let Some(target_pc) = executable.lookup_bpf_function(insn.imm as u32) {
                         resolved = true;
 


### PR DESCRIPTION
`CALL_IMM` handling in interpreter looks up syscall as well as bpf_function tables (when `static_syscalls` feature is not active). This could be optimized by not looking up bpf_function table if the syscall was already resolved.

This PR updates the condition when the bpf_function table is looked up.