### PR TITLE
Refactor - Move function names in `BuiltInPrograms`

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -21,7 +21,7 @@ use test::Bencher;
 fn loader() -> Arc<BuiltInProgram<TestContextObject>> {
     let mut loader = BuiltInProgram::default();
     loader
-        .register_function_by_name(b"log_64", bpf_syscall_u64)
+        .register_function_by_name("log_64", bpf_syscall_u64)
         .unwrap();
     Arc::new(loader)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -200,9 +200,10 @@ fn main() {
     if matches.is_present("trace") {
         println!("Trace:\n");
         let stdout = std::io::stdout();
-        vm.env
-            .context_object_pointer
-            .write_trace_log(&mut stdout.lock(), analysis.as_ref().unwrap())
+        analysis
+            .as_ref()
+            .unwrap()
+            .disassemble_trace_log(&mut stdout.lock(), &vm.env.context_object_pointer.trace_log)
             .unwrap();
     }
     if matches.is_present("profile") {

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -12,7 +12,6 @@ use std::path::PathBuf;
 
 extern crate solana_rbpf;
 use solana_rbpf::{
-    disassembler::disassemble_instruction,
     elf::Executable,
     static_analysis::Analysis,
     vm::{BuiltInProgram, Config, FunctionRegistry, TestContextObject},
@@ -52,11 +51,8 @@ fn to_json(program: &[u8]) -> String {
             // number is negative. When values takes more than 32 bits with `lddw`, the cast
             // has no effect and the complete value is printed anyway.
             "imm"  => format!("{:#x}", insn.imm as i32), // => insn.imm,
-            "desc" => disassemble_instruction(
-                insn,
-                &analysis.cfg_nodes,
-                analysis.executable.get_loader(),
-                analysis.executable.get_function_registry(),
+            "desc" => analysis.disassemble_instruction(
+                insn
             ),
         ));
     }

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -55,7 +55,7 @@ fn to_json(program: &[u8]) -> String {
             "desc" => disassemble_instruction(
                 insn,
                 &analysis.cfg_nodes,
-                analysis.executable.get_external_functions(),
+                analysis.executable.get_loader(),
                 analysis.executable.get_function_registry(),
             ),
         ));

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -10,7 +10,7 @@
 
 use crate::ebpf;
 use crate::static_analysis::CfgNode;
-use crate::vm::FunctionRegistry;
+use crate::vm::{BuiltInProgram, ContextObject, FunctionRegistry};
 use std::collections::BTreeMap;
 
 fn resolve_label(cfg_nodes: &BTreeMap<usize, CfgNode>, pc: usize) -> &str {
@@ -120,10 +120,10 @@ fn jmp_reg_str(name: &str, insn: &ebpf::Insn, cfg_nodes: &BTreeMap<usize, CfgNod
 
 /// Disassemble an eBPF instruction
 #[rustfmt::skip]
-pub fn disassemble_instruction(
+pub fn disassemble_instruction<C: ContextObject>(
     insn: &ebpf::Insn, 
     cfg_nodes: &BTreeMap<usize, CfgNode>, 
-    external_functions: &BTreeMap<u32, String>,
+    loader: &BuiltInProgram<C>,
     function_registry: &FunctionRegistry,
 ) -> String {
     let name;
@@ -250,7 +250,7 @@ pub fn disassemble_instruction(
         ebpf::JSLE_IMM   => { name = "jsle"; desc = jmp_imm_str(name, insn, cfg_nodes); },
         ebpf::JSLE_REG   => { name = "jsle"; desc = jmp_reg_str(name, insn, cfg_nodes); },
         ebpf::CALL_IMM   => {
-            desc = if let Some(function_name) = external_functions.get(&(insn.imm as u32)) {
+            desc = if let Some((function_name, _function)) = loader.lookup_function(insn.imm as u32) {
                 name = "syscall";
                 format!("{} {}", name, function_name)
             } else {

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -10,7 +10,7 @@
 
 use crate::ebpf;
 use crate::static_analysis::CfgNode;
-use crate::vm::{BuiltInProgram, ContextObject, FunctionRegistry};
+use crate::vm::{BuiltInProgram, ContextObject};
 use std::collections::BTreeMap;
 
 fn resolve_label(cfg_nodes: &BTreeMap<usize, CfgNode>, pc: usize) -> &str {
@@ -124,7 +124,6 @@ pub fn disassemble_instruction<C: ContextObject>(
     insn: &ebpf::Insn, 
     cfg_nodes: &BTreeMap<usize, CfgNode>, 
     loader: &BuiltInProgram<C>,
-    function_registry: &FunctionRegistry,
 ) -> String {
     let name;
     let desc;
@@ -255,11 +254,7 @@ pub fn disassemble_instruction<C: ContextObject>(
                 format!("{} {}", name, function_name)
             } else {
                 name = "call";
-                if let Some((target_pc, _name)) = function_registry.get(&(insn.imm as u32)) {
-                    format!("{} {}", name, resolve_label(cfg_nodes, *target_pc))
-                } else {
-                    format!("{} [invalid]", name)
-                }
+                format!("{} {}", name, resolve_label(cfg_nodes, insn.imm as usize))
             };
         },
         ebpf::CALL_REG   => { name = "callx"; desc = format!("{} r{}", name, insn.imm); },

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,15 +32,9 @@ pub enum EbpfError {
     /// ELF error
     #[error("ELF error: {0}")]
     ElfError(#[from] ElfError),
-    /// Syscall was already registered before
-    #[error("syscall #{0} was already registered before")]
-    SyscallAlreadyRegistered(usize),
-    /// Syscall was not registered before bind
-    #[error("syscall #{0} was not registered before bind")]
-    SyscallNotRegistered(usize),
-    /// Syscall already has a bound context object
-    #[error("syscall #{0} already has a bound context object")]
-    SyscallAlreadyBound(usize),
+    /// Function was already registered
+    #[error("function #{0} was already registered")]
+    FunctionAlreadyRegistered(usize),
     /// Exceeded max BPF to BPF call depth
     #[error("exceeded max BPF to BPF call depth of {1} at instruction #{0}")]
     CallDepthExceeded(usize, usize),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -448,7 +448,7 @@ impl<'a, 'b, V: Verifier, C: ContextObject> Interpreter<'a, 'b, V, C> {
                 };
 
                 if external {
-                    if let Some(function) = executable.get_loader().lookup_function(insn.imm as u32) {
+                    if let Some((_function_name, function)) = executable.get_loader().lookup_function(insn.imm as u32) {
                         resolved = true;
 
                         if config.enable_instruction_meter {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -612,7 +612,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     };
 
                     if external {
-                        if let Some(function) = self.executable.get_loader().lookup_function(insn.imm as u32) {
+                        if let Some((_function_name, function)) = self.executable.get_loader().lookup_function(insn.imm as u32) {
                             if self.config.enable_instruction_meter {
                                 self.emit_validate_and_profile_instruction_count(true, Some(0));
                             }
@@ -1572,7 +1572,7 @@ mod tests {
         };
         let mut loader = BuiltInProgram::default();
         loader
-            .register_function_by_hash(0xFFFFFFFF, syscalls::bpf_gather_bytes)
+            .register_function_by_name("gather_bytes", syscalls::bpf_gather_bytes)
             .unwrap();
         let mut function_registry = FunctionRegistry::default();
         function_registry.insert(0xFFFFFFFF, (8, "foo".to_string()));

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1575,7 +1575,7 @@ mod tests {
             .register_function_by_name("gather_bytes", syscalls::bpf_gather_bytes)
             .unwrap();
         let mut function_registry = FunctionRegistry::default();
-        function_registry.insert(0xFFFFFFFF, (8, "foo".to_string()));
+        function_registry.insert(8, (8, "function_foo".to_string()));
         Executable::<TestContextObject>::from_text_bytes(
             program,
             config,
@@ -1601,20 +1601,23 @@ mod tests {
         };
         assert!(empty_program_machine_code_length <= MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH);
 
-        for opcode in 0..255 {
+        for mut opcode in 0x00..=0xFF {
+            let immediate = match opcode {
+                0x85 | 0x8D => 8,
+                0x86 => {
+                    // Put external function calls on a separate loop iteration
+                    opcode = 0x85;
+                    0x91020CDD
+                }
+                0xD4 | 0xDC => 16,
+                _ => 0xFFFFFFFF,
+            };
             for pc in 0..INSTRUCTION_COUNT {
                 prog[pc * ebpf::INSN_SIZE] = opcode;
                 prog[pc * ebpf::INSN_SIZE + 1] = 0x88;
                 prog[pc * ebpf::INSN_SIZE + 2] = 0xFF;
                 prog[pc * ebpf::INSN_SIZE + 3] = 0xFF;
-                LittleEndian::write_u32(
-                    &mut prog[pc * ebpf::INSN_SIZE + 4..],
-                    match opcode {
-                        0x8D => 8,
-                        0xD4 | 0xDC => 16,
-                        _ => 0xFFFFFFFF,
-                    },
-                );
+                LittleEndian::write_u32(&mut prog[pc * ebpf::INSN_SIZE + 4..], immediate);
             }
             let mut executable = create_mockup_executable(&prog);
             let result = Executable::<TestContextObject>::jit_compile(&mut executable);
@@ -1631,6 +1634,7 @@ mod tests {
                 .machine_code_length()
                 - empty_program_machine_code_length;
             let instruction_count = if opcode == 0x18 {
+                // LDDW takes two slots
                 INSTRUCTION_COUNT / 2
             } else {
                 INSTRUCTION_COUNT
@@ -1638,6 +1642,12 @@ mod tests {
             let machine_code_length_per_instruction =
                 (machine_code_length as f64 / instruction_count as f64 + 0.5) as usize;
             assert!(machine_code_length_per_instruction <= MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION);
+            /*println!("opcode={:02X} machine_code_length_per_instruction={}", opcode, machine_code_length_per_instruction);
+            let analysis = crate::static_analysis::Analysis::from_executable(&executable).unwrap();
+            {
+                let stdout = std::io::stdout();
+                analysis.disassemble(&mut stdout.lock()).unwrap();
+            }*/
         }
     }
 }

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -216,10 +216,10 @@ impl<'a, C: ContextObject> Analysis<'a, C> {
             let target_pc = (insn.ptr as isize + insn.off as isize + 1) as usize;
             match insn.opc {
                 ebpf::CALL_IMM => {
-                    if let Some(function_name) = self
+                    if let Some((function_name, _function)) = self
                         .executable
-                        .get_external_functions()
-                        .get(&(insn.imm as u32))
+                        .get_loader()
+                        .lookup_function(insn.imm as u32)
                     {
                         if function_name == "abort" {
                             self.cfg_nodes
@@ -451,7 +451,7 @@ impl<'a, C: ContextObject> Analysis<'a, C> {
             let desc = disassemble_instruction(
                 insn,
                 &self.cfg_nodes,
-                self.executable.get_external_functions(),
+                self.executable.get_loader(),
                 self.executable.get_function_registry(),
             );
             writeln!(output, "    {}", desc)?;
@@ -509,7 +509,7 @@ impl<'a, C: ContextObject> Analysis<'a, C> {
                     let desc = disassemble_instruction(
                         insn,
                         &analysis.cfg_nodes,
-                        analysis.executable.get_external_functions(),
+                        analysis.executable.get_loader(),
                         analysis.executable.get_function_registry(),
                     );
                     if let Some(split_index) = desc.find(' ') {

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -448,12 +448,7 @@ impl<'a> Analysis<'a> {
 
     /// Generates assembler code for a single instruction
     pub fn disassemble_instruction(&self, insn: &ebpf::Insn) -> String {
-        disassemble_instruction(
-            insn,
-            &self.cfg_nodes,
-            self.executable.get_loader(),
-            self.executable.get_function_registry(),
-        )
+        disassemble_instruction(insn, &self.cfg_nodes, self.executable.get_loader())
     }
 
     /// Generates assembler code for the analyzed executable

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -125,7 +125,7 @@ impl<C: ContextObject> BuiltInProgram<C> {
     ) -> Result<(), EbpfError> {
         let key = ebpf::hash_symbol_name(name.as_bytes());
         if self.functions.insert(key, (name, function)).is_some() {
-            Err(EbpfError::SyscallAlreadyRegistered(key as usize))
+            Err(EbpfError::FunctionAlreadyRegistered(key as usize))
         } else {
             Ok(())
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -374,10 +374,10 @@ impl TestContextObject {
     }
 
     /// Use this method to print the trace log
-    pub fn write_trace_log<W: std::io::Write, C: ContextObject>(
+    pub fn write_trace_log<W: std::io::Write>(
         &self,
         output: &mut W,
-        analysis: &Analysis<C>,
+        analysis: &Analysis,
     ) -> Result<(), std::io::Error> {
         let mut pc_to_insn_index = vec![
             0usize;
@@ -429,7 +429,7 @@ pub struct DynamicAnalysis {
 
 impl DynamicAnalysis {
     /// Accumulates a trace
-    pub fn new<C: ContextObject>(trace_log: &[[u64; 12]], analysis: &Analysis<C>) -> Self {
+    pub fn new(trace_log: &[[u64; 12]], analysis: &Analysis) -> Self {
         let mut result = Self {
             edge_counter_max: 0,
             edges: BTreeMap::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -14,7 +14,6 @@
 
 use crate::{
     aligned_memory::AlignedMemory,
-    disassembler::disassemble_instruction,
     ebpf,
     elf::Executable,
     error::EbpfError,
@@ -401,12 +400,7 @@ impl TestContextObject {
                 index,
                 &entry[0..11],
                 pc + ebpf::ELF_INSN_DUMP_OFFSET,
-                disassemble_instruction(
-                    insn,
-                    &analysis.cfg_nodes,
-                    analysis.executable.get_loader(),
-                    analysis.executable.get_function_registry()
-                ),
+                analysis.disassemble_instruction(insn),
             )?;
         }
         Ok(())

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -106,10 +106,10 @@ fn test_fuzz_execute() {
 
     let mut loader = BuiltInProgram::default();
     loader
-        .register_function_by_name(b"log", syscalls::bpf_syscall_string)
+        .register_function_by_name("log", syscalls::bpf_syscall_string)
         .unwrap();
     loader
-        .register_function_by_name(b"log_64", syscalls::bpf_syscall_u64)
+        .register_function_by_name("log_64", syscalls::bpf_syscall_u64)
         .unwrap();
     let loader = Arc::new(loader);
 

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -90,11 +90,14 @@ macro_rules! test_interpreter_and_jit {
                         )
                         .unwrap();
                         let stdout = std::io::stdout();
-                        _tracer_interpreter
-                            .write_trace_log(&mut stdout.lock(), &analysis)
+                        analysis
+                            .disassemble_trace_log(
+                                &mut stdout.lock(),
+                                &_tracer_interpreter.trace_log,
+                            )
                             .unwrap();
-                        tracer_jit
-                            .write_trace_log(&mut stdout.lock(), &analysis)
+                        analysis
+                            .disassemble_trace_log(&mut stdout.lock(), &tracer_jit.trace_log)
                             .unwrap();
                         panic!();
                     }
@@ -4090,11 +4093,11 @@ fn execute_generated_program(prog: &[u8]) -> bool {
         println!("result_interpreter={:?}", result_interpreter);
         println!("result_jit={:?}", result_jit);
         let stdout = std::io::stdout();
-        tracer_interpreter
-            .write_trace_log(&mut stdout.lock(), &analysis)
+        analysis
+            .disassemble_trace_log(&mut stdout.lock(), &tracer_interpreter.trace_log)
             .unwrap();
-        tracer_jit
-            .write_trace_log(&mut stdout.lock(), &analysis)
+        analysis
+            .disassemble_trace_log(&mut stdout.lock(), &tracer_jit.trace_log)
             .unwrap();
         panic!();
     }

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -2252,8 +2252,8 @@ fn test_stack2() {
         exit",
         [],
         (
-            b"bpf_mem_frob" => syscalls::bpf_mem_frob,
-            b"bpf_gather_bytes" => syscalls::bpf_gather_bytes,
+            "bpf_mem_frob" => syscalls::bpf_mem_frob,
+            "bpf_gather_bytes" => syscalls::bpf_gather_bytes,
         ),
         TestContextObject::new(16),
         { |_vm, res: ProgramResult| { res.unwrap() == 0x01020304 } },
@@ -2294,7 +2294,7 @@ fn test_string_stack() {
         exit",
         [],
         (
-            b"bpf_str_cmp" => syscalls::bpf_str_cmp,
+            "bpf_str_cmp" => syscalls::bpf_str_cmp,
         ),
         TestContextObject::new(28),
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0 } },
@@ -2621,7 +2621,7 @@ fn test_relative_call() {
         "tests/elfs/relative_call.so",
         [1],
         (
-            b"log" => syscalls::bpf_syscall_string,
+            "log" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(14),
         { |_vm, res: ProgramResult| { res.unwrap() == 2 } },
@@ -2634,7 +2634,7 @@ fn test_bpf_to_bpf_scratch_registers() {
         "tests/elfs/scratch_registers.so",
         [1],
         (
-            b"log_64" => syscalls::bpf_syscall_u64,
+            "log_64" => syscalls::bpf_syscall_u64,
         ),
         TestContextObject::new(41),
         { |_vm, res: ProgramResult| { res.unwrap() == 112 } },
@@ -2664,7 +2664,7 @@ fn test_syscall_parameter_on_stack() {
         exit",
         [],
         (
-            b"bpf_syscall_string" => syscalls::bpf_syscall_string,
+            "bpf_syscall_string" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(6),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -2899,7 +2899,7 @@ fn test_bpf_to_bpf_depth() {
             config,
             [i as u8],
             (
-                b"log" => syscalls::bpf_syscall_string,
+                "log" => syscalls::bpf_syscall_string,
             ),
             TestContextObject::new(if i == 0 { 4 } else { 3 + 10 * i as u64 }),
             { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -2915,7 +2915,7 @@ fn test_err_bpf_to_bpf_too_deep() {
         config,
         [config.max_call_depth as u8],
         (
-            b"log" => syscalls::bpf_syscall_string,
+            "log" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(176),
         {
@@ -2989,7 +2989,7 @@ fn test_err_syscall_string() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"bpf_syscall_string" => syscalls::bpf_syscall_string,
+            "bpf_syscall_string" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(2),
         {
@@ -3013,7 +3013,7 @@ fn test_syscall_string() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"bpf_syscall_string" => syscalls::bpf_syscall_string,
+            "bpf_syscall_string" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(4),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3034,7 +3034,7 @@ fn test_syscall() {
         exit",
         [],
         (
-            b"bpf_syscall_u64" => syscalls::bpf_syscall_u64,
+            "bpf_syscall_u64" => syscalls::bpf_syscall_u64,
         ),
         TestContextObject::new(8),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3054,7 +3054,7 @@ fn test_call_gather_bytes() {
         exit",
         [],
         (
-            b"bpf_gather_bytes" => syscalls::bpf_gather_bytes,
+            "bpf_gather_bytes" => syscalls::bpf_gather_bytes,
         ),
         TestContextObject::new(7),
         { |_vm, res: ProgramResult| { res.unwrap() == 0x0102030405 } },
@@ -3076,7 +3076,7 @@ fn test_call_memfrob() {
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
         ],
         (
-            b"bpf_mem_frob" => syscalls::bpf_mem_frob,
+            "bpf_mem_frob" => syscalls::bpf_mem_frob,
         ),
         TestContextObject::new(7),
         { |_vm, res: ProgramResult| { res.unwrap() == 0x102292e2f2c0708 } },
@@ -3098,7 +3098,7 @@ fn nested_vm_syscall(
     if depth > 0 {
         let mut loader = BuiltInProgram::default();
         loader
-            .register_function_by_name(b"nested_vm_syscall", nested_vm_syscall)
+            .register_function_by_name("nested_vm_syscall", nested_vm_syscall)
             .unwrap();
         let mem = [depth as u8 - 1, throw as u8];
         let mut executable = assemble::<TestContextObject>(
@@ -3173,8 +3173,8 @@ fn test_load_elf() {
         "tests/elfs/noop.so",
         [],
         (
-            b"log" => syscalls::bpf_syscall_string,
-            b"log_64" => syscalls::bpf_syscall_u64,
+            "log" => syscalls::bpf_syscall_string,
+            "log_64" => syscalls::bpf_syscall_u64,
         ),
         TestContextObject::new(11),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3187,7 +3187,7 @@ fn test_load_elf_empty_noro() {
         "tests/elfs/noro.so",
         [],
         (
-            b"log_64" => syscalls::bpf_syscall_u64,
+            "log_64" => syscalls::bpf_syscall_u64,
         ),
         TestContextObject::new(8),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3200,7 +3200,7 @@ fn test_load_elf_empty_rodata() {
         "tests/elfs/empty_rodata.so",
         [],
         (
-            b"log_64" => syscalls::bpf_syscall_u64,
+            "log_64" => syscalls::bpf_syscall_u64,
         ),
         TestContextObject::new(8),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3249,7 +3249,7 @@ fn test_custom_entrypoint() {
         ..Config::default()
     };
     let mut loader = BuiltInProgram::default();
-    test_interpreter_and_jit!(register, loader, b"log_64" => syscalls::bpf_syscall_u64);
+    test_interpreter_and_jit!(register, loader, "log_64" => syscalls::bpf_syscall_u64);
     #[allow(unused_mut)]
     let mut executable =
         Executable::<TestContextObject>::from_elf(&elf, config, Arc::new(loader)).unwrap();
@@ -3357,7 +3357,7 @@ fn test_instruction_count_syscall() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"bpf_syscall_string" => syscalls::bpf_syscall_string,
+            "bpf_syscall_string" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(4),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3374,7 +3374,7 @@ fn test_err_instruction_count_syscall_capped() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"bpf_syscall_string" => syscalls::bpf_syscall_string,
+            "bpf_syscall_string" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(3),
         {
@@ -3455,7 +3455,7 @@ fn test_err_non_terminate_capped() {
         exit",
         [],
         (
-            b"bpf_trace_printf" => syscalls::bpf_trace_printf,
+            "bpf_trace_printf" => syscalls::bpf_trace_printf,
         ),
         TestContextObject::new(6),
         {
@@ -3481,7 +3481,7 @@ fn test_err_non_terminate_capped() {
         exit",
         [],
         (
-            b"bpf_trace_printf" => syscalls::bpf_trace_printf,
+            "bpf_trace_printf" => syscalls::bpf_trace_printf,
         ),
         TestContextObject::new(1000),
         {
@@ -3617,7 +3617,7 @@ fn test_symbol_relocation() {
         exit",
         [72, 101, 108, 108, 111],
         (
-            b"bpf_syscall_string" => syscalls::bpf_syscall_string
+            "bpf_syscall_string" => syscalls::bpf_syscall_string
         ),
         TestContextObject::new(6),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3648,7 +3648,7 @@ fn test_err_call_unresolved() {
 #[test]
 fn test_err_unresolved_elf() {
     let mut loader = BuiltInProgram::default();
-    test_interpreter_and_jit!(register, loader, b"log" => syscalls::bpf_syscall_string);
+    test_interpreter_and_jit!(register, loader, "log" => syscalls::bpf_syscall_string);
     let mut file = File::open("tests/elfs/unresolved_syscall.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
@@ -3667,7 +3667,7 @@ fn test_syscall_static() {
         "tests/elfs/syscall_static.so",
         [],
         (
-            b"log" => syscalls::bpf_syscall_string,
+            "log" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(5),
         { |_vm, res: ProgramResult| { res.unwrap() == 0 } },
@@ -3684,7 +3684,7 @@ fn test_syscall_unknown_static() {
         "tests/elfs/syscall_static_unknown.so",
         [],
         (
-            b"log" => syscalls::bpf_syscall_string,
+            "log" => syscalls::bpf_syscall_string,
         ),
         TestContextObject::new(1),
         { |_vm, res: ProgramResult| { matches!(res.unwrap_err(), EbpfError::UnsupportedInstruction(29)) } },


### PR DESCRIPTION
`Analysis` is now free of generic parameters and can be reused to write multiple trace logs of the same `Executable` with `Analysis::disassemble_trace_log()` independent of `TestContextObject`.