### PR TITLE
Add load(), store() and region() methods to MemoryMapping

### DIFF
--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -306,10 +306,10 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation, vm_add
             let _ = memory_mapping.map(AccessType::Load, vm_addr, 8, 0).unwrap();
         }),
         MemoryOperation::Load => bencher.iter(|| {
-            let _ = memory_mapping.load(vm_addr, 8, 0).unwrap();
+            let _ = memory_mapping.load::<u64>(vm_addr, 0).unwrap();
         }),
         MemoryOperation::Store(val) => bencher.iter(|| {
-            let _ = memory_mapping.store(val, vm_addr, 8, 0).unwrap();
+            let _ = memory_mapping.store(val, vm_addr, 0).unwrap();
         }),
     }
 }

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -281,3 +281,60 @@ bench_mapping_with_n_entries!(
     bench_mapping_with_1024_entries_aligned,
     bench_mapping_with_1024_entries_unaligned
 );
+
+enum MemoryOperation {
+    Map,
+    Load,
+    Store(u64),
+}
+
+fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation, vm_addr: u64) {
+    let mut mem1 = vec![0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18];
+    let mut mem2 = vec![0x22; 1];
+    let config = Config::default();
+    let memory_mapping = UnalignedMemoryMapping::new(
+        vec![
+            MemoryRegion::new_writable(&mut mem1, 0x100000000),
+            MemoryRegion::new_writable(&mut mem2, 0x100000000 + 8),
+        ],
+        &config,
+    )
+    .unwrap();
+
+    match op {
+        MemoryOperation::Map => bencher.iter(|| {
+            let _ = memory_mapping.map(AccessType::Load, vm_addr, 8, 0).unwrap();
+        }),
+        MemoryOperation::Load => bencher.iter(|| {
+            let _ = memory_mapping.load(vm_addr, 8, 0).unwrap();
+        }),
+        MemoryOperation::Store(val) => bencher.iter(|| {
+            let _ = memory_mapping.store(val, vm_addr, 8, 0).unwrap();
+        }),
+    }
+}
+
+#[bench]
+fn bench_mapping_8_byte_map(bencher: &mut Bencher) {
+    do_bench_mapping_operation(bencher, MemoryOperation::Map, 0x100000000)
+}
+
+#[bench]
+fn bench_mapping_8_byte_load(bencher: &mut Bencher) {
+    do_bench_mapping_operation(bencher, MemoryOperation::Load, 0x100000000)
+}
+
+#[bench]
+fn bench_mapping_8_byte_load_non_contiguous(bencher: &mut Bencher) {
+    do_bench_mapping_operation(bencher, MemoryOperation::Load, 0x100000001)
+}
+
+#[bench]
+fn bench_mapping_8_byte_store(bencher: &mut Bencher) {
+    do_bench_mapping_operation(bencher, MemoryOperation::Store(42), 0x100000000)
+}
+
+#[bench]
+fn bench_mapping_8_byte_store_non_contiguous(bencher: &mut Bencher) {
+    do_bench_mapping_operation(bencher, MemoryOperation::Store(42), 0x100000001)
+}

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -191,7 +191,9 @@ const ANCHOR_EXTERNAL_FUNCTION_CALL: usize = 12;
 const ANCHOR_ANCHOR_INTERNAL_FUNCTION_CALL_PROLOGUE: usize = 13;
 const ANCHOR_ANCHOR_INTERNAL_FUNCTION_CALL_REG: usize = 14;
 const ANCHOR_TRANSLATE_MEMORY_ADDRESS: usize = 22;
-const ANCHOR_COUNT: usize = 31; // Update me when adding or removing anchors
+const ANCHOR_LOAD_MEMORY_ADDRESS: usize = 30;
+const ANCHOR_STORE_MEMORY_ADDRESS: usize = 33;
+const ANCHOR_COUNT: usize = 36; // Update me when adding or removing anchors
 
 const REGISTER_MAP: [u8; 11] = [
     CALLER_SAVED_REGISTERS[0],
@@ -421,16 +423,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_ins(X86Instruction::load(OperandSize::S8, R11, dst, X86IndirectAccess::Offset(0)));
                 },
                 ebpf::LD_H_REG   => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 2, AccessType::Load);
