### PR TITLE
Feature - Adds `MemoryMapping::Identity`

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2146,6 +2146,6 @@ mod test {
             Executable::jit_compile(&mut executable).unwrap();
         }
 
-        assert_eq!(10538, executable.mem_size());
+        assert_eq!(10546, executable.mem_size());
     }
 }


### PR DESCRIPTION
The Config::enable_address_translation flag can then be disabled in the program-runtime-v2.