### PR TITLE
Remove unreachable BssNotSupported error

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -82,9 +82,6 @@ pub enum ElfError {
     #[error("Multiple or no text sections, consider removing llc option: -function-sections")]
     NotOneTextSection,
     /// Read-write data not supported
-    #[error("Found .bss section in ELF, read-write data not supported")]
-    BssNotSupported,
-    /// Read-write data not supported
     #[error("Found writable section ({0}) in ELF, read-write data not supported")]
     WritableSectionNotSupported(String),
     /// Relocation failed, no loadable section contains virtual address
@@ -692,8 +689,6 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
                         && (name.starts_with(".data") && !name.starts_with(".data.rel")))
                 {
                     return Err(ElfError::WritableSectionNotSupported(name.to_owned()));
-                } else if name == ".bss" {
-                    return Err(ElfError::BssNotSupported);
                 }
             }
         }


### PR DESCRIPTION
Minor find while porting the ELF loader:

The second branch of the if expression in the writable section check is dead code.

We already check for `name.starts_with(".bss") || ?` so `name == ".bss"` is unreachable.

https://github.com/solana-labs/rbpf/blob/e9c2d206e18a5e759b63f39353b029dec6dc4247/src/elf.rs#L690-L697

The unit test for this piece of code confirms this:

https://github.com/solana-labs/rbpf/blob/e9c2d206e18a5e759b63f39353b029dec6dc4247/src/elf.rs#L2114-L2119

Related to that, we should probably add a unit test for an ELF that has a read-only `.bss` section. 