-                    self.emit_ins(X86Instruction::load(OperandSize::S16, R11, dst, X86IndirectAccess::Offset(0)));
+                    self.emit_memory_load(dst, Value::RegisterPlusConstant64(src, insn.off as i64, true), 2);
                 },
                 ebpf::LD_W_REG   => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 4, AccessType::Load);
-                    self.emit_ins(X86Instruction::load(OperandSize::S32, R11, dst, X86IndirectAccess::Offset(0)));
+                    self.emit_memory_load(dst, Value::RegisterPlusConstant64(src, insn.off as i64, true), 4);
                 },
                 ebpf::LD_DW_REG  => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(src, insn.off as i64, true), 8, AccessType::Load);
-                    self.emit_ins(X86Instruction::load(OperandSize::S64, R11, dst, X86IndirectAccess::Offset(0)));
+                    self.emit_memory_load(dst, Value::RegisterPlusConstant64(src, insn.off as i64, true), 8);
                 },
 
                 // BPF_ST class
@@ -439,16 +438,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_ins(X86Instruction::store_immediate(OperandSize::S8, R11, X86IndirectAccess::Offset(0), insn.imm));
                 },
                 ebpf::ST_H_IMM   => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, AccessType::Store);
-                    self.emit_ins(X86Instruction::store_immediate(OperandSize::S16, R11, X86IndirectAccess::Offset(0), insn.imm));
+                    self.emit_memory_store(Value::Constant64(insn.imm, false), Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2);
                 },
                 ebpf::ST_W_IMM   => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4, AccessType::Store);
-                    self.emit_ins(X86Instruction::store_immediate(OperandSize::S32, R11, X86IndirectAccess::Offset(0), insn.imm));
+                    self.emit_memory_store(Value::Constant64(insn.imm, false), Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4);
                 },
                 ebpf::ST_DW_IMM  => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, AccessType::Store);
-                    self.emit_ins(X86Instruction::store_immediate(OperandSize::S64, R11, X86IndirectAccess::Offset(0), insn.imm));
+                    self.emit_memory_store(Value::Constant64(insn.imm, false), Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8);
                 },
 
                 // BPF_STX class
@@ -457,16 +453,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_ins(X86Instruction::store(OperandSize::S8, src, R11, X86IndirectAccess::Offset(0)));
                 },
                 ebpf::ST_H_REG  => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, AccessType::Store);
-                    self.emit_ins(X86Instruction::store(OperandSize::S16, src, R11, X86IndirectAccess::Offset(0)));
+                    self.emit_memory_store(Value::Register(src), Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2);
                 },
                 ebpf::ST_W_REG  => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4, AccessType::Store);
-                    self.emit_ins(X86Instruction::store(OperandSize::S32, src, R11, X86IndirectAccess::Offset(0)));
+                    self.emit_memory_store(Value::Register(src), Value::RegisterPlusConstant64(dst, insn.off as i64, true), 4);
                 },
                 ebpf::ST_DW_REG  => {
-                    self.emit_address_translation(R11, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, AccessType::Store);
-                    self.emit_ins(X86Instruction::store(OperandSize::S64, src, R11, X86IndirectAccess::Offset(0)));
+                    self.emit_memory_store(Value::Register(src), Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8);
                 },
 
                 // BPF_ALU class
@@ -1033,6 +1026,63 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::mov(OperandSize::S64, R11, host_addr));
     }
 
