### PR TITLE
elf_parser: remove dead map expression

### DIFF
--- a/src/elf_parser/mod.rs
+++ b/src/elf_parser/mod.rs
@@ -132,7 +132,6 @@ impl<'a> Elf64<'a> {
             slice_from_bytes::<Elf64Shdr>(elf_bytes, section_header_table_range.clone())?;
         section_header_table
             .get(0)
-            .map(|section_header| section_header.sh_type == SHT_NULL)
             .ok_or(ElfParserError::InvalidSectionHeader)?;
 
         let mut prev_program_header: Option<&Elf64Phdr> = None;


### PR DESCRIPTION
There is a misleading piece of code that I missed while auditing (the differential fuzzer found it though!)

https://github.com/solana-labs/rbpf/blob/8a1615c583cf62e8fff978c89dce298b1aa87761/src/elf_parser/mod.rs#L131-L136

This looks like it's supposed to check that
1. section index 0 exists
2. section index 0 is SHT_NULL

However, the code only checks for 1, and fails to properly evaluate 2. The `section_header.sh_type == SHT_NULL` subexpression is dead code, because the result just gets passed up through the outer expression value.

Suggest removing this `.map` call entirely to make this more clear.