### PR TITLE
Refactor - ContextObject

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -13,7 +13,7 @@ extern crate test_utils;
 use solana_rbpf::{
     elf::Executable,
     syscalls::BpfSyscallU64,
-    vm::{Config, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, SyscallRegistry, TestContextObject},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -32,7 +32,7 @@ fn bench_load_elf(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        Executable::<TestInstructionMeter>::from_elf(&elf, Config::default(), syscall_registry())
+        Executable::<TestContextObject>::from_elf(&elf, Config::default(), syscall_registry())
             .unwrap()
     });
 }
@@ -43,7 +43,7 @@ fn bench_load_elf_without_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        Executable::<TestInstructionMeter>::from_elf(&elf, Config::default(), syscall_registry())
+        Executable::<TestContextObject>::from_elf(&elf, Config::default(), syscall_registry())
             .unwrap()
     });
 }
@@ -54,7 +54,7 @@ fn bench_load_elf_with_syscall(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     bencher.iter(|| {
-        Executable::<TestInstructionMeter>::from_elf(&elf, Config::default(), syscall_registry())
+        Executable::<TestContextObject>::from_elf(&elf, Config::default(), syscall_registry())
             .unwrap()
     });
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -11,7 +11,7 @@ extern crate test;
 
 use solana_rbpf::{
     elf::Executable,
-    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
+    vm::{Config, EbpfVm, SyscallRegistry, TestContextObject, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 use test::Bencher;
@@ -22,14 +22,14 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<TestInstructionMeter>::from_elf(
+    let executable = Executable::<TestContextObject>::from_elf(
         &elf,
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
     let verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     bencher.iter(|| EbpfVm::new(&verified_executable, &mut (), &mut [], Vec::new()).unwrap());
 }
@@ -40,14 +40,14 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/pass_stack_reference.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<TestInstructionMeter>::from_elf(
+    let executable = Executable::<TestContextObject>::from_elf(
         &elf,
         Config::default(),
         SyscallRegistry::default(),
     )
     .unwrap();
     let mut verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     bencher.iter(|| verified_executable.jit_compile().unwrap());
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -31,7 +31,16 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let verified_executable =
         VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
-    bencher.iter(|| EbpfVm::new(&verified_executable, &mut (), &mut [], Vec::new()).unwrap());
+    bencher.iter(|| {
+        let mut context_object = TestContextObject::default();
+        EbpfVm::new(
+            &verified_executable,
+            &mut context_object,
+            &mut [],
+            Vec::new(),
+        )
+        .unwrap();
+    });
 }
 
 #[cfg(not(windows))]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -204,13 +204,13 @@ fn main() {
     if matches.is_present("trace") {
         println!("Trace:\n");
         let stdout = std::io::stdout();
-        vm.get_program_environment()
+        vm.program_environment
             .tracer
             .write(&mut stdout.lock(), analysis.as_ref().unwrap())
             .unwrap();
     }
     if matches.is_present("profile") {
-        let tracer = &vm.get_program_environment().tracer;
+        let tracer = &vm.program_environment.tracer;
         let dynamic_analysis = DynamicAnalysis::new(tracer, analysis.as_ref().unwrap());
         let mut file = File::create("profile.dot").unwrap();
         analysis

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     static_analysis::Analysis,
     verifier::RequisiteVerifier,
     vm::{
-        Config, DynamicAnalysis, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable,
+        Config, DynamicAnalysis, EbpfVm, SyscallRegistry, TestContextObject, VerifiedExecutable,
     },
 };
 use std::{fs::File, io::Read, path::Path};
@@ -105,7 +105,7 @@ fn main() {
             let mut file = File::open(Path::new(asm_file_name)).unwrap();
             let mut source = Vec::new();
             file.read_to_end(&mut source).unwrap();
-            assemble::<TestInstructionMeter>(
+            assemble::<TestContextObject>(
                 std::str::from_utf8(source.as_slice()).unwrap(),
                 config,
                 syscall_registry,
@@ -115,14 +115,14 @@ fn main() {
             let mut file = File::open(Path::new(matches.value_of("elf").unwrap())).unwrap();
             let mut elf = Vec::new();
             file.read_to_end(&mut elf).unwrap();
-            Executable::<TestInstructionMeter>::from_elf(&elf, config, syscall_registry)
+            Executable::<TestContextObject>::from_elf(&elf, config, syscall_registry)
                 .map_err(|err| format!("Executable constructor failed: {:?}", err))
         }
     }
     .unwrap();
 
     let mut verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 
     let mut mem = match matches.value_of("input").unwrap().parse::<usize>() {
@@ -134,7 +134,7 @@ fn main() {
             memory
         }
     };
-    let mut instruction_meter = TestInstructionMeter {
+    let mut instruction_meter = TestContextObject {
         remaining: matches
             .value_of("instruction limit")
             .unwrap()

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -8,7 +8,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
-    vm::{Config, FunctionRegistry, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, FunctionRegistry, SyscallRegistry, TestContextObject},
 };
 
 // Simply disassemble a program into human-readable instructions.
@@ -31,7 +31,7 @@ fn main() {
     ];
     let syscall_registry = SyscallRegistry::default();
     let config = Config::default();
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         program,
         config,
         syscall_registry,

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -15,7 +15,7 @@ use solana_rbpf::{
     disassembler::disassemble_instruction,
     elf::Executable,
     static_analysis::Analysis,
-    vm::{Config, FunctionRegistry, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, FunctionRegistry, SyscallRegistry, TestContextObject},
 };
 // Turn a program into a JSON string.
 //
@@ -27,7 +27,7 @@ use solana_rbpf::{
 // * Print integers as integers, and not as strings containing their hexadecimal representation
 //   (just replace the relevant `format!()` calls by the commented values.
 fn to_json(program: &[u8]) -> String {
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         program,
         Config::default(),
         SyscallRegistry::default(),

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     elf::Executable,
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, Verifier},
-    vm::{EbpfVm, SyscallRegistry, FunctionRegistry, TestInstructionMeter, VerifiedExecutable},
+    vm::{EbpfVm, SyscallRegistry, FunctionRegistry, TestContextObject, VerifiedExecutable},
 };
 use test_utils::TautologyVerifier;
 
@@ -33,7 +33,7 @@ fuzz_target!(|data: DumbFuzzData| {
         return;
     }
     let mut mem = data.mem;
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         &prog,
         config,
         SyscallRegistry::default(),
@@ -41,12 +41,12 @@ fuzz_target!(|data: DumbFuzzData| {
     )
     .unwrap();
     let verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
     let mut vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![mem_region]).unwrap();
 
     drop(black_box(vm.execute_program_interpreted(
-        &mut TestInstructionMeter { remaining: 1024 },
+        &mut TestContextObject { remaining: 1024 },
     )));
 });

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -44,9 +44,8 @@ fuzz_target!(|data: DumbFuzzData| {
         VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-    let mut vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![mem_region]).unwrap();
+    let mut context_object = TestContextObject { remaining: 29 };
+    let mut vm = EbpfVm::new(&verified_executable, &mut context_object, &mut [], vec![mem_region]).unwrap();
 
-    drop(black_box(vm.execute_program_interpreted(
-        &mut TestContextObject { remaining: 1024 },
-    )));
+    drop(black_box(vm.execute_program_interpreted()));
 });

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -11,7 +11,7 @@ use solana_rbpf::{
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, Verifier},
-    vm::{EbpfVm, SyscallRegistry, FunctionRegistry, TestInstructionMeter, VerifiedExecutable},
+    vm::{EbpfVm, SyscallRegistry, FunctionRegistry, TestContextObject, VerifiedExecutable},
 };
 use test_utils::TautologyVerifier;
 
@@ -37,7 +37,7 @@ fuzz_target!(|data: FuzzData| {
         return;
     }
     let mut mem = data.mem;
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog.into_bytes(),
         config,
         SyscallRegistry::default(),
@@ -45,12 +45,12 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     let verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
     let mut vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![mem_region]).unwrap();
 
     drop(black_box(vm.execute_program_interpreted(
-        &mut TestInstructionMeter { remaining: 1 << 16 },
+        &mut TestContextObject { remaining: 1 << 16 },
     )));
 });

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -48,9 +48,8 @@ fuzz_target!(|data: FuzzData| {
         VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
-    let mut vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![mem_region]).unwrap();
+    let mut context_object = TestContextObject { remaining: 1 << 16 };
+    let mut vm = EbpfVm::new(&verified_executable, &mut context_object, &mut [], vec![mem_region]).unwrap();
 
-    drop(black_box(vm.execute_program_interpreted(
-        &mut TestContextObject { remaining: 1 << 16 },
-    )));
+    drop(black_box(vm.execute_program_interpreted()));
 });

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -56,25 +56,25 @@ fuzz_target!(|data: FuzzData| {
         VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     if verified_executable.jit_compile().is_ok() {
+        let mut interp_syscall_object = TestContextObject { remaining: 1 << 16 };
         let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
         let mut interp_vm =
-            EbpfVm::new(&verified_executable, &mut (), &mut [], vec![interp_mem_region]).unwrap();
+            EbpfVm::new(&verified_executable, &mut interp_syscall_object, &mut [], vec![interp_mem_region]).unwrap();
+        let mut jit_syscall_object = TestContextObject { remaining: 1 << 16 };
         let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
-        let mut jit_vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![jit_mem_region]).unwrap();
-
-        let mut interp_meter = TestContextObject { remaining: 1 << 16 };
-        let interp_res = interp_vm.execute_program_interpreted(&mut interp_meter);
-        let mut jit_meter = TestContextObject { remaining: 1 << 16 };
-        let jit_res = jit_vm.execute_program_jit(&mut jit_meter);
+        let mut jit_vm = EbpfVm::new(&verified_executable, &mut jit_syscall_object, &mut [], vec![jit_mem_region]).unwrap();
+        
+        let interp_res = interp_vm.execute_program_interpreted();
+        let jit_res = jit_vm.execute_program_jit();
         if format!("{:?}", interp_res) != format!("{:?}", jit_res) {
             panic!("Expected {:?}, but got {:?}", interp_res, jit_res);
         }
         if interp_res.is_ok() {
             // we know jit res must be ok if interp res is by this point
-            if interp_meter.remaining != jit_meter.remaining {
+            if interp_syscall_object.remaining != jit_syscall_object.remaining {
                 panic!(
                     "Expected {} insts remaining, but got {}",
-                    interp_meter.remaining, jit_meter.remaining
+                    interp_syscall_object.remaining, jit_syscall_object.remaining
                 );
             }
             if interp_mem != jit_mem {

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, Verifier},
-    vm::{EbpfVm, SyscallRegistry, FunctionRegistry, TestInstructionMeter, VerifiedExecutable},
+    vm::{EbpfVm, SyscallRegistry, FunctionRegistry, TestContextObject, VerifiedExecutable},
 };
 use test_utils::TautologyVerifier;
 
@@ -45,7 +45,7 @@ fuzz_target!(|data: FuzzData| {
     }
     let mut interp_mem = data.mem.clone();
     let mut jit_mem = data.mem;
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog.into_bytes(),
         config,
         SyscallRegistry::default(),
@@ -53,7 +53,7 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     let mut verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     if verified_executable.jit_compile().is_ok() {
         let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
@@ -62,9 +62,9 @@ fuzz_target!(|data: FuzzData| {
         let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
         let mut jit_vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![jit_mem_region]).unwrap();
 
-        let mut interp_meter = TestInstructionMeter { remaining: 1 << 16 };
+        let mut interp_meter = TestContextObject { remaining: 1 << 16 };
         let interp_res = interp_vm.execute_program_interpreted(&mut interp_meter);
-        let mut jit_meter = TestInstructionMeter { remaining: 1 << 16 };
+        let mut jit_meter = TestContextObject { remaining: 1 << 16 };
         let jit_res = jit_vm.execute_program_jit(&mut jit_meter);
         if format!("{:?}", interp_res) != format!("{:?}", jit_res) {
             panic!("Expected {:?}, but got {:?}", interp_res, jit_res);

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -12,7 +12,7 @@ use solana_rbpf::{
     static_analysis::Analysis,
     verifier::{RequisiteVerifier, Verifier},
     vm::{
-        EbpfVm, InstructionMeter, ProgramResult, SyscallRegistry, TestInstructionMeter,
+        EbpfVm, ContextObject, ProgramResult, SyscallRegistry, TestContextObject,
         VerifiedExecutable, FunctionRegistry,
     },
 };
@@ -30,7 +30,7 @@ struct FuzzData {
     mem: Vec<u8>,
 }
 
-fn dump_insns<V: Verifier, I: InstructionMeter>(verified_executable: &VerifiedExecutable<V, I>) {
+fn dump_insns<V: Verifier, C: ContextObject>(verified_executable: &VerifiedExecutable<V, C>) {
     let analysis = Analysis::from_executable(verified_executable.get_executable()).unwrap();
     eprint!("Using the following disassembly");
     analysis.disassemble(&mut std::io::stderr().lock()).unwrap();
@@ -46,7 +46,7 @@ fuzz_target!(|data: FuzzData| {
     }
     let mut interp_mem = data.mem.clone();
     let mut jit_mem = data.mem;
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog.into_bytes(),
         config,
         SyscallRegistry::default(),
@@ -54,7 +54,7 @@ fuzz_target!(|data: FuzzData| {
     )
     .unwrap();
     let mut verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
     if verified_executable.jit_compile().is_ok() {
         let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
@@ -63,9 +63,9 @@ fuzz_target!(|data: FuzzData| {
         let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
         let mut jit_vm = EbpfVm::new(&verified_executable, &mut (), &mut [], vec![jit_mem_region]).unwrap();
 
-        let mut interp_meter = TestInstructionMeter { remaining: 1 << 16 };
+        let mut interp_meter = TestContextObject { remaining: 1 << 16 };
         let interp_res = interp_vm.execute_program_interpreted(&mut interp_meter);
-        let mut jit_meter = TestInstructionMeter { remaining: 1 << 16 };
+        let mut jit_meter = TestContextObject { remaining: 1 << 16 };
         let jit_res = jit_vm.execute_program_jit(&mut jit_meter);
         if format!("{:?}", interp_res) != format!("{:?}", jit_res) {
             // spot check: there's a meaningless bug where ExceededMaxInstructions is different due to jump calculations

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     ebpf::{self, Insn},
     elf::{register_bpf_function, Executable},
-    vm::{Config, FunctionRegistry, InstructionMeter, SyscallRegistry},
+    vm::{Config, ContextObject, FunctionRegistry, SyscallRegistry},
 };
 use std::collections::HashMap;
 
@@ -182,8 +182,8 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 /// # Examples
 ///
 /// ```
-/// use solana_rbpf::{assembler::assemble, vm::{Config, TestInstructionMeter, SyscallRegistry}};
-/// let executable = assemble::<TestInstructionMeter>(
+/// use solana_rbpf::{assembler::assemble, vm::{Config, TestContextObject, SyscallRegistry}};
+/// let executable = assemble::<TestContextObject>(
 ///    "add64 r1, 0x605
 ///     mov64 r2, 0x32
 ///     mov64 r1, r0
@@ -214,11 +214,11 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 ///  0x87, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ///  0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
 /// ```
-pub fn assemble<I: 'static + InstructionMeter>(
+pub fn assemble<C: 'static + ContextObject>(
     src: &str,
     config: Config,
     syscall_registry: SyscallRegistry,
-) -> Result<Executable<I>, String> {
+) -> Result<Executable<C>, String> {
     fn resolve_label(
         insn_ptr: usize,
         labels: &HashMap<&str, usize>,
@@ -361,6 +361,6 @@ pub fn assemble<I: 'static + InstructionMeter>(
         .iter()
         .flat_map(|insn| insn.to_vec())
         .collect::<Vec<_>>();
-    Executable::<I>::from_text_bytes(&program, config, syscall_registry, function_registry)
+    Executable::<C>::from_text_bytes(&program, config, syscall_registry, function_registry)
         .map_err(|err| format!("Executable constructor {:?}", err))
 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -10,9 +10,9 @@
 
 use crate::ebpf;
 use crate::static_analysis::Analysis;
-use crate::vm::InstructionMeter;
+use crate::vm::ContextObject;
 
-fn resolve_label<'a, I: InstructionMeter>(analysis: &'a Analysis<I>, pc: usize) -> &'a str {
+fn resolve_label<'a, C: ContextObject>(analysis: &'a Analysis<C>, pc: usize) -> &'a str {
     analysis
         .cfg_nodes
         .get(&pc)
@@ -95,11 +95,7 @@ fn ldind_str(name: &str, insn: &ebpf::Insn) -> String {
 }
 
 #[inline]
-fn jmp_imm_str<I: InstructionMeter>(
-    name: &str,
-    insn: &ebpf::Insn,
-    analysis: &Analysis<I>,
-) -> String {
+fn jmp_imm_str<C: ContextObject>(name: &str, insn: &ebpf::Insn, analysis: &Analysis<C>) -> String {
     let target_pc = (insn.ptr as isize + insn.off as isize + 1) as usize;
     format!(
         "{} r{}, {}, {}",
@@ -111,11 +107,7 @@ fn jmp_imm_str<I: InstructionMeter>(
 }
 
 #[inline]
-fn jmp_reg_str<I: InstructionMeter>(
-    name: &str,
-    insn: &ebpf::Insn,
-    analysis: &Analysis<I>,
-) -> String {
+fn jmp_reg_str<C: ContextObject>(name: &str, insn: &ebpf::Insn, analysis: &Analysis<C>) -> String {
     let target_pc = (insn.ptr as isize + insn.off as isize + 1) as usize;
     format!(
         "{} r{}, r{}, {}",
@@ -128,7 +120,7 @@ fn jmp_reg_str<I: InstructionMeter>(
 
 /// Disassemble an eBPF instruction
 #[rustfmt::skip]
-pub fn disassemble_instruction<I: InstructionMeter>(insn: &ebpf::Insn, analysis: &Analysis<I>) -> String {
+pub fn disassemble_instruction<C: ContextObject>(insn: &ebpf::Insn, analysis: &Analysis<C>) -> String {
     let name;
     let desc;
     match insn.opc {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -18,7 +18,7 @@ use crate::{
     error::EbpfError,
     memory_region::AccessType,
     verifier::Verifier,
-    vm::{EbpfVm, InstructionMeter, ProgramResult},
+    vm::{ContextObject, EbpfVm, ProgramResult},
 };
 
 /// Translates a vm_addr into a host_addr and sets the pc in the error if one occurs
@@ -76,10 +76,10 @@ pub enum DebugState {
 }
 
 /// State of an interpreter
-pub struct Interpreter<'a, 'b, V: Verifier, I: InstructionMeter> {
-    pub(crate) vm: &'a mut EbpfVm<'b, V, I>,
+pub struct Interpreter<'a, 'b, V: Verifier, C: ContextObject> {
+    pub(crate) vm: &'a mut EbpfVm<'b, V, C>,
 
-    pub(crate) instruction_meter: &'a mut I,
+    pub(crate) instruction_meter: &'a mut C,
 
     pub(crate) initial_insn_count: u64,
     remaining_insn_count: u64,
@@ -96,11 +96,11 @@ pub struct Interpreter<'a, 'b, V: Verifier, I: InstructionMeter> {
     pub(crate) breakpoints: Vec<u64>,
 }
 
-impl<'a, 'b, V: Verifier, I: InstructionMeter> Interpreter<'a, 'b, V, I> {
+impl<'a, 'b, V: Verifier, C: ContextObject> Interpreter<'a, 'b, V, C> {
     /// Creates a new interpreter state
     pub fn new(
-        vm: &'a mut EbpfVm<'b, V, I>,
-        instruction_meter: &'a mut I,
+        vm: &'a mut EbpfVm<'b, V, C>,
+        instruction_meter: &'a mut C,
     ) -> Result<Self, EbpfError> {
         let executable = vm.verified_executable.get_executable();
         let initial_insn_count = if executable.get_config().enable_instruction_meter {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -463,7 +463,7 @@ impl<'a, 'b, V: Verifier, I: InstructionMeter> Interpreter<'a, 'b, V, I> {
                         self.due_insn_count = 0;
                         let mut result = ProgramResult::Ok(0);
                         syscall(
-                            self.vm.program_environment.syscall_context_object,
+                            self.vm.program_environment.context_object,
                             self.reg[1],
                             self.reg[2],
                             self.reg[3],

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -944,7 +944,7 @@ impl JitCompiler {
             if config.encrypt_environment_registers {
                 (
                     diversification_rng.gen::<i32>() / 16, // -3 bits for 8 Byte alignment, and -1 bit to have encoding space for EnvironmentStackSlot::SlotCount
-                    diversification_rng.gen::<i32>() / 2, // -1 bit to have encoding space for (ProgramEnvironment::SYSCALL_CONTEXT_OBJECT + syscall.context_object_slot) * 8
+                    diversification_rng.gen::<i32>() / 2, // -1 bit to have encoding space for (ProgramEnvironment::CONTEXT_OBJECT + syscall.context_object_slot) * 8
                 )
             } else { (0, 0) };
 
@@ -1223,7 +1223,7 @@ impl JitCompiler {
                                 emit_validate_and_profile_instruction_count(self, true, Some(0));
                             }
                             emit_ins(self, X86Instruction::load_immediate(OperandSize::S64, R11, syscall as *const SyscallFunction<*mut ()> as i64));
-                            emit_ins(self, X86Instruction::load(OperandSize::S64, R10, RAX, X86IndirectAccess::Offset(ProgramEnvironment::SYSCALL_CONTEXT_OBJECT as i32 + self.program_argument_key)));
+                            emit_ins(self, X86Instruction::load(OperandSize::S64, R10, RAX, X86IndirectAccess::Offset(ProgramEnvironment::CONTEXT_OBJECT as i32 + self.program_argument_key)));
                             emit_ins(self, X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_SYSCALL, 5)));
                             if self.config.enable_instruction_meter {
                                 emit_undo_profile_instruction_count(self, 0);

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -323,14 +323,19 @@ impl BpfSyscallU64 {
 
 /// Example of a syscall with internal state.
 pub struct SyscallWithContext {
+    /// Maximal amount of instructions which still can be executed
+    pub remaining: u64,
     /// Mutable state
     pub context: u64,
 }
 impl ContextObject for SyscallWithContext {
-    fn consume(&mut self, _amount: u64) {}
+    fn consume(&mut self, amount: u64) {
+        debug_assert!(amount <= self.remaining, "Execution count exceeded");
+        self.remaining = self.remaining.saturating_sub(amount);
+    }
 
     fn get_remaining(&self) -> u64 {
-        100
+        self.remaining
     }
 }
 impl SyscallWithContext {

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -332,8 +332,6 @@ impl ContextObject for SyscallWithContext {
     fn get_remaining(&self) -> u64 {
         100
     }
-
-    fn set_remaining(&mut self, _ammount: u64) {}
 }
 impl SyscallWithContext {
     /// Syscall handler method

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -23,7 +23,7 @@
 
 use crate::{
     memory_region::{AccessType, MemoryMapping},
-    vm::ProgramResult,
+    vm::{ContextObject, ProgramResult},
 };
 use std::{slice::from_raw_parts, str::from_utf8};
 
@@ -325,6 +325,15 @@ impl BpfSyscallU64 {
 pub struct SyscallWithContext {
     /// Mutable state
     pub context: u64,
+}
+impl ContextObject for SyscallWithContext {
+    fn consume(&mut self, _amount: u64) {}
+
+    fn get_remaining(&self) -> u64 {
+        100
+    }
+
+    fn set_remaining(&mut self, _ammount: u64) {}
 }
 impl SyscallWithContext {
     /// Syscall handler method

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -308,8 +308,6 @@ pub trait ContextObject {
     fn consume(&mut self, amount: u64);
     /// Get the number of remaining instructions allowed
     fn get_remaining(&self) -> u64;
-    /// Use only in tests and benches
-    fn set_remaining(&mut self, ammount: u64);
 }
 
 /// Simple instruction meter for testing
@@ -327,10 +325,6 @@ impl ContextObject for TestContextObject {
 
     fn get_remaining(&self) -> u64 {
         self.remaining
-    }
-
-    fn set_remaining(&mut self, amount: u64) {
-        self.remaining = amount;
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -525,11 +525,6 @@ impl<'a, V: Verifier, C: ContextObject> EbpfVm<'a, V, C> {
         self.program
     }
 
-    /// Returns the tracer
-    pub fn get_program_environment(&self) -> &ProgramEnvironment<C> {
-        &self.program_environment
-    }
-
     /// Execute the program loaded, with the given packet data.
     ///
     /// Warning: The program is executed without limiting the number of

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -616,15 +616,9 @@ impl<'a, V: Verifier, C: ContextObject> EbpfVm<'a, V, C> {
             Ok(compiled_program) => compiled_program,
             Err(error) => return ProgramResult::Err(error),
         };
-        let instruction_meter = self.program_environment.context_object as *mut C;
         let instruction_meter_final = unsafe {
-            (compiled_program.main)(
-                &mut result,
-                ebpf::MM_INPUT_START,
-                &self.program_environment,
-                instruction_meter, // TODO
-            )
-            .max(0) as u64
+            (compiled_program.main)(&mut result, ebpf::MM_INPUT_START, &self.program_environment)
+                .max(0) as u64
         };
         if executable.get_config().enable_instruction_meter {
             let remaining_insn_count = self.program_environment.context_object.get_remaining();

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -11,13 +11,13 @@ extern crate test_utils;
 use solana_rbpf::{
     assembler::assemble,
     ebpf,
-    vm::{Config, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, SyscallRegistry, TestContextObject},
 };
 use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
 
 fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
     let executable =
-        assemble::<TestInstructionMeter>(src, Config::default(), SyscallRegistry::default())?;
+        assemble::<TestContextObject>(src, Config::default(), SyscallRegistry::default())?;
     let (_program_vm_addr, program) = executable.get_text_bytes();
     Ok((0..program.len() / ebpf::INSN_SIZE)
         .map(|insn_ptr| ebpf::get_insn(program, insn_ptr))
@@ -536,12 +536,9 @@ fn test_large_immediate() {
 
 #[test]
 fn test_tcp_sack() {
-    let executable = assemble::<TestInstructionMeter>(
-        TCP_SACK_ASM,
-        Config::default(),
-        SyscallRegistry::default(),
-    )
-    .unwrap();
+    let executable =
+        assemble::<TestContextObject>(TCP_SACK_ASM, Config::default(), SyscallRegistry::default())
+            .unwrap();
     let (_program_vm_addr, program) = executable.get_text_bytes();
     assert_eq!(program, TCP_SACK_BIN.to_vec());
 }

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -10,7 +10,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     assembler::assemble,
     static_analysis::Analysis,
-    vm::{Config, SyscallRegistry, TestInstructionMeter},
+    vm::{Config, SyscallRegistry, TestContextObject},
 };
 
 // Using a macro to keep actual line numbers in failure output
@@ -22,7 +22,7 @@ macro_rules! disasm {
             ..Config::default()
         };
         let executable =
-            assemble::<TestInstructionMeter>(src, config, SyscallRegistry::default()).unwrap();
+            assemble::<TestContextObject>(src, config, SyscallRegistry::default()).unwrap();
         let analysis = Analysis::from_executable(&executable).unwrap();
         let mut reasm = Vec::new();
         analysis.disassemble(&mut reasm).unwrap();

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -129,16 +129,17 @@ fn test_fuzz_execute() {
                     TestContextObject,
                 >::from_executable(executable)
                 {
+                    let mut context_object = TestContextObject {
+                        remaining: 1_000_000,
+                    };
                     let mut vm = EbpfVm::<RequisiteVerifier, TestContextObject>::new(
                         &verified_executable,
-                        &mut (),
+                        &mut context_object,
                         &mut [],
                         Vec::new(),
                     )
                     .unwrap();
-                    let _ = vm.execute_program_interpreted(&mut TestContextObject {
-                        remaining: 1_000_000,
-                    });
+                    let _ = vm.execute_program_interpreted();
                 }
             }
         },

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -27,7 +27,7 @@ use solana_rbpf::{
     fuzz::fuzz,
     syscalls::{BpfSyscallString, BpfSyscallU64},
     verifier::RequisiteVerifier,
-    vm::{Config, EbpfVm, SyscallRegistry, TestInstructionMeter, VerifiedExecutable},
+    vm::{Config, EbpfVm, SyscallRegistry, TestContextObject, VerifiedExecutable},
 };
 use std::{fs::File, io::Read};
 
@@ -119,24 +119,24 @@ fn test_fuzz_execute() {
             syscall_registry
                 .register_syscall_by_name(b"log_64", BpfSyscallU64::call)
                 .unwrap();
-            if let Ok(executable) = Executable::<TestInstructionMeter>::from_elf(
+            if let Ok(executable) = Executable::<TestContextObject>::from_elf(
                 bytes,
                 Config::default(),
                 syscall_registry,
             ) {
                 if let Ok(verified_executable) = VerifiedExecutable::<
                     RequisiteVerifier,
-                    TestInstructionMeter,
+                    TestContextObject,
                 >::from_executable(executable)
                 {
-                    let mut vm = EbpfVm::<RequisiteVerifier, TestInstructionMeter>::new(
+                    let mut vm = EbpfVm::<RequisiteVerifier, TestContextObject>::new(
                         &verified_executable,
                         &mut (),
                         &mut [],
                         Vec::new(),
                     )
                     .unwrap();
-                    let _ = vm.execute_program_interpreted(&mut TestInstructionMeter {
+                    let _ = vm.execute_program_interpreted(&mut TestContextObject {
                         remaining: 1_000_000,
                     });
                 }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -59,7 +59,7 @@ macro_rules! test_interpreter_and_jit {
             assert!(check_closure(&vm, result));
             (
                 vm.get_total_instruction_count(),
-                vm.get_program_environment().tracer.clone(),
+                vm.program_environment.tracer.clone(),
             )
         };
         #[cfg(all(not(windows), target_arch = "x86_64"))]
@@ -81,7 +81,7 @@ macro_rules! test_interpreter_and_jit {
                 Err(err) => assert!(check_closure(&vm, ProgramResult::Err(err))),
                 Ok(()) => {
                     let result = vm.execute_program_jit();
-                    let tracer_jit = &vm.get_program_environment().tracer;
+                    let tracer_jit = &vm.program_environment.tracer;
                     if !check_closure(&vm, result)
                         || !solana_rbpf::vm::Tracer::compare(&_tracer_interpreter, tracer_jit)
                     {
@@ -3097,7 +3097,7 @@ fn test_syscall_with_context() {
         ),
         syscalls::SyscallWithContext { remaining: 8, context: 42 },
         { |vm: &EbpfVm<RequisiteVerifier, syscalls::SyscallWithContext>, res: ProgramResult| {
-            let context_object = unsafe { &*(vm.get_program_environment().context_object as *const syscalls::SyscallWithContext) };
+            let context_object = unsafe { &*(vm.program_environment.context_object as *const syscalls::SyscallWithContext) };
             assert_eq!(context_object.context, 84);
             res.unwrap() == 0
         }},
@@ -4073,7 +4073,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         )
         .unwrap();
         let result_interpreter = vm.execute_program_interpreted();
-        let tracer_interpreter = vm.get_program_environment().tracer.clone();
+        let tracer_interpreter = vm.program_environment.tracer.clone();
         (
             vm.get_total_instruction_count(),
             tracer_interpreter,
@@ -4093,7 +4093,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     )
     .unwrap();
     let result_jit = vm.execute_program_jit();
-    let tracer_jit = &vm.get_program_environment().tracer;
+    let tracer_jit = &vm.program_environment.tracer;
     if format!("{:?}", result_interpreter) != format!("{:?}", result_jit)
         || !solana_rbpf::vm::Tracer::compare(&tracer_interpreter, tracer_jit)
     {

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -43,10 +43,7 @@ macro_rules! test_interpreter_and_jit {
         let mut check_closure = $check;
         #[allow(unused_mut)]
         let mut verified_executable =
-            VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(
-                $executable,
-            )
-            .unwrap();
+            VerifiedExecutable::<RequisiteVerifier, _>::from_executable($executable).unwrap();
         let (instruction_count_interpreter, _tracer_interpreter) = {
             let mut mem = $mem;
             let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
@@ -3082,7 +3079,6 @@ fn test_call_memfrob() {
     );
 }
 
-/* TODO
 #[test]
 fn test_syscall_with_context() {
     test_interpreter_and_jit_asm!(
@@ -3099,14 +3095,14 @@ fn test_syscall_with_context() {
         (
             b"SyscallWithContext" => syscalls::SyscallWithContext::call
         ),
-        &mut syscalls::SyscallWithContext { remaining: 8, context: 42 },
-        { |vm: &EbpfVm<RequisiteVerifier, TestContextObject>, res: ProgramResult| {
+        syscalls::SyscallWithContext { remaining: 8, context: 42 },
+        { |vm: &EbpfVm<RequisiteVerifier, syscalls::SyscallWithContext>, res: ProgramResult| {
             let context_object = unsafe { &*(vm.get_program_environment().context_object as *const syscalls::SyscallWithContext) };
             assert_eq!(context_object.context, 84);
             res.unwrap() == 0
         }},
     );
-}*/
+}
 
 pub struct NestedVmSyscall {}
 impl NestedVmSyscall {

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -37,8 +37,8 @@ macro_rules! test_interpreter_and_jit {
             .register_syscall_by_name($location, $syscall_function)
             .unwrap();
     };
-    ($executable:expr, $mem:tt, $context_object:expr, $check:block, $expected_instruction_count:expr) => {
-        // let expected_instruction_count = $context_object.get_remaining();
+    ($executable:expr, $mem:tt, $context_object:expr, $check:block $(,)?) => {
+        let expected_instruction_count = $context_object.get_remaining();
         #[allow(unused_mut)]
         let mut check_closure = $check;
         #[allow(unused_mut)]
@@ -51,7 +51,6 @@ macro_rules! test_interpreter_and_jit {
             let mut mem = $mem;
             let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
             let mut context_object = $context_object;
-            context_object.set_remaining($expected_instruction_count);
             let mut vm = EbpfVm::new(
                 &verified_executable,
                 &mut context_object,
@@ -74,7 +73,6 @@ macro_rules! test_interpreter_and_jit {
             let mut mem = $mem;
             let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
             let mut context_object = $context_object;
-            context_object.set_remaining($expected_instruction_count);
             let mut vm = EbpfVm::new(
                 &verified_executable,
                 &mut context_object,
@@ -117,35 +115,35 @@ macro_rules! test_interpreter_and_jit {
             .get_config()
             .enable_instruction_meter
         {
-            assert_eq!(instruction_count_interpreter, $expected_instruction_count);
+            assert_eq!(instruction_count_interpreter, expected_instruction_count);
         }
     };
 }
 
 macro_rules! test_interpreter_and_jit_asm {
-    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block $(,)?) => {
         #[allow(unused_mut)]
         {
             let mut syscall_registry = SyscallRegistry::default();
             $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_function);)*
             let mut executable = assemble($source, $config, syscall_registry).unwrap();
-            test_interpreter_and_jit!(executable, $mem, $context_object, $check, $expected_instruction_count);
+            test_interpreter_and_jit!(executable, $mem, $context_object, $check);
         }
     };
-    ($source:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block $(,)?) => {
         #[allow(unused_mut)]
         {
             let config = Config {
                 enable_instruction_tracing: true,
                 ..Config::default()
             };
-            test_interpreter_and_jit_asm!($source, config, $mem, ($($location => $syscall_function),*), $context_object, $check, $expected_instruction_count);
+            test_interpreter_and_jit_asm!($source, config, $mem, ($($location => $syscall_function),*), $context_object, $check);
         }
     };
 }
 
 macro_rules! test_interpreter_and_jit_elf {
-    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block $(,)?) => {
         let mut file = File::open($source).unwrap();
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
@@ -154,15 +152,15 @@ macro_rules! test_interpreter_and_jit_elf {
             let mut syscall_registry = SyscallRegistry::default();
             $(test_interpreter_and_jit!(register, syscall_registry, $location => $syscall_function);)*
             let mut executable = Executable::<TestContextObject>::from_elf(&elf, $config, syscall_registry).unwrap();
-            test_interpreter_and_jit!(executable, $mem, $context_object, $check, $expected_instruction_count);
+            test_interpreter_and_jit!(executable, $mem, $context_object, $check);
         }
     };
-    ($source:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block, $expected_instruction_count:expr) => {
+    ($source:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $check:block $(,)?) => {
         let config = Config {
             enable_instruction_tracing: true,
             ..Config::default()
         };
-        test_interpreter_and_jit_elf!($source, config, $mem, ($($location => $syscall_function),*), $context_object, $check, $expected_instruction_count);
+        test_interpreter_and_jit_elf!($source, config, $mem, ($($location => $syscall_function),*), $context_object, $check);
     };
 }
 
@@ -177,9 +175,8 @@ fn test_mov() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        3
     );
 }
 
@@ -191,9 +188,8 @@ fn test_mov32_imm_large() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xffffffff } },
-        2
     );
 }
 
@@ -206,9 +202,8 @@ fn test_mov_large() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xffffffff } },
-        3
     );
 }
 
@@ -225,9 +220,8 @@ fn test_bounce() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -242,9 +236,8 @@ fn test_add32() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x3 } },
-        5
     );
 }
 
@@ -257,9 +250,8 @@ fn test_neg32() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xfffffffe } },
-        3
     );
 }
 
@@ -272,9 +264,8 @@ fn test_neg64() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xfffffffffffffffe } },
-        3
     );
 }
 
@@ -303,9 +294,8 @@ fn test_alu32_arithmetic() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 19 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2a } },
-        19
     );
 }
 
@@ -334,9 +324,8 @@ fn test_alu64_arithmetic() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 19 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2a } },
-        19
     );
 }
 
@@ -388,9 +377,8 @@ fn test_mul128() {
         exit",
         [0; 16],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 42 },
         { |_vm, res: ProgramResult| { res.unwrap() == 600 } },
-        42
     );
 }
 
@@ -421,9 +409,8 @@ fn test_alu32_logic() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 21 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11 } },
-        21
     );
 }
 
@@ -456,9 +443,8 @@ fn test_alu64_logic() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 23 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11 } },
-        23
     );
 }
 
@@ -472,9 +458,8 @@ fn test_arsh32_high_shift() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x4 } },
-        4
     );
 }
 
@@ -488,9 +473,8 @@ fn test_arsh32_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xffff8000 } },
-        4
     );
 }
 
@@ -505,9 +489,8 @@ fn test_arsh32_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xffff8000 } },
-        5
     );
 }
 