+    fn emit_memory_load(&mut self, dst: u8, vm_addr: Value, len: u64) {
+        match vm_addr {
+            Value::RegisterPlusConstant64(reg, constant, user_provided) => {
+                if user_provided && self.should_sanitize_constant(constant) {
+                    self.emit_sanitized_load_immediate(OperandSize::S64, R11, constant);
+                } else {
+                    self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, R11, constant));
+                }
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, reg, R11, 0, None));
+            },
+            _ => {
+                #[cfg(debug_assertions)]
+                unreachable!();
+            },
+        }
+        let anchor = ANCHOR_LOAD_MEMORY_ADDRESS + len.trailing_zeros() as usize - 1;
+        self.emit_ins(X86Instruction::push_immediate(OperandSize::S64, self.pc as i32));
+        self.emit_ins(X86Instruction::call_immediate(self.relative_to_anchor(anchor, 5)));
+        self.emit_ins(X86Instruction::mov(OperandSize::S64, R11, dst));
+    }
+
+    fn emit_memory_store(&mut self, value: Value, vm_addr: Value, len: u64) {
+        match value {
+            Value::Register(reg) => {
+                self.emit_ins(X86Instruction::mov(OperandSize::S64, reg, R10));
+            }
+            Value::Constant64(constant, user_provided) => {
+                if user_provided && self.should_sanitize_constant(constant) {
+                    self.emit_sanitized_load_immediate(OperandSize::S64, R10, constant);
+                } else {
+                    self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, R10, constant));
+                }
+            }
+            _ => {
+                #[cfg(debug_assertions)]
+                unreachable!();
+            },
+        }
+        match vm_addr {
+            Value::RegisterPlusConstant64(reg, constant, user_provided) => {
+                if user_provided && self.should_sanitize_constant(constant) {
+                    self.emit_sanitized_load_immediate(OperandSize::S64, R11, constant);
+                } else {
+                    self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, R11, constant));
+                }
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, reg, R11, 0, None));
+            },
+            _ => {
+                #[cfg(debug_assertions)]
+                unreachable!();
+            },
+        }
+        let anchor = ANCHOR_STORE_MEMORY_ADDRESS + len.trailing_zeros() as usize - 1;
+        self.emit_ins(X86Instruction::push_immediate(OperandSize::S64, self.pc as i32));
+        self.emit_ins(X86Instruction::call_immediate(self.relative_to_anchor(anchor, 5)));
+    }
+
     #[inline]
     fn emit_conditional_branch_reg(&mut self, op: u8, bitwise: bool, first_operand: u8, second_operand: u8, target_pc: usize) {
         self.emit_validate_and_profile_instruction_count(false, Some(target_pc));
@@ -1443,6 +1493,55 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             // unwrap() the host addr into R11
             self.emit_ins(X86Instruction::lea(OperandSize::S64, RBP, R11, Some(X86IndirectAccess::Offset(self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult)))));
             self.emit_ins(X86Instruction::load(OperandSize::S64, R11, R11, X86IndirectAccess::Offset(8)));
