### PR TITLE
Fix lints, fix ci a bit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,14 @@ jobs:
       run: |
         rustup update ${{ matrix.rust }} --no-self-update
         rustup default ${{ matrix.rust }}
-        rustup component add clippy-preview
+        rustup component add clippy
         rustup component add rustfmt
       shell: bash
     - name: Lint
       run: |
         cargo fmt --all -- --check
         cargo clippy --all --tests -- --deny=warnings
-      if: matrix.rust != 'nightly'
+      if: matrix.rust == 'nightly'
       shell: bash
     - name: Build and test
       run: |
@@ -40,11 +40,15 @@ jobs:
         cargo test --verbose
       if: matrix.rust != 'nightly'
       shell: bash
-    - name: Check CLI
+    - name: CLI - Lint
       run: |
-        export RUSTFLAGS="-D warnings"
         cargo fmt --all --manifest-path cli/Cargo.toml -- --check
         cargo clippy --all --tests --manifest-path cli/Cargo.toml -- --deny=warnings
+      if: matrix.rust == 'nightly'
+      shell: bash
+    - name: CLI - Build and test
+      run: |
+        export RUSTFLAGS="-D warnings"
         cargo build --manifest-path cli/Cargo.toml --verbose
         cargo test --manifest-path cli/Cargo.toml --verbose
       if: matrix.rust != 'nightly'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,6 @@ jobs:
         export RUSTFLAGS="-D warnings"
         cargo build --verbose
         cargo test --verbose
-      if: matrix.rust != 'nightly'
       shell: bash
     - name: CLI - Lint
       run: |
@@ -51,7 +50,6 @@ jobs:
         export RUSTFLAGS="-D warnings"
         cargo build --manifest-path cli/Cargo.toml --verbose
         cargo test --manifest-path cli/Cargo.toml --verbose
-      if: matrix.rust != 'nightly'
       shell: bash
     - name: Check fuzz
       run: |

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -510,6 +510,7 @@ impl<C: ContextObject> Executable<C> {
 
     /// Calculate the total memory size of the executable
     #[rustfmt::skip]
+    #[allow(clippy::size_of_ref)]
     pub fn mem_size(&self) -> usize {
         let mut total = mem::size_of::<Self>();
         total = total
@@ -527,7 +528,7 @@ impl<C: ContextObject> Executable<C> {
             .saturating_add(self.function_registry
             .iter()
             .fold(0, |state: usize, (_, (val, name))| state
-                .saturating_add(mem::size_of_val(&val)
+                .saturating_add(mem::size_of_val(val)
                 .saturating_add(mem::size_of_val(&name)
                 .saturating_add(name.capacity())))))
             // loader built-in program


### PR DESCRIPTION
This fixes a failing nightly only clippy lint, and changes CI so that:

- we only run rustfmt and clippy with nightly
- we actually build and test crates on nightly (we used to build only on stable and beta before)