@@ -523,9 +506,8 @@ fn test_arsh64() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xfffffffffffffff8 } },
-        6
     );
 }
 
@@ -539,9 +521,8 @@ fn test_lsh64_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x10 } },
-        4
     );
 }
 
@@ -555,9 +536,8 @@ fn test_rhs32_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x00ffffff } },
-        4
     );
 }
 
@@ -571,9 +551,8 @@ fn test_rsh64_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        4
     );
 }
 
@@ -586,9 +565,8 @@ fn test_be16() {
         exit",
         [0x11, 0x22],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1122 } },
-        3
     );
 }
 
@@ -601,9 +579,8 @@ fn test_be16_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1122 } },
-        3
     );
 }
 
@@ -616,9 +593,8 @@ fn test_be32() {
         exit",
         [0x11, 0x22, 0x33, 0x44],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11223344 } },
-        3
     );
 }
 
@@ -631,9 +607,8 @@ fn test_be32_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11223344 } },
-        3
     );
 }
 
@@ -646,9 +621,8 @@ fn test_be64() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1122334455667788 } },
-        3
     );
 }
 
@@ -661,9 +635,8 @@ fn test_le16() {
         exit",
         [0x22, 0x11],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1122 } },
-        3
     );
 }
 
@@ -676,9 +649,8 @@ fn test_le16_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2211 } },
-        3
     );
 }
 
