### PR TITLE
Refactor - Stop hashing when static syscalls is active

### DIFF
--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -6,7 +6,7 @@
 
 extern crate solana_rbpf;
 use solana_rbpf::{
-    elf::{register_bpf_function, Executable},
+    elf::Executable,
     static_analysis::Analysis,
     vm::{Config, SyscallRegistry, TestInstructionMeter},
 };
@@ -32,15 +32,7 @@ fn main() {
     ];
     let syscall_registry = SyscallRegistry::default();
     let config = Config::default();
-    let mut bpf_functions = BTreeMap::new();
-    register_bpf_function(
-        &config,
-        &mut bpf_functions,
-        &syscall_registry,
-        0,
-        "entrypoint",
-    )
-    .unwrap();
+    let bpf_functions = BTreeMap::new();
     let executable = Executable::<TestInstructionMeter>::from_text_bytes(
         &program,
         config,

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -7,7 +7,7 @@ use libfuzzer_sys::fuzz_target;
 
 use solana_rbpf::{
     ebpf,
-    elf::{register_bpf_function, Executable},
+    elf::Executable,
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, Verifier},
     vm::{EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
@@ -33,14 +33,11 @@ fuzz_target!(|data: DumbFuzzData| {
         return;
     }
     let mut mem = data.mem;
-    let registry = SyscallRegistry::default();
-    let mut bpf_functions = BTreeMap::new();
-    register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
     let executable = Executable::<TestInstructionMeter>::from_text_bytes(
         &prog,
         config,
         SyscallRegistry::default(),
-        bpf_functions,
+        BTreeMap::new(),
     )
     .unwrap();
     let verified_executable =

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -8,7 +8,7 @@ use libfuzzer_sys::fuzz_target;
 use grammar_aware::*;
 use solana_rbpf::{
     ebpf,
-    elf::{register_bpf_function, Executable},
+    elf::Executable,
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, Verifier},
@@ -37,14 +37,11 @@ fuzz_target!(|data: FuzzData| {
         return;
     }
     let mut mem = data.mem;
-    let registry = SyscallRegistry::default();
-    let mut bpf_functions = BTreeMap::new();
-    register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
     let executable = Executable::<TestInstructionMeter>::from_text_bytes(
         prog.into_bytes(),
         config,
         SyscallRegistry::default(),
-        bpf_functions,
+        BTreeMap::new(),
     )
     .unwrap();
     let verified_executable =

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -7,7 +7,7 @@ use libfuzzer_sys::fuzz_target;
 use grammar_aware::*;
 use solana_rbpf::{
     ebpf,
-    elf::{register_bpf_function, Executable},
+    elf::Executable,
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, Verifier},
@@ -46,14 +46,11 @@ fuzz_target!(|data: FuzzData| {
     }
     let mut interp_mem = data.mem.clone();
     let mut jit_mem = data.mem;
-    let registry = SyscallRegistry::default();
-    let mut bpf_functions = BTreeMap::new();
-    register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
     let executable = Executable::<TestInstructionMeter>::from_text_bytes(
         prog.into_bytes(),
         config,
         SyscallRegistry::default(),
-        bpf_functions,
+        BTreeMap::new(),
     )
     .unwrap();
     let mut verified_executable =

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -7,7 +7,7 @@ use libfuzzer_sys::fuzz_target;
 use semantic_aware::*;
 use solana_rbpf::{
     ebpf,
-    elf::{register_bpf_function, Executable},
+    elf::Executable,
     error::EbpfError,
     insn_builder::IntoBytes,
     memory_region::MemoryRegion,
@@ -47,14 +47,11 @@ fuzz_target!(|data: FuzzData| {
     }
     let mut interp_mem = data.mem.clone();
     let mut jit_mem = data.mem;
-    let registry = SyscallRegistry::default();
-    let mut bpf_functions = BTreeMap::new();
-    register_bpf_function(&config, &mut bpf_functions, &registry, 0, "entrypoint").unwrap();
     let executable = Executable::<TestInstructionMeter>::from_text_bytes(
         prog.into_bytes(),
         config,
         SyscallRegistry::default(),
-        bpf_functions,
+        BTreeMap::new(),
     )
     .unwrap();
     let mut verified_executable =

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -127,23 +127,31 @@ pub fn hash_bpf_function(pc: usize, name: &str) -> u32 {
 }
 
 /// Register a symbol or throw ElfError::SymbolHashCollision
-pub fn register_bpf_function<T: AsRef<str> + ToString>(
+pub fn register_bpf_function<T: AsRef<str> + ToString + std::cmp::PartialEq<&'static str>>(
     config: &Config,
     bpf_functions: &mut BTreeMap<u32, (usize, String)>,
     syscall_registry: &SyscallRegistry,
     pc: usize,
     name: T,
 ) -> Result<u32, ElfError> {
-    let hash = hash_bpf_function(pc, name.as_ref());
-    if config.syscall_bpf_function_hash_collision && syscall_registry.lookup_syscall(hash).is_some()
-    {
-        return Err(ElfError::SymbolHashCollision(hash));
-    }
-    match bpf_functions.entry(hash) {
+    let key = if config.static_syscalls {
+        // With static_syscalls normal function calls and syscalls are differentiated in the ISA.
+        // Thus, we don't need to hash them here anymore and collisions are gone as well.
+        pc as u32
+    } else {
+        let hash = hash_bpf_function(pc, name.as_ref());
+        if config.syscall_bpf_function_hash_collision
+            && syscall_registry.lookup_syscall(hash).is_some()
+        {
+            return Err(ElfError::SymbolHashCollision(hash));
+        }
+        hash
+    };
+    match bpf_functions.entry(key) {
         Entry::Vacant(entry) => {
             entry.insert((
                 pc,
-                if config.enable_symbol_and_section_labels {
+                if config.enable_symbol_and_section_labels || name == "entrypoint" {
                     name.to_string()
                 } else {
                     String::default()
@@ -152,12 +160,11 @@ pub fn register_bpf_function<T: AsRef<str> + ToString>(
         }
         Entry::Occupied(entry) => {
             if entry.get().0 != pc {
-                return Err(ElfError::SymbolHashCollision(hash));
+                return Err(ElfError::SymbolHashCollision(key));
             }
         }
     }
-
-    Ok(hash)
+    Ok(key)
 }
 
 // For more information on the BPF instruction set:
@@ -323,7 +330,8 @@ impl<I: InstructionMeter> Executable<I> {
     /// Get the entry point offset into the text section
     pub fn get_entrypoint_instruction_offset(&self) -> Result<usize, EbpfError> {
         self.bpf_functions
-            .get(&ebpf::hash_symbol_name(b"entrypoint"))
+            .values()
+            .find(|(_pc, name)| name == "entrypoint")
             .map(|(pc, _name)| *pc)
             .ok_or(EbpfError::ElfError(ElfError::InvalidEntrypoint))
     }
@@ -493,7 +501,9 @@ impl<I: InstructionMeter> Executable<I> {
             return Err(ElfError::InvalidEntrypoint);
         }
         if let Some(entrypoint) = (offset as usize).checked_div(ebpf::INSN_SIZE) {
-            bpf_functions.remove(&ebpf::hash_symbol_name(b"entrypoint"));
+            if !config.static_syscalls {
+                bpf_functions.remove(&ebpf::hash_symbol_name(b"entrypoint"));
+            }
             register_bpf_function(
                 &config,
                 &mut bpf_functions,
@@ -602,14 +612,14 @@ impl<I: InstructionMeter> Executable<I> {
                     String::default()
                 };
 
-                let hash = register_bpf_function(
+                let key = register_bpf_function(
                     config,
                     bpf_functions,
                     syscall_registry,
                     target_pc as usize,
                     name,
                 )?;
-                insn.imm = hash as i64;
+                insn.imm = key as i64;
                 let offset = i.saturating_mul(ebpf::INSN_SIZE);
                 let checked_slice = elf_bytes
                     .get_mut(offset..offset.saturating_add(ebpf::INSN_SIZE))
@@ -1097,7 +1107,7 @@ impl<I: InstructionMeter> Executable<I> {
                         .ok_or_else(|| ElfError::UnknownSymbol(symbol.st_name() as usize))?;
 
                     // If the symbol is defined, this is a bpf-to-bpf call
-                    let hash = if symbol.is_function() && symbol.st_value() != 0 {
+                    let key = if symbol.is_function() && symbol.st_value() != 0 {
                         if !text_section.vm_range().contains(&symbol.st_value()) {
                             return Err(ElfError::ValueOutOfBounds);
                         }
@@ -1138,7 +1148,7 @@ impl<I: InstructionMeter> Executable<I> {
                     let checked_slice = elf_bytes
                         .get_mut(imm_offset..imm_offset.saturating_add(BYTE_LENGTH_IMMEDIATE))
                         .ok_or(ElfError::ValueOutOfBounds)?;
-                    LittleEndian::write_u32(checked_slice, hash);
+                    LittleEndian::write_u32(checked_slice, key);
                 }
                 _ => return Err(ElfError::UnknownRelocation(relocation.r_type())),
             }
@@ -1437,6 +1447,7 @@ mod test {
     #[test]
     fn test_fixup_relative_calls_back() {
         let config = Config {
+            static_syscalls: false,
             enable_symbol_and_section_labels: true,
             ..Config::default()
         };
@@ -1498,6 +1509,7 @@ mod test {
     #[test]
     fn test_fixup_relative_calls_forward() {
         let config = Config {
+            static_syscalls: false,
             enable_symbol_and_section_labels: true,
             ..Config::default()
         };
@@ -2234,6 +2246,6 @@ mod test {
             Executable::jit_compile(&mut executable).unwrap();
         }
 
-        assert_eq!(18464, executable.mem_size());
+        assert_eq!(18474, executable.mem_size());
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -122,7 +122,7 @@ impl<'a, 'b, V: Verifier, I: InstructionMeter> Interpreter<'a, 'b, V, I> {
             0,
             vm.stack.get_frame_ptr(),
         ];
-        let pc = executable.get_entrypoint_instruction_offset()?;
+        let pc = executable.get_entrypoint_instruction_offset();
         Ok(Self {
             vm,
             instruction_meter,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1361,7 +1361,7 @@ impl JitCompiler {
         }
 
         // Jump to entry point
-        let entry = executable.get_entrypoint_instruction_offset().unwrap_or(0);
+        let entry = executable.get_entrypoint_instruction_offset();
         if self.config.enable_instruction_meter {
             emit_profile_instruction_count(self, Some(entry + 1));
         }
@@ -1699,7 +1699,7 @@ impl JitCompiler {
 #[cfg(all(test, target_arch = "x86_64", not(target_os = "windows")))]
 mod tests {
     use super::*;
-    use crate::{syscalls, vm::{SyscallRegistry, TestInstructionMeter}, elf::register_bpf_function};
+    use crate::{syscalls, vm::{SyscallRegistry, TestInstructionMeter}};
     use std::collections::BTreeMap;
     use byteorder::{LittleEndian, ByteOrder};
 
@@ -1716,14 +1716,6 @@ mod tests {
             )
             .unwrap();
         let mut bpf_functions = BTreeMap::new();
-        register_bpf_function(
-            &config,
-            &mut bpf_functions,
-            &syscall_registry,
-            0,
-            "entrypoint",
-        )
-        .unwrap();
         bpf_functions.insert(0xFFFFFFFF, (8, "foo".to_string()));
         Executable::<TestInstructionMeter>::from_text_bytes(
             program,

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -171,7 +171,7 @@ impl<'a, I: InstructionMeter> Analysis<'a, I> {
             functions,
             cfg_nodes: BTreeMap::new(),
             topological_order: Vec::new(),
-            entrypoint: executable.get_entrypoint_instruction_offset()?,
+            entrypoint: executable.get_entrypoint_instruction_offset(),
             super_root: insn_ptr,
             dfg_forward_edges: BTreeMap::new(),
             dfg_reverse_edges: BTreeMap::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -260,12 +260,8 @@ impl<I: 'static + InstructionMeter> Executable<I> {
         syscall_registry: SyscallRegistry,
         bpf_functions: BTreeMap<u32, (usize, String)>,
     ) -> Result<Self, EbpfError> {
-        Ok(Executable::new_from_text_bytes(
-            config,
-            text_bytes,
-            syscall_registry,
-            bpf_functions,
-        ))
+        Executable::new_from_text_bytes(config, text_bytes, syscall_registry, bpf_functions)
+            .map_err(EbpfError::ElfError)
     }
 }
 
@@ -437,7 +433,6 @@ impl Tracer {
 /// let config = Config::default();
 /// let mut bpf_functions = std::collections::BTreeMap::new();
 /// let syscall_registry = SyscallRegistry::default();
-/// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
 /// let mut executable = Executable::<TestInstructionMeter>::from_text_bytes(prog, config, syscall_registry, bpf_functions).unwrap();
 /// let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
 /// let verified_executable = VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable).unwrap();
@@ -473,7 +468,6 @@ impl<'a, V: Verifier, I: InstructionMeter> EbpfVm<'a, V, I> {
     /// let config = Config::default();
     /// let mut bpf_functions = std::collections::BTreeMap::new();
     /// let syscall_registry = SyscallRegistry::default();
-    /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
     /// let mut executable = Executable::<TestInstructionMeter>::from_text_bytes(prog, config, syscall_registry, bpf_functions).unwrap();
     /// let verified_executable = VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable).unwrap();
     /// let mut vm = EbpfVm::new(&verified_executable, &mut (), &mut [], Vec::new()).unwrap();
@@ -548,7 +542,6 @@ impl<'a, V: Verifier, I: InstructionMeter> EbpfVm<'a, V, I> {
     /// let config = Config::default();
     /// let mut bpf_functions = std::collections::BTreeMap::new();
     /// let syscall_registry = SyscallRegistry::default();
-    /// register_bpf_function(&config, &mut bpf_functions, &syscall_registry, 0, "entrypoint").unwrap();
     /// let mut executable = Executable::<TestInstructionMeter>::from_text_bytes(prog, config, syscall_registry, bpf_functions).unwrap();
     /// let verified_executable = VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable).unwrap();
     /// let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -124,8 +124,8 @@ fn test_call_reg() {
 #[test]
 fn test_call_imm() {
     assert_eq!(
-        asm("call 300"),
-        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 1, 0, -1090069135)])
+        asm("call 299"),
+        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 1, 0, 300)])
     );
 }
 

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -18,7 +18,7 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use solana_rbpf::{
     assembler::assemble,
     ebpf,
-    elf::{register_bpf_function, ElfError, Executable},
+    elf::{ElfError, Executable},
     error::EbpfError,
     memory_region::{AccessType, MemoryMapping, MemoryRegion},
     syscalls,
@@ -2715,16 +2715,8 @@ fn test_err_mem_access_out_of_bound() {
         LittleEndian::write_u32(&mut prog[4..], address as u32);
         LittleEndian::write_u32(&mut prog[12..], (address >> 32) as u32);
         let config = Config::default();
-        let mut bpf_functions = BTreeMap::new();
+        let bpf_functions = BTreeMap::new();
         let syscall_registry = SyscallRegistry::default();
-        register_bpf_function(
-            &config,
-            &mut bpf_functions,
-            &syscall_registry,
-            0,
-            "entrypoint",
-        )
-        .unwrap();
         #[allow(unused_mut)]
         let mut executable = Executable::<TestInstructionMeter>::from_text_bytes(
             &prog,
@@ -4185,20 +4177,12 @@ fn test_tcp_sack_nomatch() {
 fn execute_generated_program(prog: &[u8]) -> bool {
     let max_instruction_count = 1024;
     let mem_size = 1024 * 1024;
-    let mut bpf_functions = BTreeMap::new();
+    let bpf_functions = BTreeMap::new();
     let config = Config {
         enable_instruction_tracing: true,
         ..Config::default()
     };
     let syscall_registry = SyscallRegistry::default();
-    register_bpf_function(
-        &config,
-        &mut bpf_functions,
-        &syscall_registry,
-        0,
-        "entrypoint",
-    )
-    .unwrap();
     let executable = Executable::<TestInstructionMeter>::from_text_bytes(
         prog,
         config,


### PR DESCRIPTION
- Stores PC addresses rather than symbol name hashes in `bpf_functions` if `config.static_syscalls` is active.
- Explicitly stores `entry_pc` in Executable.
- Defaults `entry_pc` to `0` for `Executable::new_from_text_bytes()`.
  - Thus, `Executable::get_entrypoint_instruction_offset()` can not fail,
  - `Executable::load_with_parser()` does not need to search for the "entrypoint" symbol by name,
  - `register_bpf_function()` of "entrypoint" at PC `0` becomes unnecessary.