### PR TITLE
Refactor - `BuiltInProgram::register_function()`

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -21,7 +21,7 @@ use test::Bencher;
 fn loader() -> Arc<BuiltInProgram<TestContextObject>> {
     let mut loader = BuiltInProgram::new_loader(Config::default());
     loader
-        .register_function_by_name("log_64", bpf_syscall_u64)
+        .register_function(b"log_64", bpf_syscall_u64)
         .unwrap();
     Arc::new(loader)
 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -260,7 +260,7 @@ pub fn disassemble_instruction<C: ContextObject>(
                 function_name
             } else {
                 name = "syscall";
-                loader.lookup_function(insn.imm as u32).map(|(function_name, _)| function_name).unwrap_or("[invalid]")
+                loader.lookup_function(insn.imm as u32).map(|(function_name, _)| std::str::from_utf8(function_name).unwrap()).unwrap_or("[invalid]")
             };
             desc = format!("{name} {function_name}");
         },

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1212,10 +1212,10 @@ mod test {
     fn loader() -> Arc<BuiltInProgram<TestContextObject>> {
         let mut loader = BuiltInProgram::new_loader(Config::default());
         loader
-            .register_function_by_name("log", syscalls::bpf_syscall_string)
+            .register_function(b"log", syscalls::bpf_syscall_string)
             .unwrap();
         loader
-            .register_function_by_name("log_64", syscalls::bpf_syscall_u64)
+            .register_function(b"log_64", syscalls::bpf_syscall_u64)
             .unwrap();
         Arc::new(loader)
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1584,7 +1584,7 @@ mod tests {
             ..Config::default()
         });
         loader
-            .register_function_by_name("gather_bytes", syscalls::bpf_gather_bytes)
+            .register_function(b"gather_bytes", syscalls::bpf_gather_bytes)
             .unwrap();
         let mut function_registry = FunctionRegistry::default();
         function_registry.insert(8, (8, "function_foo".to_string()));

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -229,7 +229,7 @@ impl<'a> Analysis<'a> {
                         .get_loader()
                         .lookup_function(insn.imm as u32)
                     {
-                        if function_name == "abort" {
+                        if function_name == b"abort" {
                             self.cfg_nodes
                                 .entry(insn.ptr + 1)
                                 .or_insert_with(CfgNode::default);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -107,7 +107,7 @@ pub struct BuiltInProgram<C: ContextObject> {
     /// Holds the Config if this is a loader program
     config: Option<Box<Config>>,
     /// Function pointers by symbol
-    functions: HashMap<u32, (&'static str, BuiltInFunction<C>)>,
+    functions: HashMap<u32, (&'static [u8], BuiltInFunction<C>)>,
 }
 
 impl<C: ContextObject> BuiltInProgram<C> {
@@ -125,12 +125,12 @@ impl<C: ContextObject> BuiltInProgram<C> {
     }
 
     /// Register a built-in function
-    pub fn register_function_by_name(
+    pub fn register_function(
         &mut self,
-        name: &'static str,
+        name: &'static [u8],
         function: BuiltInFunction<C>,
     ) -> Result<(), EbpfError> {
-        let key = ebpf::hash_symbol_name(name.as_bytes());
+        let key = ebpf::hash_symbol_name(name);
         if self.functions.insert(key, (name, function)).is_some() {
             Err(EbpfError::FunctionAlreadyRegistered(key as usize))
         } else {
@@ -139,7 +139,7 @@ impl<C: ContextObject> BuiltInProgram<C> {
     }
 
     /// Get a symbol's function pointer
-    pub fn lookup_function(&self, key: u32) -> Option<(&'static str, BuiltInFunction<C>)> {
+    pub fn lookup_function(&self, key: u32) -> Option<(&'static [u8], BuiltInFunction<C>)> {
         self.functions.get(&key).cloned()
     }
 
@@ -152,7 +152,7 @@ impl<C: ContextObject> BuiltInProgram<C> {
                 0
             }
             + self.functions.capacity()
-                * mem::size_of::<(u32, (&'static str, BuiltInFunction<C>))>()
+                * mem::size_of::<(u32, (&'static [u8], BuiltInFunction<C>))>()
     }
 }
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -107,10 +107,10 @@ fn test_fuzz_execute() {
 
     let mut loader = BuiltInProgram::default();
     loader
-        .register_function_by_name("log", syscalls::bpf_syscall_string)
+        .register_function(b"log", syscalls::bpf_syscall_string)
         .unwrap();
     loader
-        .register_function_by_name("log_64", syscalls::bpf_syscall_u64)
+        .register_function(b"log_64", syscalls::bpf_syscall_u64)
         .unwrap();
     let loader = Arc::new(loader);
 

--- a/tests/ubpf_execution.rs
+++ b/tests/ubpf_execution.rs
@@ -38,7 +38,7 @@ const INSTRUCTION_METER_BUDGET: u64 = 1024;
 macro_rules! test_interpreter_and_jit {
     (register, $loader:expr, $location:expr => $syscall_function:expr) => {
         $loader
-            .register_function_by_name($location, $syscall_function)
+            .register_function($location.as_bytes(), $syscall_function)
             .unwrap();
     };
     ($executable:expr, $mem:tt, $context_object:expr, $expected_result:expr $(,)?) => {
@@ -3015,7 +3015,7 @@ fn nested_vm_syscall(
     if depth > 0 {
         let mut loader = BuiltInProgram::new_loader(Config::default());
         loader
-            .register_function_by_name("nested_vm_syscall", nested_vm_syscall)
+            .register_function(b"nested_vm_syscall", nested_vm_syscall)
             .unwrap();
         let mem = [depth as u8 - 1, throw as u8];
         let mut executable = assemble::<TestContextObject>(


### PR DESCRIPTION
- Renames `register_function_by_name()` => `register_function()`.
- Makes `register_function()` take `&[u8]` instead of `&str`.