@@ -691,9 +663,8 @@ fn test_le32() {
         exit",
         [0x44, 0x33, 0x22, 0x11],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11223344 } },
-        3
     );
 }
 
@@ -706,9 +677,8 @@ fn test_le32_high() {
         exit",
         [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x44332211 } },
-        3
     );
 }
 
@@ -721,9 +691,8 @@ fn test_le64() {
         exit",
         [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1122334455667788 } },
-        3
     );
 }
 
@@ -736,9 +705,8 @@ fn test_mul32_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xc } },
-        3
     );
 }
 
@@ -752,9 +720,8 @@ fn test_mul32_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xc } },
-        4
     );
 }
 
@@ -768,9 +735,8 @@ fn test_mul32_reg_overflow() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x4 } },
-        4
     );
 }
 
@@ -783,9 +749,8 @@ fn test_mul64_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x100000004 } },
-        3
     );
 }
 
@@ -799,9 +764,8 @@ fn test_mul64_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x100000004 } },
-        4
     );
 }
 
@@ -815,9 +779,8 @@ fn test_div32_high_divisor() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x3 } },
-        4
     );
 }
 
@@ -830,9 +793,8 @@ fn test_div32_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x3 } },
-        3
     );
 }
 
@@ -846,9 +808,8 @@ fn test_div32_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x3 } },
-        4
     );
 }
 