+
+            self.emit_ins(X86Instruction::return_near());
+        }
+
+        // Load a value from a virtual memory address
+        for len in &[2i32, 4, 8] {
+            let target_offset = len.trailing_zeros() as usize - 1;
+            self.set_anchor(ANCHOR_LOAD_MEMORY_ADDRESS + target_offset);
+            // call MemoryMapping::load() storing the result in RuntimeEnvironmentSlot::ProgramResult
+            self.emit_rust_call(Value::Constant64(MemoryMapping::load as *const u8 as i64, false), &[
+                Argument { index: 2, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
+                Argument { index: 4, value: Value::Constant64(0, false) }, // self.pc is set later
+                Argument { index: 3, value: Value::Constant64(*len as i64, false) },
+                Argument { index: 1, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::MemoryMapping), false) },
+                Argument { index: 0, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult), false) },
+            ], None);
+
+            // Throw error if the result indicates one
+            self.emit_result_is_err(R11);
+            self.emit_ins(X86Instruction::pop(R11)); // R11 = self.pc
+            self.emit_ins(X86Instruction::xchg(OperandSize::S64, R11, RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Swap return address and self.pc
+            self.emit_ins(X86Instruction::conditional_jump_immediate(0x85, self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 6)));
+
+            // unwrap() the host addr into R11
+            self.emit_ins(X86Instruction::lea(OperandSize::S64, RBP, R11, Some(X86IndirectAccess::Offset(self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult)))));
+            self.emit_ins(X86Instruction::load(OperandSize::S64, R11, R11, X86IndirectAccess::Offset(8)));
+
+            self.emit_ins(X86Instruction::return_near());
+        }
+
+        // Store a value at a virtual memory address
+        for len in &[2i32, 4, 8] {
+            let target_offset = len.trailing_zeros() as usize - 1;
+            self.set_anchor(ANCHOR_STORE_MEMORY_ADDRESS + target_offset);
+            // call MemoryMapping::load() storing the result in RuntimeEnvironmentSlot::ProgramResult
+            self.emit_rust_call(Value::Constant64(MemoryMapping::store as *const u8 as i64, false), &[
+                Argument { index: 3, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
+                Argument { index: 2, value: Value::Register(R10) },
+                Argument { index: 5, value: Value::Constant64(0, false) }, // self.pc is set later
+                Argument { index: 4, value: Value::Constant64(*len as i64, false) },
+                Argument { index: 1, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::MemoryMapping), false) },
+                Argument { index: 0, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult), false) },
+            ], None);
+
+            // Throw error if the result indicates one
+            self.emit_result_is_err(R11);
+            self.emit_ins(X86Instruction::pop(R11)); // R11 = self.pc
+            self.emit_ins(X86Instruction::xchg(OperandSize::S64, R11, RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Swap return address and self.pc
+            self.emit_ins(X86Instruction::conditional_jump_immediate(0x85, self.relative_to_anchor(ANCHOR_EXCEPTION_AT, 6)));
 
             self.emit_ins(X86Instruction::return_near());
         }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1451,8 +1451,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 };
                 self.emit_rust_call(Value::Constant64(load, false), &[
                     Argument { index: 2, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
-                    Argument { index: 4, value: Value::Constant64(0, false) }, // self.pc is set later
-                    Argument { index: 3, value: Value::Constant64(*len as i64, false) },
+                    Argument { index: 3, value: Value::Constant64(0, false) }, // self.pc is set later
                     Argument { index: 1, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::MemoryMapping), false) },
                     Argument { index: 0, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult), false) },
                 ], None);