@@ -861,9 +822,8 @@ fn test_sdiv32_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xFFFFFFFFE0000000 } },
-        3
     );
 }
 
@@ -876,9 +836,8 @@ fn test_sdiv32_neg_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() as i64 == -0xc } },
-        3
     );
 }
 
@@ -892,9 +851,8 @@ fn test_sdiv32_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xFFFFFFFFE0000000 } },
-        4
     );
 }
 
@@ -908,9 +866,8 @@ fn test_sdiv32_neg_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() as i64 == -0xc } },
-        4
     );
 }
 
@@ -924,9 +881,8 @@ fn test_div64_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x300000000 } },
-        4
     );
 }
 
@@ -941,9 +897,8 @@ fn test_div64_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x300000000 } },
-        5
     );
 }
 
@@ -957,9 +912,8 @@ fn test_sdiv64_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x300000000 } },
-        4
     );
 }
 
@@ -974,9 +928,8 @@ fn test_sdiv64_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x300000000 } },
-        5
     );
 }
 
@@ -990,11 +943,10 @@ fn test_err_div64_by_zero_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1008,11 +960,10 @@ fn test_err_div32_by_zero_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1026,11 +977,10 @@ fn test_err_sdiv64_by_zero_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1044,11 +994,10 @@ fn test_err_sdiv32_by_zero_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1062,11 +1011,10 @@ fn test_err_sdiv64_overflow_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1081,11 +1029,10 @@ fn test_err_sdiv64_overflow_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 32)
         },
-        4
     );
 }
 
@@ -1099,11 +1046,10 @@ fn test_err_sdiv32_overflow_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1118,11 +1064,10 @@ fn test_err_sdiv32_overflow_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideOverflow(pc) if pc == 32)
         },
-        4
     );
 }
 
@@ -1137,9 +1082,8 @@ fn test_mod32() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x5 } },
-        5
     );
 }
 
@@ -1152,9 +1096,8 @@ fn test_mod32_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        3
     );
 }
 
@@ -1173,9 +1116,8 @@ fn test_mod64() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x30ba5a04 } },
-        9
     );
 }
 
@@ -1189,11 +1131,10 @@ fn test_err_mod64_by_zero_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1207,11 +1148,10 @@ fn test_err_mod_by_zero_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::DivideByZero(pc) if pc == 31)
         },
-        3
     );
 }
 
@@ -1225,9 +1165,8 @@ fn test_ldxb() {
         exit",
         [0xaa, 0xbb, 0x11, 0xcc, 0xdd],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11 } },
-        2
     );
 }
 
@@ -1239,9 +1178,8 @@ fn test_ldxh() {
         exit",
         [0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2211 } },
-        2
     );
 }
 
@@ -1255,9 +1193,8 @@ fn test_ldxw() {
             0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x44332211 } },
-        2
     );
 }
 
@@ -1271,9 +1208,8 @@ fn test_ldxh_same_reg() {
         exit",
         [0xff, 0xff],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1234 } },
-        4
     );
 }
 
@@ -1288,9 +1224,8 @@ fn test_lldxdw() {
             0x77, 0x88, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x8877665544332211 } },
-        2
     );
 }
 
@@ -1305,7 +1240,7 @@ fn test_err_ldxdw_oob() {
             0x77, 0x88, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -1314,7 +1249,6 @@ fn test_err_ldxdw_oob() {
                 )
             }
         },
-        1
     );
 }
 
@@ -1326,7 +1260,7 @@ fn test_err_ldxdw_nomem() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -1335,7 +1269,6 @@ fn test_err_ldxdw_nomem() {
                 )
             }
         },
-        1
     );
 }
 
@@ -1379,9 +1312,8 @@ fn test_ldxb_all() {
             0x08, 0x09, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 31 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x9876543210 } },
-        31
     );
 }
 
@@ -1436,9 +1368,8 @@ fn test_ldxh_all() {
             0x00, 0x08, 0x00, 0x09, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 41 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x9876543210 } },
-        41
     );
 }
 
@@ -1483,9 +1414,8 @@ fn test_ldxh_all2() {
             0x01, 0x00, 0x02, 0x00, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 31 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x3ff } },
-        31
     );
 }
 
@@ -1532,9 +1462,8 @@ fn test_ldxw_all() {
             0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 31 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x030f0f } },
-        31
     );
 }
 
@@ -1546,9 +1475,8 @@ fn test_lddw() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1122334455667788 } },
-        2
     );
     test_interpreter_and_jit_asm!(
         "
@@ -1556,9 +1484,8 @@ fn test_lddw() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x80000000 } },
-        2
     );
 }
 
@@ -1571,9 +1498,8 @@ fn test_stb() {
         exit",
         [0xaa, 0xbb, 0xff, 0xcc, 0xdd],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11 } },
-        3
     );
 }
 
@@ -1588,9 +1514,8 @@ fn test_sth() {
             0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2211 } },
-        3
     );
 }
 
@@ -1605,9 +1530,8 @@ fn test_stw() {
             0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x44332211 } },
-        3
     );
 }
 
@@ -1623,9 +1547,8 @@ fn test_stdw() {
             0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x44332211 } },
-        3
     );
 }
 
@@ -1641,9 +1564,8 @@ fn test_stxb() {
             0xaa, 0xbb, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x11 } },
-        4
     );
 }
 
@@ -1659,9 +1581,8 @@ fn test_stxh() {
             0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2211 } },
-        4
     );
 }
 
@@ -1677,9 +1598,8 @@ fn test_stxw() {
             0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x44332211 } },
-        4
     );
 }
 
@@ -1698,9 +1618,8 @@ fn test_stxdw() {
             0xff, 0xff, 0xcc, 0xdd, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x8877665544332211 } },
-        6
     );
 }
 
@@ -1731,9 +1650,8 @@ fn test_stxb_all() {
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 19 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xf0f2f3f4f5f6f7f8 } },
-        19
     );
 }
 
@@ -1751,9 +1669,8 @@ fn test_stxb_all2() {
         exit",
         [0xff, 0xff],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xf1f9 } },
-        8
     );
 }
 
@@ -1787,9 +1704,8 @@ fn test_stxb_chain() {
             0x00, 0x00, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 21 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2a } },
-        21
     );
 }
 
@@ -1802,9 +1718,8 @@ fn test_exit_without_value() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        1
     );
 }
 
@@ -1816,9 +1731,8 @@ fn test_exit() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        2
     );
 }
 
@@ -1832,9 +1746,8 @@ fn test_early_exit() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x3 } },
-        2
     );
 }
 
@@ -1848,9 +1761,8 @@ fn test_ja() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        3
     );
 }
 
@@ -1868,9 +1780,8 @@ fn test_jeq_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -1889,9 +1800,8 @@ fn test_jeq_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        8
     );
 }
 
@@ -1909,9 +1819,8 @@ fn test_jge_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -1930,9 +1839,8 @@ fn test_jge_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        8
     );
 }
 
@@ -1951,9 +1859,8 @@ fn test_jle_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -1974,9 +1881,8 @@ fn test_jle_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        9
     );
 }
 
@@ -1994,9 +1900,8 @@ fn test_jgt_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2016,9 +1921,8 @@ fn test_jgt_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        9
     );
 }
 