@@ -1467,8 +1466,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 self.emit_rust_call(Value::Constant64(store, false), &[
                     Argument { index: 3, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
                     Argument { index: 2, value: Value::Register(R10) },
-                    Argument { index: 5, value: Value::Constant64(0, false) }, // self.pc is set later
-                    Argument { index: 4, value: Value::Constant64(*len as i64, false) },
+                    Argument { index: 4, value: Value::Constant64(0, false) }, // self.pc is set later
                     Argument { index: 1, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::MemoryMapping), false) },
                     Argument { index: 0, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult), false) },
                 ], None);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1441,7 +1441,15 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     Argument { index: 0, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult), false) },
                 ], None);
             } else if *access_type == AccessType::Load {
-                self.emit_rust_call(Value::Constant64(MemoryMapping::load as *const u8 as i64, false), &[
+                let load = match len {
+                    1 => MemoryMapping::load::<u8> as *const u8 as i64,
+                    2 => MemoryMapping::load::<u16> as *const u8 as i64,
+                    4 => MemoryMapping::load::<u32> as *const u8 as i64,
+                    8 => MemoryMapping::load::<u64> as *const u8 as i64,
+                    _ => unreachable!()
+
+                };
+                self.emit_rust_call(Value::Constant64(load, false), &[
                     Argument { index: 2, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
                     Argument { index: 4, value: Value::Constant64(0, false) }, // self.pc is set later
                     Argument { index: 3, value: Value::Constant64(*len as i64, false) },
@@ -1449,7 +1457,14 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     Argument { index: 0, value: Value::RegisterPlusConstant32(RBP, self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult), false) },
                 ], None);
             } else {
-                self.emit_rust_call(Value::Constant64(MemoryMapping::store as *const u8 as i64, false), &[
+                let store = match len {
+                    1 => MemoryMapping::store::<u8> as *const u8 as i64,
+                    2 => MemoryMapping::store::<u16> as *const u8 as i64,
+                    4 => MemoryMapping::store::<u32> as *const u8 as i64,
+                    8 => MemoryMapping::store::<u64> as *const u8 as i64,
+                    _ => unreachable!()
+                };
+                self.emit_rust_call(Value::Constant64(store, false), &[
                     Argument { index: 3, value: Value::Register(R11) }, // Specify first as the src register could be overwritten by other arguments
                     Argument { index: 2, value: Value::Register(R10) },
                     Argument { index: 5, value: Value::Constant64(0, false) }, // self.pc is set later

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -5,7 +5,7 @@ use crate::{
     error::EbpfError,
     vm::{Config, ProgramResult},
 };
-use std::{array, cell::UnsafeCell, fmt, ops::Range};
+use std::{array, cell::UnsafeCell, fmt, ops::Range, ptr::copy_nonoverlapping};
 
 /* Explaination of the Gapped Memory
 
@@ -32,6 +32,8 @@ pub struct MemoryRegion {
     pub host_addr: u64,
     /// start virtual address
     pub vm_addr: u64,
+    /// end virtual address
+    pub vm_addr_end: u64,
     /// Length in bytes
     pub len: u64,
     /// Size of regular gaps as bit shift (63 means this region is continuous)
@@ -52,6 +54,7 @@ impl MemoryRegion {
         MemoryRegion {
             host_addr: slice.as_ptr() as u64,
             vm_addr,
+            vm_addr_end: vm_addr.saturating_add(slice.len() as u64),
             len: slice.len() as u64,
             vm_gap_shift,
             is_writable,
@@ -201,17 +204,13 @@ impl<'a> UnalignedMemoryMapping<'a> {
         Ok(result)
     }
 
-    /// Given a list of regions translate from virtual machine to host address
     #[allow(clippy::integer_arithmetic)]
-    pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64, pc: usize) -> ProgramResult {
-        // Safety:
-        // &mut references to the mapping cache are only created internally here
-        // and in replace_region(). The methods never invoke each other and
-        // UnalignedMemoryMapping is !Sync, so the cache reference below is
-        // guaranteed to be unique.
-        let cache = unsafe { &mut *self.cache.get() };
-        let (cache_miss, index) = if let Some(region) = cache.find(vm_addr) {
-            (false, region)
+    fn find_region(&self, cache: &mut MappingCache, vm_addr: u64) -> Option<&MemoryRegion> {
+        if let Some(index) = cache.find(vm_addr) {
+            // Safety:
+            // Cached index, we validated it before caching it. See the corresponding safety section
+            // in the miss branch.
+            Some(unsafe { self.regions.get_unchecked(index - 1) })
         } else {
             let mut index = 1;
             while index <= self.region_addresses.len() {
@@ -224,28 +223,170 @@ impl<'a> UnalignedMemoryMapping<'a> {
             }
             index >>= index.trailing_zeros() + 1;
             if index == 0 {
-                return generate_access_violation(self.config, access_type, vm_addr, len, pc);
+                return None;
             }
-            (true, index)
+            // Safety:
+            // we check for index==0 above, and by construction if we get here index
+            // must be contained in region
+            let region = unsafe { self.regions.get_unchecked(index - 1) };
+            cache.insert(
+                region.vm_addr..region.vm_addr.saturating_add(region.len),
+                index,
+            );
+            Some(region)
+        }
+    }
+
+    /// Given a list of regions translate from virtual machine to host address
+    pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64, pc: usize) -> ProgramResult {
+        // Safety:
+        // &mut references to the mapping cache are only created internally from methods that do not
+        // invoke each other. UnalignedMemoryMapping is !Sync, so the cache reference below is
+        // guaranteed to be unique.
+        let cache = unsafe { &mut *self.cache.get() };
+
+        let region = match self.find_region(cache, vm_addr) {
+            Some(res) => res,
+            None => return generate_access_violation(self.config, access_type, vm_addr, len, pc),
         };
 
-        // Safety:
-        // we check for index==0 above, and by construction if we get here index
-        // must be contained in region
-        let region = unsafe { self.regions.get_unchecked(index - 1) };
         if access_type == AccessType::Load || region.is_writable {
             if let ProgramResult::Ok(host_addr) = region.vm_to_host(vm_addr, len) {
-                if cache_miss {
-                    cache.insert(
-                        region.vm_addr..region.vm_addr.saturating_add(region.len),
-                        index,
-                    );
-                }
                 return ProgramResult::Ok(host_addr);
             }
         }
 
         generate_access_violation(self.config, access_type, vm_addr, len, pc)
+    }
+
+    /// Loads `len` bytes from the given address.
+    ///
+    /// See [MemoryMapping::load].
+    pub fn load(&self, mut vm_addr: u64, mut len: u64, pc: usize) -> ProgramResult {
+        debug_assert!(len <= 8);
+
+        // Safety:
+        // &mut references to the mapping cache are only created internally from methods that do not
+        // invoke each other. UnalignedMemoryMapping is !Sync, so the cache reference below is
+        // guaranteed to be unique.
+        let cache = unsafe { &mut *self.cache.get() };
+
+        let mut region = match self.find_region(cache, vm_addr) {
+            Some(region) => {
+                if let ProgramResult::Ok(host_addr) = region.vm_to_host(vm_addr, len) {
+                    // fast path
+                    return ProgramResult::Ok(read_uint(host_addr as *const _, len as usize));
+                }
+
+                region
+            }
+            None => {
+                return generate_access_violation(self.config, AccessType::Load, vm_addr, len, pc)
+            }
+        };
+
+        // slow path
+        let initial_len = len;
+        let initial_vm_addr = vm_addr;
+        let mut value = 0u64;
+        let mut ptr = &mut value as *mut _ as *mut u8;
+
+        while len > 0 {
+            let load_len = len.min(region.vm_addr_end.saturating_sub(vm_addr));
+            if let ProgramResult::Ok(host_addr) = region.vm_to_host(vm_addr, load_len) {
+                // Safety:
+                // We debug_assert!(len <= 8) so we're guaranteed to write
+                // inside `value`
+                unsafe {
+                    copy_nonoverlapping(host_addr as *const _, ptr, load_len as usize);
+                    ptr = ptr.add(load_len as usize);
+                };
+                len = len.saturating_sub(load_len);
+                if len == 0 {
+                    return ProgramResult::Ok(value);
+                }
+                vm_addr = vm_addr.saturating_add(load_len);
+                region = match self.find_region(cache, vm_addr) {
+                    Some(region) => region,
+                    None => break,
+                };
+            }
+        }
+
+        generate_access_violation(
+            self.config,
+            AccessType::Load,
+            initial_vm_addr,
+            initial_len,
+            pc,
+        )
+    }
+
+    /// Store `len` bytes from `value` at the given address.
+    ///
+    /// See [MemoryMapping::store].
+    pub fn store(&self, value: u64, mut vm_addr: u64, mut len: u64, pc: usize) -> ProgramResult {
+        debug_assert!(len <= 8);
+
+        // Safety:
+        // &mut references to the mapping cache are only created internally from methods that do not
+        // invoke each other. UnalignedMemoryMapping is !Sync, so the cache reference below is
+        // guaranteed to be unique.
+        let cache = unsafe { &mut *self.cache.get() };
+
+        let mut src = &value as *const _ as *const u8;
+
+        let mut region = match self.find_region(cache, vm_addr) {
+            Some(region) if region.is_writable => {
+                // fast path
+                if let ProgramResult::Ok(host_addr) = region.vm_to_host(vm_addr, len) {
+                    // Safety:
+                    // We debug_assert!(len <= 8) so we're guaranteed to write
+                    // inside `value`
+                    unsafe { copy_nonoverlapping(src, host_addr as *mut _, len as usize) };
+                    return ProgramResult::Ok(host_addr);
+                }
+                region
+            }
+            _ => {
+                return generate_access_violation(self.config, AccessType::Store, vm_addr, len, pc)
+            }
+        };
+
+        // slow path
+        let initial_len = len;
+        let initial_vm_addr = vm_addr;
+
+        while len > 0 {
+            if !region.is_writable {
+                break;
+            }
+            let write_len = len.min(region.vm_addr_end.saturating_sub(vm_addr));
+            if let ProgramResult::Ok(host_addr) = region.vm_to_host(vm_addr, write_len) {
+                // Safety:
+                // We debug_assert!(len <= 8) so we're guaranteed to write
+                // inside `value`
+                unsafe { copy_nonoverlapping(src, host_addr as *mut _, write_len as usize) };
+                len = len.saturating_sub(write_len);
+                if len == 0 {
+                    return ProgramResult::Ok(host_addr);
+                }
+                src = unsafe { src.add(write_len as usize) };
+                vm_addr = vm_addr.saturating_add(write_len);
+                region = match self.find_region(cache, vm_addr) {
+                    Some(region) => region,
+                    None => break,
+                };
+            }
+        }
+
+        generate_access_violation(
+            self.config,
+            AccessType::Store,
+            initial_vm_addr,
+            initial_len,
+            pc,
+        )
     }
 
     /// Returns the `MemoryRegion`s in this mapping
@@ -311,6 +452,43 @@ impl<'a> AlignedMemoryMapping<'a> {
         generate_access_violation(self.config, access_type, vm_addr, len, pc)
     }
 
+    /// Loads `len` bytes from the given address.
+    ///
+    /// See [MemoryMapping::load].
+    pub fn load(&self, vm_addr: u64, len: u64, pc: usize) -> ProgramResult {
+        match self.map(AccessType::Load, vm_addr, len, pc) {
+            ProgramResult::Ok(host_addr) => {
+                ProgramResult::Ok(read_uint(host_addr as *const _, len as usize))
+            }
+            err => err,
+        }
+    }
+
+    /// Store `len` bytes from `value` at the given address.
+    ///
+    /// See [MemoryMapping::store].
+    pub fn store(&self, value: u64, vm_addr: u64, len: u64, pc: usize) -> ProgramResult {
+        debug_assert!(len <= 8);
+
+        match self.map(AccessType::Store, vm_addr, len, pc) {
+            ProgramResult::Ok(host_addr) => {
+                // Safety:
+                // We debug_assert!(len <= 8) so we're guaranteed to write
+                // inside `value`
+                unsafe {
+                    copy_nonoverlapping(
+                        &value as *const _ as *const u8,
+                        host_addr as *mut u8,
+                        len as usize,
+                    );
+                }
+                ProgramResult::Ok(host_addr)
+            }
+
+            err => err,
+        }
+    }
+
     /// Returns the `MemoryRegion`s in this mapping
     pub fn get_regions(&self) -> &[MemoryRegion] {
         &self.regions
@@ -366,6 +544,26 @@ impl<'a> MemoryMapping<'a> {
         match self {
             MemoryMapping::Aligned(m) => m.map(access_type, vm_addr, len, pc),
             MemoryMapping::Unaligned(m) => m.map(access_type, vm_addr, len, pc),
+        }
+    }
+
+    /// Load `len` bytes from the given address.
+    ///
+    /// Works across memory region boundaries if `len` does not fit within a single region.
+    pub fn load(&self, vm_addr: u64, len: u64, pc: usize) -> ProgramResult {
+        match self {
+            MemoryMapping::Aligned(m) => m.load(vm_addr, len, pc),
+            MemoryMapping::Unaligned(m) => m.load(vm_addr, len, pc),
+        }
+    }
+
+    /// Store `len` bytes from `value` at the given address.
+    ///
+    /// Works across memory region boundaries if `len` does not fit within a single region.
+    pub fn store(&self, value: u64, vm_addr: u64, len: u64, pc: usize) -> ProgramResult {
+        match self {
+            MemoryMapping::Aligned(m) => m.store(value, vm_addr, len, pc),
+            MemoryMapping::Unaligned(m) => m.store(value, vm_addr, len, pc),
         }
     }
 
@@ -478,6 +676,20 @@ impl MappingCache {
         self.entries = array::from_fn(|_| (0..0, 0));
         self.head = 0;
     }
+}
+
+#[inline]
+fn read_uint(src: *const u8, len: usize) -> u64 {
+    debug_assert!(len <= 8);
+    let mut out = 0u64;
+    let dst = &mut out as *mut u64 as *mut u8;
+    // Safety:
+    // We debug_assert!(len <= 8) so we're guaranteed to write
+    // inside `value`
+    unsafe {
+        copy_nonoverlapping(src, dst, len);
+    }
+    out
 }
 
 #[cfg(test)]
@@ -655,6 +867,107 @@ mod test {
             ),
             ProgramResult::Err(EbpfError::AccessViolation(..))
         ));
+    }
+
+    #[test]
+    fn test_unaligned_map_load() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mem1 = [0x11, 0x22];
+        let mem2 = [0x33];
+        let mem3 = [0x44, 0x55, 0x66];
+        let mem4 = [0x77, 0x88, 0x99];
+        let m = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_readonly(&mem1, ebpf::MM_INPUT_START),
+                MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + mem1.len() as u64),
+                MemoryRegion::new_readonly(
+                    &mem3,
+                    ebpf::MM_INPUT_START + (mem1.len() + mem2.len()) as u64,
+                ),
+                MemoryRegion::new_readonly(
+                    &mem4,
+                    ebpf::MM_INPUT_START + (mem1.len() + mem2.len() + mem3.len()) as u64,
+                ),
+            ],
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(m.load(ebpf::MM_INPUT_START, 2, 0).unwrap(), 0x2211);
+        assert_eq!(m.load(ebpf::MM_INPUT_START, 4, 0).unwrap(), 0x44332211);
+        assert_eq!(
+            m.load(ebpf::MM_INPUT_START, 8, 0).unwrap(),
+            0x8877665544332211
+        );
+        assert_eq!(m.load(ebpf::MM_INPUT_START + 1, 2, 0).unwrap(), 0x3322);
+        assert_eq!(m.load(ebpf::MM_INPUT_START + 1, 4, 0).unwrap(), 0x55443322);
+        assert_eq!(
+            m.load(ebpf::MM_INPUT_START + 1, 8, 0).unwrap(),
+            0x9988776655443322
+        );
+    }
+
+    #[test]
+    fn test_unaligned_map_store() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mut mem1 = vec![0xff, 0xff];
+        let mut mem2 = vec![0xff];
+        let mut mem3 = vec![0xff, 0xff, 0xff];
+        let mut mem4 = vec![0xff, 0xff];
+        let m = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_writable(&mut mem1, ebpf::MM_INPUT_START),
+                MemoryRegion::new_writable(&mut mem2, ebpf::MM_INPUT_START + mem1.len() as u64),
+                MemoryRegion::new_writable(
+                    &mut mem3,
+                    ebpf::MM_INPUT_START + (mem1.len() + mem2.len()) as u64,
+                ),
+                MemoryRegion::new_writable(
+                    &mut mem4,
+                    ebpf::MM_INPUT_START + (mem1.len() + mem2.len() + mem3.len()) as u64,
+                ),
+            ],
+            &config,
+        )
+        .unwrap();
+        m.store(0x1122, ebpf::MM_INPUT_START, 2, 0).unwrap();
+        assert_eq!(m.load(ebpf::MM_INPUT_START, 2, 0).unwrap(), 0x1122);
+
+        m.store(0x33445566, ebpf::MM_INPUT_START, 4, 0).unwrap();
+        assert_eq!(m.load(ebpf::MM_INPUT_START, 4, 0).unwrap(), 0x33445566);
+
+        m.store(0x778899AABBCCDDEE, ebpf::MM_INPUT_START, 8, 0)
+            .unwrap();
+        assert_eq!(
+            m.load(ebpf::MM_INPUT_START, 8, 0).unwrap(),
+            0x778899AABBCCDDEE
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "AccessViolation")]
+    fn test_store_readonly() {
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let mut mem1 = vec![0xff, 0xff];
+        let mem2 = vec![0xff, 0xff];
+        let m = MemoryMapping::new(
+            vec![
+                MemoryRegion::new_writable(&mut mem1, ebpf::MM_INPUT_START),
+                MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + mem1.len() as u64),
+            ],
+            &config,
+        )
+        .unwrap();
+        m.store(0x11223344, ebpf::MM_INPUT_START, 4, 0).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
The new methods allow loading and storing values across memory region boundaries.

Say you have `[region1 vm_addr:0 len:2][region2 vm_addr:2 len:42]`, the methods allow doing loads and stores starting at `vm_addr=0` of `length > 2`, whereas calling `map()` with `len > 2` fails.

This changes the JIT and the interpreter to use the new methods for load and stores larger than one byte. `region()` is used  by the monorepo to implement memory syscalls across regions.