@@ -2036,9 +1940,8 @@ fn test_jlt_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2058,9 +1961,8 @@ fn test_jlt_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        9
     );
 }
 
@@ -2078,9 +1980,8 @@ fn test_jne_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2099,9 +2000,8 @@ fn test_jne_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        8
     );
 }
 
@@ -2119,9 +2019,8 @@ fn test_jset_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2140,9 +2039,8 @@ fn test_jset_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        8
     );
 }
 
@@ -2161,9 +2059,8 @@ fn test_jsge_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        8
     );
 }
 
@@ -2184,9 +2081,8 @@ fn test_jsge_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 10 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        10
     );
 }
 
@@ -2205,9 +2101,8 @@ fn test_jsle_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2229,9 +2124,8 @@ fn test_jsle_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 10 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        10
     );
 }
 
@@ -2249,9 +2143,8 @@ fn test_jsgt_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2270,9 +2163,8 @@ fn test_jsgt_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        8
     );
 }
 
@@ -2290,9 +2182,8 @@ fn test_jslt_imm() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        7
     );
 }
 
@@ -2312,9 +2203,8 @@ fn test_jslt_reg() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        9
     );
 }
 
@@ -2335,9 +2225,8 @@ fn test_stack1() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0xcd } },
-        9
     );
 }
 
@@ -2366,9 +2255,8 @@ fn test_stack2() {
             b"BpfMemFrob" => syscalls::BpfMemFrob::call,
             b"BpfGatherBytes" => syscalls::BpfGatherBytes::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 16 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x01020304 } },
-        16
     );
 }
 
@@ -2408,9 +2296,8 @@ fn test_string_stack() {
         (
             b"BpfStrCmp" => syscalls::BpfStrCmp::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 28 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        28
     );
 }
 
@@ -2428,7 +2315,7 @@ fn test_err_fixed_stack_out_of_bound() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2437,7 +2324,6 @@ fn test_err_fixed_stack_out_of_bound() {
                 )
             }
         },
-        1
     );
 }
 
@@ -2459,7 +2345,7 @@ fn test_err_dynamic_stack_out_of_bound() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2468,7 +2354,6 @@ fn test_err_dynamic_stack_out_of_bound() {
                 )
             }
         },
-        1
     );
 
     // Check that accessing MM_STACK_START + expected_stack_len fails
@@ -2479,7 +2364,7 @@ fn test_err_dynamic_stack_out_of_bound() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2488,7 +2373,6 @@ fn test_err_dynamic_stack_out_of_bound() {
                 )
             }
         },
-        1
     );
 }
 
@@ -2518,7 +2402,7 @@ fn test_err_dynamic_stack_ptr_overflow() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2527,7 +2411,6 @@ fn test_err_dynamic_stack_ptr_overflow() {
                 )
             }
         },
-        7
     );
 }
 
@@ -2549,13 +2432,12 @@ fn test_dynamic_stack_frames_empty() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 res.unwrap() == ebpf::MM_STACK_START + config.stack_size() as u64
             }
         },
-        4
     );
 }
 
@@ -2579,13 +2461,12 @@ fn test_dynamic_frame_ptr() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         {
             |_vm, res: ProgramResult| {
                 res.unwrap() == ebpf::MM_STACK_START + config.stack_size() as u64 - 8
             }
         },
-        5
     );
 
     // And check that when exiting a function (foo) the caller's frame pointer
@@ -2602,13 +2483,12 @@ fn test_dynamic_frame_ptr() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         {
             |_vm, res: ProgramResult| {
                 res.unwrap() == ebpf::MM_STACK_START + config.stack_size() as u64
             }
         },
-        5
     );
 }
 
@@ -2640,9 +2520,8 @@ fn test_entrypoint_exit() {
             config,
             [],
             (),
-            TestContextObject::default(),
+            TestContextObject { remaining: 5 },
             { |_vm, res: ProgramResult| { res.unwrap() == 42 } },
-            5
         );
     }
 }
@@ -2671,9 +2550,8 @@ fn test_stack_call_depth_tracking() {
             config,
             [],
             (),
-            TestContextObject::default(),
+            TestContextObject { remaining: 5 },
             { |_vm, res: ProgramResult| { res.is_ok() } },
-            5
         );
 
         // two nested calls should trigger CallDepthExceeded instead
@@ -2691,7 +2569,7 @@ fn test_stack_call_depth_tracking() {
             config,
             [],
             (),
-            TestContextObject::default(),
+            TestContextObject { remaining: 2 },
             {
                 |_vm, res: ProgramResult| {
                     matches!(res.unwrap_err(),
@@ -2700,7 +2578,6 @@ fn test_stack_call_depth_tracking() {
                     )
                 }
             },
-            2
         );
     }
 }
@@ -2724,20 +2601,14 @@ fn test_err_mem_access_out_of_bound() {
             FunctionRegistry::default(),
         )
         .unwrap();
-        test_interpreter_and_jit!(
-            executable,
-            mem,
-            TestContextObject::default(),
-            {
-                |_vm, res: ProgramResult| {
-                    matches!(res.unwrap_err(),
-                        EbpfError::AccessViolation(pc, access_type, vm_addr, len, name)
-                        if access_type == AccessType::Store && pc == 31 && vm_addr == address && len == 1 && name == "unknown"
-                    )
-                }
-            },
-            2
-        );
+        test_interpreter_and_jit!(executable, mem, TestContextObject { remaining: 2 }, {
+            |_vm, res: ProgramResult| {
+                matches!(res.unwrap_err(),
+                    EbpfError::AccessViolation(pc, access_type, vm_addr, len, name)
+                    if access_type == AccessType::Store && pc == 31 && vm_addr == address && len == 1 && name == "unknown"
+                )
+            }
+        });
     }
 }
 
@@ -2751,9 +2622,8 @@ fn test_relative_call() {
         (
             b"log" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 14 },
         { |_vm, res: ProgramResult| { res.unwrap() == 2 } },
-        14
     );
 }
 
@@ -2765,9 +2635,8 @@ fn test_bpf_to_bpf_scratch_registers() {
         (
             b"log_64" => syscalls::BpfSyscallU64::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 41 },
         { |_vm, res: ProgramResult| { res.unwrap() == 112 } },
-        41
     );
 }
 
@@ -2777,9 +2646,8 @@ fn test_bpf_to_bpf_pass_stack_reference() {
         "tests/elfs/pass_stack_reference.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 29 },
         { |_vm, res: ProgramResult| res.unwrap() == 42 },
-        29
     );
 }
 
@@ -2797,9 +2665,8 @@ fn test_syscall_parameter_on_stack() {
         (
             b"BpfSyscallString" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        6
     );
 }
 
@@ -2818,9 +2685,8 @@ fn test_callx() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 42 } },
-        8
     );
 }
 
@@ -2838,11 +2704,10 @@ fn test_err_callx_unregistered() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::UnsupportedInstruction(pc) if pc == 35)
         },
-        6
     );
 }
 
@@ -2855,7 +2720,7 @@ fn test_err_callx_oob_low() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2864,7 +2729,6 @@ fn test_err_callx_oob_low() {
                 )
             }
         },
-        2
     );
 }
 
@@ -2879,7 +2743,7 @@ fn test_err_callx_oob_high() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2888,7 +2752,6 @@ fn test_err_callx_oob_high() {
                 )
             }
         },
-        4
     );
 }
 
@@ -2909,9 +2772,8 @@ fn test_err_static_jmp_lddw() {
         ",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x2 } },
-        9
     );
     test_interpreter_and_jit_asm!(
         "
@@ -2923,7 +2785,7 @@ fn test_err_static_jmp_lddw() {
         ",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2931,7 +2793,6 @@ fn test_err_static_jmp_lddw() {
                 )
             }
         },
-        2
     );
 }
 
@@ -2952,7 +2813,7 @@ fn test_err_dynamic_jmp_lddw() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2961,7 +2822,6 @@ fn test_err_dynamic_jmp_lddw() {
                 )
             }
         },
-        4
     );
     test_interpreter_and_jit_asm!(
         "
@@ -2973,7 +2833,7 @@ fn test_err_dynamic_jmp_lddw() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -2981,7 +2841,6 @@ fn test_err_dynamic_jmp_lddw() {
                 )
             }
         },
-        5
     );
     test_interpreter_and_jit_asm!(
         "
@@ -2997,7 +2856,7 @@ fn test_err_dynamic_jmp_lddw() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3005,7 +2864,6 @@ fn test_err_dynamic_jmp_lddw() {
                 )
             }
         },
-        5
     );
     test_interpreter_and_jit_asm!(
         "
@@ -3020,7 +2878,7 @@ fn test_err_dynamic_jmp_lddw() {
         config,
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3028,7 +2886,6 @@ fn test_err_dynamic_jmp_lddw() {
                 )
             }
         },
-        3
     );
 }
 
@@ -3043,9 +2900,8 @@ fn test_bpf_to_bpf_depth() {
             (
                 b"log" => syscalls::BpfSyscallString::call,
             ),
-            TestContextObject::default(),
+            TestContextObject { remaining: if i == 0 { 4 } else { 3 + 10 * i as u64 } },
             { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-            if i == 0 { 4 } else { 3 + 10 * i as u64 }
         );
     }
 }
@@ -3060,7 +2916,7 @@ fn test_err_bpf_to_bpf_too_deep() {
         (
             b"log" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 176 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3069,7 +2925,6 @@ fn test_err_bpf_to_bpf_too_deep() {
                 )
             }
         },
-        176
     );
 }
 
@@ -3084,7 +2939,7 @@ fn test_err_reg_stack_depth() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 60 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3093,7 +2948,6 @@ fn test_err_reg_stack_depth() {
                 )
             }
         },
-        60
     );
 }
 
@@ -3136,7 +2990,7 @@ fn test_err_syscall_string() {
         (
             b"BpfSyscallString" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3145,7 +2999,6 @@ fn test_err_syscall_string() {
                 )
             }
         },
-        2
     );
 }
 
@@ -3161,9 +3014,8 @@ fn test_syscall_string() {
         (
             b"BpfSyscallString" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        4
     );
 }
 
@@ -3183,9 +3035,8 @@ fn test_syscall() {
         (
             b"BpfSyscallU64" => syscalls::BpfSyscallU64::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        8
     );
 }
 
@@ -3204,9 +3055,8 @@ fn test_call_gather_bytes() {
         (
             b"BpfGatherBytes" => syscalls::BpfGatherBytes::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0102030405 } },
-        7
     );
 }
 
@@ -3227,9 +3077,8 @@ fn test_call_memfrob() {
         (
             b"BpfMemFrob" => syscalls::BpfMemFrob::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x102292e2f2c0708 } },
-        7
     );
 }
 
@@ -3250,13 +3099,12 @@ fn test_syscall_with_context() {
         (
             b"SyscallWithContext" => syscalls::SyscallWithContext::call
         ),
-        &mut syscalls::SyscallWithContext { context: 42 },
+        &mut syscalls::SyscallWithContext { remaining: 8, context: 42 },
         { |vm: &EbpfVm<RequisiteVerifier, TestContextObject>, res: ProgramResult| {
             let context_object = unsafe { &*(vm.get_program_environment().context_object as *const syscalls::SyscallWithContext) };
             assert_eq!(context_object.context, 84);
             res.unwrap() == 0
         }},
-        8
     );
 }*/
 
@@ -3293,14 +3141,15 @@ impl NestedVmSyscall {
             test_interpreter_and_jit!(
                 executable,
                 mem,
-                TestContextObject::default(),
+                TestContextObject {
+                    remaining: if throw == 0 { 4 } else { 3 }
+                },
                 {
                     |_vm, res: ProgramResult| {
                         *result = res;
                         true
                     }
                 },
-                if throw == 0 { 4 } else { 3 }
             );
         } else {
             *result = if throw == 0 {
@@ -3339,9 +3188,8 @@ fn test_load_elf() {
             b"log" => syscalls::BpfSyscallString::call,
             b"log_64" => syscalls::BpfSyscallU64::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 11 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        11
     );
 }
 
@@ -3353,9 +3201,8 @@ fn test_load_elf_empty_noro() {
         (
             b"log_64" => syscalls::BpfSyscallU64::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        8
     );
 }
 
@@ -3367,9 +3214,8 @@ fn test_load_elf_empty_rodata() {
         (
             b"log_64" => syscalls::BpfSyscallU64::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 8 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        8
     );
 }
 
@@ -3387,9 +3233,8 @@ fn test_load_elf_rodata() {
             config,
             [],
             (),
-            TestContextObject::default(),
+            TestContextObject { remaining: 3 },
             { |_vm, res: ProgramResult| { res.unwrap() == 42 } },
-            3
         );
     }
 }
@@ -3400,9 +3245,8 @@ fn test_load_elf_rodata_high_vaddr() {
         "tests/elfs/rodata_high_vaddr.so",
         [1],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == 42 } },
-        3
     );
 }
 
@@ -3423,13 +3267,9 @@ fn test_custom_entrypoint() {
     #[allow(unused_mut)]
     let mut executable =
         Executable::<TestContextObject>::from_elf(&elf, config, syscall_registry).unwrap();
-    test_interpreter_and_jit!(
-        executable,
-        [],
-        TestContextObject::default(),
-        { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        2
-    );
+    test_interpreter_and_jit!(executable, [], TestContextObject { remaining: 2 }, {
+        |_vm, res: ProgramResult| res.unwrap() == 0
+    });
 }
 
 // Instruction Meter Limit
@@ -3442,7 +3282,7 @@ fn test_tight_infinite_loop_conditional() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3451,7 +3291,6 @@ fn test_tight_infinite_loop_conditional() {
                 )
             }
         },
-        4
     );
 }
 
@@ -3463,7 +3302,7 @@ fn test_tight_infinite_loop_unconditional() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3472,7 +3311,6 @@ fn test_tight_infinite_loop_unconditional() {
                 )
             }
         },
-        4
     );
 }
 
@@ -3486,7 +3324,7 @@ fn test_tight_infinite_recursion() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3495,7 +3333,6 @@ fn test_tight_infinite_recursion() {
                 )
             }
         },
-        4
     );
 }
 
@@ -3512,7 +3349,7 @@ fn test_tight_infinite_recursion_callx() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3521,7 +3358,6 @@ fn test_tight_infinite_recursion_callx() {
                 )
             }
         },
-        7
     );
 }
 
@@ -3537,9 +3373,8 @@ fn test_instruction_count_syscall() {
         (
             b"BpfSyscallString" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        4
     );
 }
 
@@ -3555,7 +3390,7 @@ fn test_err_instruction_count_syscall_capped() {
         (
             b"BpfSyscallString" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3564,7 +3399,6 @@ fn test_err_instruction_count_syscall_capped() {
                 )
             }
         },
-        3
     );
 }
 
@@ -3579,7 +3413,7 @@ fn test_err_instruction_count_lddw_capped() {
         ",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3588,7 +3422,6 @@ fn test_err_instruction_count_lddw_capped() {
                 )
             }
         },
-        2
     );
 }
 
@@ -3608,7 +3441,7 @@ fn test_non_terminate_early() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3617,7 +3450,6 @@ fn test_non_terminate_early() {
                 )
             }
         },
-        7
     );
 }
 
@@ -3639,7 +3471,7 @@ fn test_err_non_terminate_capped() {
         (
             b"BpfTracePrintf" => syscalls::BpfTracePrintf::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3648,7 +3480,6 @@ fn test_err_non_terminate_capped() {
                 )
             }
         },
-        6
     );
     test_interpreter_and_jit_asm!(
         "
@@ -3666,7 +3497,7 @@ fn test_err_non_terminate_capped() {
         (
             b"BpfTracePrintf" => syscalls::BpfTracePrintf::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1000 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3675,7 +3506,6 @@ fn test_err_non_terminate_capped() {
                 )
             }
         },
-        1000
     );
 }
 
@@ -3692,7 +3522,7 @@ fn test_err_capped_before_exception() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3701,7 +3531,6 @@ fn test_err_capped_before_exception() {
                 )
             }
         },
-        2
     );
     test_interpreter_and_jit_asm!(
         "
@@ -3714,7 +3543,7 @@ fn test_err_capped_before_exception() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 4 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3723,7 +3552,6 @@ fn test_err_capped_before_exception() {
                 )
             }
         },
-        4
     );
 }
 
@@ -3740,7 +3568,7 @@ fn test_err_exit_capped() {
         ",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3748,7 +3576,6 @@ fn test_err_exit_capped() {
                 )
             }
         },
-        5
     );
     test_interpreter_and_jit_asm!(
         "
@@ -3762,7 +3589,7 @@ fn test_err_exit_capped() {
         ",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3770,7 +3597,6 @@ fn test_err_exit_capped() {
                 )
             }
         },
-        6
     );
     test_interpreter_and_jit_asm!(
         "
@@ -3780,7 +3606,7 @@ fn test_err_exit_capped() {
         ",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         {
             |_vm, res: ProgramResult| {
                 matches!(res.unwrap_err(),
@@ -3788,7 +3614,6 @@ fn test_err_exit_capped() {
                 )
             }
         },
-        3
     );
 }
 
@@ -3808,9 +3633,8 @@ fn test_symbol_relocation() {
         (
             b"BpfSyscallString" => syscalls::BpfSyscallString::call
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        6
     );
 }
 
@@ -3828,11 +3652,10 @@ fn test_err_call_unresolved() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 6 },
         {
             |_vm, res: ProgramResult| matches!(res.unwrap_err(), EbpfError::UnsupportedInstruction(pc) if pc == 34)
         },
-        6
     );
 }
 
@@ -3860,9 +3683,8 @@ fn test_syscall_static() {
         (
             b"log" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 5 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
-        5
     );
 }
 
@@ -3878,9 +3700,8 @@ fn test_syscall_unknown_static() {
         (
             b"log" => syscalls::BpfSyscallString::call,
         ),
-        TestContextObject::default(),
+        TestContextObject { remaining: 1 },
         { |_vm, res: ProgramResult| { matches!(res.unwrap_err(), EbpfError::UnsupportedInstruction(29)) } },
-        1
     );
 }
 
@@ -3893,9 +3714,8 @@ fn test_reloc_64_64() {
         "tests/elfs/reloc_64_64.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START + 0xe8 } },
-        2
     );
 }
 
@@ -3907,9 +3727,8 @@ fn test_reloc_64_64_high_vaddr() {
         "tests/elfs/reloc_64_64_high_vaddr.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START } },
-        2
     );
 }
 
@@ -3923,9 +3742,8 @@ fn test_reloc_64_relative() {
         "tests/elfs/reloc_64_relative.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START + 0x100 } },
-        2
     );
 }
 
@@ -3939,9 +3757,8 @@ fn test_reloc_64_relative_high_vaddr() {
         "tests/elfs/reloc_64_relative_high_vaddr.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 2 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START + 0x18 } },
-        2
     );
 }
 
@@ -3958,9 +3775,8 @@ fn test_reloc_64_relative_data() {
         "tests/elfs/reloc_64_relative_data.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START + 0x108 } },
-        3
     );
 }
 
@@ -3977,9 +3793,8 @@ fn test_reloc_64_relative_data_high_vaddr() {
         "tests/elfs/reloc_64_relative_data_high_vaddr.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START + 0x20 } },
-        3
     );
 }
 
@@ -4002,9 +3817,8 @@ fn test_reloc_64_relative_data_pre_sbfv2() {
         "tests/elfs/reloc_64_relative_data_pre_sbfv2.so",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 3 },
         { |_vm, res: ProgramResult| { res.unwrap() == ebpf::MM_PROGRAM_START + 0x108 } },
-        3
     );
 }
 
@@ -4026,9 +3840,8 @@ fn test_mul_loop() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 37 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x75db9c97 } },
-        37
     );
 }
 
@@ -4054,9 +3867,8 @@ fn test_prime() {
         exit",
         [],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 655 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        655
     );
 }
 
@@ -4091,9 +3903,8 @@ fn test_subnet() {
             0x03, 0x00, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 11 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        11
     );
 }
 
@@ -4117,9 +3928,8 @@ fn test_tcp_port80_match() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 17 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x1 } },
-        17
     );
 }
 
@@ -4143,9 +3953,8 @@ fn test_tcp_port80_nomatch() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 18 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        18
     );
 }
 
@@ -4169,9 +3978,8 @@ fn test_tcp_port80_nomatch_ethertype() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 7 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        7
     );
 }
 
@@ -4195,9 +4003,8 @@ fn test_tcp_port80_nomatch_proto() {
             0x44, 0x44, 0x44, 0x44, //
         ],
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 9 },
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
-        9
     );
 }
 
@@ -4207,9 +4014,8 @@ fn test_tcp_sack_match() {
         TCP_SACK_ASM,
         TCP_SACK_MATCH,
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 79 },
         { |_vm, res: ProgramResult| res.unwrap() == 0x1 },
-        79
     );
 }
 
@@ -4219,9 +4025,8 @@ fn test_tcp_sack_nomatch() {
         TCP_SACK_ASM,
         TCP_SACK_NOMATCH,
         (),
-        TestContextObject::default(),
+        TestContextObject { remaining: 55 },
         { |_vm, res: ProgramResult| res.unwrap() == 0x0 },
-        55
     );
 }
 

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -67,7 +67,7 @@ fn test_verifier_success() {
             .unwrap();
     let _vm = EbpfVm::<TautologyVerifier, TestContextObject>::new(
         &verified_executable,
-        &mut (),
+        &mut TestContextObject::default(),
         &mut [],
         Vec::new(),
     )

--- a/tests/ubpf_verifier.rs
+++ b/tests/ubpf_verifier.rs
@@ -28,7 +28,7 @@ use solana_rbpf::{
     elf::Executable,
     verifier::{RequisiteVerifier, Verifier, VerifierError},
     vm::{
-        Config, EbpfVm, FunctionRegistry, SyscallRegistry, TestInstructionMeter, VerifiedExecutable,
+        Config, EbpfVm, FunctionRegistry, SyscallRegistry, TestContextObject, VerifiedExecutable,
     },
 };
 use test_utils::TautologyVerifier;
@@ -54,7 +54,7 @@ impl Verifier for ContradictionVerifier {
 
 #[test]
 fn test_verifier_success() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         mov32 r0, 0xBEE
         exit",
@@ -63,9 +63,9 @@ fn test_verifier_success() {
     )
     .unwrap();
     let verified_executable =
-        VerifiedExecutable::<TautologyVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<TautologyVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
-    let _vm = EbpfVm::<TautologyVerifier, TestInstructionMeter>::new(
+    let _vm = EbpfVm::<TautologyVerifier, TestContextObject>::new(
         &verified_executable,
         &mut (),
         &mut [],
@@ -77,7 +77,7 @@ fn test_verifier_success() {
 #[test]
 #[should_panic(expected = "NoProgram")]
 fn test_verifier_fail() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         mov32 r0, 0xBEE
         exit",
@@ -86,16 +86,14 @@ fn test_verifier_fail() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<ContradictionVerifier, TestInstructionMeter>::from_executable(
-            executable,
-        )
-        .unwrap();
+        VerifiedExecutable::<ContradictionVerifier, TestContextObject>::from_executable(executable)
+            .unwrap();
 }
 
 #[test]
 #[should_panic(expected = "DivisionByZero(30)")]
 fn test_verifier_err_div_by_zero_imm() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         mov32 r0, 1
         div32 r0, 0
@@ -105,7 +103,7 @@ fn test_verifier_err_div_by_zero_imm() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
@@ -117,7 +115,7 @@ fn test_verifier_err_endian_size() {
         0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
         Config::default(),
         SyscallRegistry::default(),
@@ -125,7 +123,7 @@ fn test_verifier_err_endian_size() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
@@ -137,7 +135,7 @@ fn test_verifier_err_incomplete_lddw() {
         0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
         Config::default(),
         SyscallRegistry::default(),
@@ -145,7 +143,7 @@ fn test_verifier_err_incomplete_lddw() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
@@ -154,7 +152,7 @@ fn test_verifier_err_invalid_reg_dst() {
     // r11 is disabled when dynamic_stack_frames=false, and only sub and add are
     // allowed when dynamic_stack_frames=true
     for dynamic_stack_frames in [false, true] {
-        let executable = assemble::<TestInstructionMeter>(
+        let executable = assemble::<TestContextObject>(
             "
             mov r11, 1
             exit",
@@ -166,10 +164,8 @@ fn test_verifier_err_invalid_reg_dst() {
         )
         .unwrap();
         let result =
-            VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(
-                executable,
-            )
-            .map_err(|err| format!("Executable constructor {:?}", err));
+            VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
+                .map_err(|err| format!("Executable constructor {:?}", err));
 
         assert_eq!(
             result.unwrap_err(),
@@ -183,7 +179,7 @@ fn test_verifier_err_invalid_reg_src() {
     // r11 is disabled when dynamic_stack_frames=false, and only sub and add are
     // allowed when dynamic_stack_frames=true
     for dynamic_stack_frames in [false, true] {
-        let executable = assemble::<TestInstructionMeter>(
+        let executable = assemble::<TestContextObject>(
             "
             mov r0, r11
             exit",
@@ -195,10 +191,8 @@ fn test_verifier_err_invalid_reg_src() {
         )
         .unwrap();
         let result =
-            VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(
-                executable,
-            )
-            .map_err(|err| format!("Executable constructor {:?}", err));
+            VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
+                .map_err(|err| format!("Executable constructor {:?}", err));
 
         assert_eq!(
             result.unwrap_err(),
@@ -209,7 +203,7 @@ fn test_verifier_err_invalid_reg_src() {
 
 #[test]
 fn test_verifier_resize_stack_ptr_success() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         sub r11, 1
         add r11, 1
@@ -223,14 +217,14 @@ fn test_verifier_resize_stack_ptr_success() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JumpToMiddleOfLDDW(2, 29)")]
 fn test_verifier_err_jmp_lddw() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         ja +1
         lddw r0, 0x1122334455667788
@@ -240,14 +234,14 @@ fn test_verifier_err_jmp_lddw() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JumpOutOfCode(3, 29)")]
 fn test_verifier_err_jmp_out() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         ja +2
         exit",
@@ -256,14 +250,14 @@ fn test_verifier_err_jmp_out() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
 #[test]
 #[should_panic(expected = "JumpOutOfCode(18446744073709551615, 29)")]
 fn test_verifier_err_jmp_out_start() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         ja -2
         exit",
@@ -272,7 +266,7 @@ fn test_verifier_err_jmp_out_start() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
@@ -283,7 +277,7 @@ fn test_verifier_err_unknown_opcode() {
         0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let executable = Executable::<TestInstructionMeter>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
         Config::default(),
         SyscallRegistry::default(),
@@ -291,14 +285,14 @@ fn test_verifier_err_unknown_opcode() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
 #[test]
 #[should_panic(expected = "CannotWriteR10(29)")]
 fn test_verifier_err_write_r10() {
-    let executable = assemble::<TestInstructionMeter>(
+    let executable = assemble::<TestContextObject>(
         "
         mov r10, 1
         exit",
@@ -307,7 +301,7 @@ fn test_verifier_err_write_r10() {
     )
     .unwrap();
     let _verified_executable =
-        VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(executable)
+        VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
             .unwrap();
 }
 
@@ -339,17 +333,12 @@ fn test_verifier_err_all_shift_overflows() {
 
     for (overflowing_instruction, expected) in testcases {
         let assembly = format!("\n{}\nexit", overflowing_instruction);
-        let executable = assemble::<TestInstructionMeter>(
-            &assembly,
-            Config::default(),
-            SyscallRegistry::default(),
-        )
-        .unwrap();
+        let executable =
+            assemble::<TestContextObject>(&assembly, Config::default(), SyscallRegistry::default())
+                .unwrap();
         let result =
-            VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(
-                executable,
-            )
-            .map_err(|err| format!("Executable constructor {:?}", err));
+            VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(executable)
+                .map_err(|err| format!("Executable constructor {:?}", err));
         match expected {
             Ok(()) => assert!(result.is_ok()),
             Err(overflow_msg) => match result {
@@ -375,7 +364,7 @@ fn test_sdiv_disabled() {
     for (opc, instruction) in instructions {
         for enable_sdiv in [true, false] {
             let assembly = format!("\n{}\nexit", instruction);
-            let executable = assemble::<TestInstructionMeter>(
+            let executable = assemble::<TestContextObject>(
                 &assembly,
                 Config {
                     enable_sdiv,
@@ -385,7 +374,7 @@ fn test_sdiv_disabled() {
             )
             .unwrap();
             let result =
-                VerifiedExecutable::<RequisiteVerifier, TestInstructionMeter>::from_executable(
+                VerifiedExecutable::<RequisiteVerifier, TestContextObject>::from_executable(
                     executable,
                 )
                 .map_err(|err| format!("Executable constructor {:?}", err));


### PR DESCRIPTION
Renames `syscall_context_object` to `context_object` and merges `InstructionMeter` into it.

This simplifies a few things as both are always required in the VM, and in the program runtime they are both contained in the same struct, so one pointer to them suffices.