### PR TITLE
Refactor - `BuiltinProgram`

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -14,13 +14,13 @@ use solana_rbpf::{
     elf::Executable,
     syscalls::bpf_syscall_u64,
     verifier::TautologyVerifier,
-    vm::{BuiltInProgram, Config, TestContextObject},
+    vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::{fs::File, io::Read, sync::Arc};
 use test::Bencher;
 
-fn loader() -> Arc<BuiltInProgram<TestContextObject>> {
-    let mut loader = BuiltInProgram::new_loader(Config::default());
+fn loader() -> Arc<BuiltinProgram<TestContextObject>> {
+    let mut loader = BuiltinProgram::new_loader(Config::default());
     loader
         .register_function(b"log_64", bpf_syscall_u64)
         .unwrap();

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -12,7 +12,7 @@ extern crate test;
 use solana_rbpf::{
     elf::Executable,
     verifier::{RequisiteVerifier, TautologyVerifier},
-    vm::{BuiltInProgram, Config, TestContextObject},
+    vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::{fs::File, io::Read, sync::Arc};
 use test::Bencher;
@@ -25,7 +25,7 @@ fn bench_init_vm(bencher: &mut Bencher) {
     file.read_to_end(&mut elf).unwrap();
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
         &elf,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let verified_executable =
@@ -52,7 +52,7 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     file.read_to_end(&mut elf).unwrap();
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
         &elf,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let mut verified_executable =

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -14,7 +14,7 @@ use solana_rbpf::{
     elf::Executable,
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, TautologyVerifier},
-    vm::{BuiltInProgram, Config, TestContextObject},
+    vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::{fs::File, io::Read, sync::Arc};
 use test::Bencher;
@@ -27,7 +27,7 @@ fn bench_init_interpreter_execution(bencher: &mut Bencher) {
     file.read_to_end(&mut elf).unwrap();
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
         &elf,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let verified_executable =
@@ -56,7 +56,7 @@ fn bench_init_jit_execution(bencher: &mut Bencher) {
     file.read_to_end(&mut elf).unwrap();
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
         &elf,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let mut verified_executable =
@@ -88,7 +88,7 @@ fn bench_jit_vs_interpreter(
 ) {
     let executable = solana_rbpf::assembler::assemble::<TestContextObject>(
         assembly,
-        Arc::new(BuiltInProgram::new_loader(config)),
+        Arc::new(BuiltinProgram::new_loader(config)),
     )
     .unwrap();
     let mut verified_executable =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@ use solana_rbpf::{
     memory_region::{MemoryMapping, MemoryRegion},
     static_analysis::Analysis,
     verifier::{RequisiteVerifier, TautologyVerifier},
-    vm::{BuiltInProgram, Config, DynamicAnalysis, EbpfVm, TestContextObject},
+    vm::{BuiltinProgram, Config, DynamicAnalysis, EbpfVm, TestContextObject},
 };
 use std::{fs::File, io::Read, path::Path, sync::Arc};
 
@@ -92,7 +92,7 @@ fn main() {
         )
         .get_matches();
 
-    let loader = Arc::new(BuiltInProgram::new_loader(Config {
+    let loader = Arc::new(BuiltinProgram::new_loader(Config {
         enable_instruction_tracing: matches.is_present("trace") || matches.is_present("profile"),
         enable_symbol_and_section_labels: true,
         ..Config::default()

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
     verifier::TautologyVerifier,
-    vm::{BuiltInProgram, FunctionRegistry, TestContextObject},
+    vm::{BuiltinProgram, FunctionRegistry, TestContextObject},
 };
 use std::sync::Arc;
 
@@ -31,7 +31,7 @@ fn main() {
         0x00, 0x00, 0x00, 0x00, 0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x95, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00,
     ];
-    let loader = Arc::new(BuiltInProgram::default());
+    let loader = Arc::new(BuiltinProgram::default());
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         program,
         loader,

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -15,7 +15,7 @@ use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,
     verifier::TautologyVerifier,
-    vm::{BuiltInProgram, FunctionRegistry, TestContextObject},
+    vm::{BuiltinProgram, FunctionRegistry, TestContextObject},
 };
 use std::sync::Arc;
 // Turn a program into a JSON string.
@@ -30,7 +30,7 @@ use std::sync::Arc;
 fn to_json(program: &[u8]) -> String {
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         program,
-        Arc::new(BuiltInProgram::default()),
+        Arc::new(BuiltinProgram::default()),
         FunctionRegistry::default(),
     )
     .unwrap();

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     elf::Executable,
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
-    vm::{BuiltInProgram, FunctionRegistry, TestContextObject},
+    vm::{BuiltinProgram, FunctionRegistry, TestContextObject},
 };
 use test_utils::create_vm;
 
@@ -35,7 +35,7 @@ fuzz_target!(|data: DumbFuzzData| {
     let mut mem = data.mem;
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         &prog,
-        std::sync::Arc::new(BuiltInProgram::new_loader(config)),
+        std::sync::Arc::new(BuiltinProgram::new_loader(config)),
         function_registry,
     )
     .unwrap();

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -11,7 +11,7 @@ use solana_rbpf::{
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
-    vm::{BuiltInProgram, FunctionRegistry, TestContextObject},
+    vm::{BuiltinProgram, FunctionRegistry, TestContextObject},
 };
 use test_utils::create_vm;
 
@@ -39,7 +39,7 @@ fuzz_target!(|data: FuzzData| {
     let mut mem = data.mem;
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog.into_bytes(),
-        std::sync::Arc::new(BuiltInProgram::new_loader(config)),
+        std::sync::Arc::new(BuiltinProgram::new_loader(config)),
         function_registry,
     )
     .unwrap();

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
     verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
-    vm::{BuiltInProgram, FunctionRegistry, TestContextObject},
+    vm::{BuiltinProgram, FunctionRegistry, TestContextObject},
 };
 use test_utils::create_vm;
 
@@ -47,7 +47,7 @@ fuzz_target!(|data: FuzzData| {
     let mut jit_mem = data.mem;
     let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog.into_bytes(),
-        std::sync::Arc::new(BuiltInProgram::new_loader(config)),
+        std::sync::Arc::new(BuiltinProgram::new_loader(config)),
         function_registry,
     )
     .unwrap();

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -11,7 +11,7 @@ use solana_rbpf::{
     static_analysis::Analysis,
     verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
     vm::{
-        BuiltInProgram, ContextObject, FunctionRegistry, TestContextObject,
+        BuiltinProgram, ContextObject, FunctionRegistry, TestContextObject,
     },
 };
 use test_utils::create_vm;
@@ -46,7 +46,7 @@ fuzz_target!(|data: FuzzData| {
     let mut jit_mem = data.mem;
     let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog.into_bytes(),
-        std::sync::Arc::new(BuiltInProgram::new_loader(config)),
+        std::sync::Arc::new(BuiltinProgram::new_loader(config)),
         function_registry,
     )
     .unwrap();

--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -215,7 +215,7 @@ pub fn is_memory_aligned(ptr: usize, align: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::integer_arithmetic)]
+    #![allow(clippy::arithmetic_side_effects)]
     use {super::*, std::io::Write};
 
     fn do_test<const ALIGN: usize>() {

--- a/src/asm_parser.rs
+++ b/src/asm_parser.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -20,7 +20,7 @@ use crate::{
     ebpf::{self, Insn},
     elf::{register_internal_function, Executable},
     verifier::TautologyVerifier,
-    vm::{BuiltInProgram, ContextObject, FunctionRegistry},
+    vm::{BuiltinProgram, ContextObject, FunctionRegistry},
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -183,7 +183,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 /// # Examples
 ///
 /// ```
-/// use solana_rbpf::{assembler::assemble, vm::{Config, TestContextObject, BuiltInProgram}};
+/// use solana_rbpf::{assembler::assemble, vm::{Config, TestContextObject, BuiltinProgram}};
 /// let executable = assemble::<TestContextObject>(
 ///    "add64 r1, 0x605
 ///     mov64 r2, 0x32
@@ -191,7 +191,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 ///     be16 r0
 ///     neg64 r2
 ///     exit",
-///     std::sync::Arc::new(BuiltInProgram::new_loader(Config::default())),
+///     std::sync::Arc::new(BuiltinProgram::new_loader(Config::default())),
 /// ).unwrap();
 /// let program = executable.get_text_bytes().1;
 /// println!("{:?}", program);
@@ -216,7 +216,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 /// ```
 pub fn assemble<C: ContextObject>(
     src: &str,
-    loader: Arc<BuiltInProgram<C>>,
+    loader: Arc<BuiltinProgram<C>>,
 ) -> Result<Executable<TautologyVerifier, C>, String> {
     fn resolve_label(
         insn_ptr: usize,

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -10,7 +10,7 @@
 
 use crate::ebpf;
 use crate::static_analysis::CfgNode;
-use crate::vm::{BuiltInProgram, ContextObject, FunctionRegistry};
+use crate::vm::{BuiltinProgram, ContextObject, FunctionRegistry};
 use std::collections::BTreeMap;
 
 fn resolve_label(cfg_nodes: &BTreeMap<usize, CfgNode>, pc: usize) -> &str {
@@ -121,7 +121,7 @@ pub fn disassemble_instruction<C: ContextObject>(
     insn: &ebpf::Insn, 
     cfg_nodes: &BTreeMap<usize, CfgNode>,
     function_registry: &FunctionRegistry,
-    loader: &BuiltInProgram<C>,
+    loader: &BuiltinProgram<C>,
 ) -> String {
     let name;
     let desc;

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Copyright 2017 6WIND S.A. <quentin.monnet@6wind.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Copyright 2016 6WIND S.A. <quentin.monnet@6wind.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -343,7 +343,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     }
 
     /// Get the loader built-in program
-    pub fn get_loader(&self) -> &BuiltinProgram<C> {
+    pub fn get_loader(&self) -> &Arc<BuiltinProgram<C>> {
         &self.loader
     }
 

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -23,7 +23,7 @@ use crate::{
     error::EbpfError,
     memory_region::MemoryRegion,
     verifier::{TautologyVerifier, Verifier},
-    vm::{BuiltInProgram, Config, ContextObject, FunctionRegistry},
+    vm::{BuiltinProgram, Config, ContextObject, FunctionRegistry},
 };
 
 #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
@@ -130,7 +130,7 @@ pub fn register_internal_function<
     T: AsRef<str> + ToString + std::cmp::PartialEq<&'static str>,
 >(
     function_registry: &mut FunctionRegistry,
-    loader: &BuiltInProgram<C>,
+    loader: &BuiltinProgram<C>,
     pc: usize,
     name: T,
 ) -> Result<u32, ElfError> {
@@ -279,7 +279,7 @@ pub struct Executable<V: Verifier, C: ContextObject> {
     /// Call resolution map (hash, pc, name)
     function_registry: FunctionRegistry,
     /// Loader built-in program
-    loader: Arc<BuiltInProgram<C>>,
+    loader: Arc<BuiltinProgram<C>>,
     /// Compiled program and argument
     #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
     compiled_program: Option<JitProgram>,
@@ -343,7 +343,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     }
 
     /// Get the loader built-in program
-    pub fn get_loader(&self) -> &BuiltInProgram<C> {
+    pub fn get_loader(&self) -> &BuiltinProgram<C> {
         &self.loader
     }
 
@@ -381,7 +381,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     /// Create from raw text section bytes (list of instructions)
     pub fn new_from_text_bytes(
         text_bytes: &[u8],
-        loader: Arc<BuiltInProgram<C>>,
+        loader: Arc<BuiltinProgram<C>>,
         mut function_registry: FunctionRegistry,
     ) -> Result<Self, ElfError> {
         let elf_bytes = AlignedMemory::from_slice(text_bytes);
@@ -418,7 +418,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     }
 
     /// Fully loads an ELF, including validation and relocation
-    pub fn load(bytes: &[u8], loader: Arc<BuiltInProgram<C>>) -> Result<Self, ElfError> {
+    pub fn load(bytes: &[u8], loader: Arc<BuiltinProgram<C>>) -> Result<Self, ElfError> {
         if loader.get_config().new_elf_parser {
             // The new parser creates references from the input byte slice, so
             // it must be properly aligned. We assume that HOST_ALIGN is a
@@ -439,7 +439,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     fn load_with_parser<'a, P: ElfParser<'a>>(
         elf: &'a P,
         bytes: &[u8],
-        loader: Arc<BuiltInProgram<C>>,
+        loader: Arc<BuiltinProgram<C>>,
     ) -> Result<Self, ElfError> {
         let mut elf_bytes = AlignedMemory::from_slice(bytes);
         let config = loader.get_config();
@@ -564,7 +564,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     /// Fix-ups relative calls
     pub fn fixup_relative_calls(
         function_registry: &mut FunctionRegistry,
-        loader: &BuiltInProgram<C>,
+        loader: &BuiltinProgram<C>,
         elf_bytes: &mut [u8],
     ) -> Result<(), ElfError> {
         let config = loader.get_config();
@@ -886,7 +886,7 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     /// Relocates the ELF in-place
     fn relocate<'a, P: ElfParser<'a>>(
         function_registry: &mut FunctionRegistry,
-        loader: &BuiltInProgram<C>,
+        loader: &BuiltinProgram<C>,
         elf: &'a P,
         elf_bytes: &mut [u8],
     ) -> Result<(), ElfError> {
@@ -1232,8 +1232,8 @@ mod test {
     use test_utils::assert_error;
     type ElfExecutable = Executable<TautologyVerifier, TestContextObject>;
 
-    fn loader() -> Arc<BuiltInProgram<TestContextObject>> {
-        let mut loader = BuiltInProgram::new_loader(Config::default());
+    fn loader() -> Arc<BuiltinProgram<TestContextObject>> {
+        let mut loader = BuiltinProgram::new_loader(Config::default());
         loader
             .register_function(b"log", syscalls::bpf_syscall_string)
             .unwrap();
@@ -1399,7 +1399,7 @@ mod test {
     #[test]
     fn test_fixup_relative_calls_back() {
         let mut function_registry = FunctionRegistry::default();
-        let loader = BuiltInProgram::new_loader(Config {
+        let loader = BuiltinProgram::new_loader(Config {
             static_syscalls: false,
             enable_symbol_and_section_labels: true,
             ..Config::default()
@@ -1448,7 +1448,7 @@ mod test {
     #[test]
     fn test_fixup_relative_calls_forward() {
         let mut function_registry = FunctionRegistry::default();
-        let loader = BuiltInProgram::new_loader(Config {
+        let loader = BuiltinProgram::new_loader(Config {
             static_syscalls: false,
             enable_symbol_and_section_labels: true,
             ..Config::default()
@@ -2117,7 +2117,7 @@ mod test {
     #[test]
     #[should_panic(expected = r#"validation failed: RelativeJumpOutOfBounds(29)"#)]
     fn test_static_syscall_disabled() {
-        let loader = BuiltInProgram::new_loader(Config {
+        let loader = BuiltinProgram::new_loader(Config {
             static_syscalls: false,
             ..Config::default()
         });

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Copyright 2017 Alex Dukhno <alex.dukhno@icloud.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: VM architecture, parts of the interpreter, originally in C)

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1553,7 +1553,7 @@ mod tests {
     use crate::{
         syscalls,
         verifier::TautologyVerifier,
-        vm::{BuiltInProgram, FunctionRegistry, TestContextObject},
+        vm::{BuiltinProgram, FunctionRegistry, TestContextObject},
     };
     use byteorder::{ByteOrder, LittleEndian};
     use std::sync::Arc;
@@ -1601,7 +1601,7 @@ mod tests {
     fn create_mockup_executable(
         program: &[u8],
     ) -> Executable<TautologyVerifier, TestContextObject> {
-        let mut loader = BuiltInProgram::new_loader(Config {
+        let mut loader = BuiltinProgram::new_loader(Config {
             noop_instruction_rate: 0,
             ..Config::default()
         });

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: JIT algorithm, originally in C)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
     html_logo_url = "https://raw.githubusercontent.com/qmonnet/rbpf/master/misc/rbpf.png",
     html_favicon_url = "https://raw.githubusercontent.com/qmonnet/rbpf/master/misc/rbpf.ico"
 )]
-#![deny(clippy::integer_arithmetic)]
+#![deny(clippy::arithmetic_side_effects)]
 
 extern crate byteorder;
 extern crate combine;

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -88,7 +88,8 @@ pub fn round_to_page_size(value: usize, page_size: usize) -> usize {
     value
         .saturating_add(page_size)
         .saturating_sub(1)
-        .saturating_div(page_size)
+        .checked_div(page_size)
+        .unwrap()
         .saturating_mul(page_size)
 }
 

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -277,7 +277,7 @@ impl<'a> UnalignedMemoryMapping<'a> {
         Self::new_internal(regions, Some(cow_cb), config)
     }
 
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     fn find_region(&self, cache: &mut MappingCache, vm_addr: u64) -> Option<&MemoryRegion> {
         if let Some(index) = cache.find(vm_addr) {
             // Safety:
@@ -874,7 +874,7 @@ impl MappingCache {
         }
     }
 
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     #[inline]
     fn find(&self, vm_addr: u64) -> Option<usize> {
         for i in 0..Self::SIZE {
@@ -890,7 +890,7 @@ impl MappingCache {
         None
     }
 
-    #[allow(clippy::integer_arithmetic)]
+    #[allow(clippy::arithmetic_side_effects)]
     #[inline]
     fn insert(&mut self, vm_range: Range<u64>, region_index: usize) {
         self.head = (self.head - 1).rem_euclid(Self::SIZE);

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 //! Static Byte Code Analysis
 
 use crate::disassembler::disassemble_instruction;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::too_many_arguments)]
 // Copyright 2015 Big Switch Networks, Inc
 //      (Algorithms for uBPF syscalls, originally in C)

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: safety checks, originally in C)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Derived from uBPF <https://github.com/iovisor/ubpf>
 // Copyright 2015 Big Switch Networks, Inc
 //      (uBPF: VM architecture, parts of the interpreter, originally in C)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -175,6 +175,9 @@ impl<C: ContextObject> Debug for BuiltinProgram<C> {
 
 impl<C: ContextObject> PartialEq for BuiltinProgram<C> {
     fn eq(&self, other: &Self) -> bool {
+        if self.config != other.config {
+            return false;
+        }
         for ((a_key, a_function), (b_key, b_function)) in
             self.functions.iter().zip(other.functions.iter())
         {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -98,18 +98,18 @@ pub type ProgramResult = StableResult<u64, Box<dyn std::error::Error>>;
 pub type FunctionRegistry = BTreeMap<u32, (usize, String)>;
 
 /// Syscall function without context
-pub type BuiltInFunction<C> =
+pub type BuiltinFunction<C> =
     fn(&mut C, u64, u64, u64, u64, u64, &mut MemoryMapping, &mut ProgramResult);
 
 /// Represents the interface to a fixed functionality program
-pub struct BuiltInProgram<C: ContextObject> {
+pub struct BuiltinProgram<C: ContextObject> {
     /// Holds the Config if this is a loader program
     config: Option<Box<Config>>,
     /// Function pointers by symbol
-    functions: HashMap<u32, (&'static [u8], BuiltInFunction<C>)>,
+    functions: HashMap<u32, (&'static [u8], BuiltinFunction<C>)>,
 }
 
-impl<C: ContextObject> BuiltInProgram<C> {
+impl<C: ContextObject> BuiltinProgram<C> {
     /// Constructs a loader built-in program
     pub fn new_loader(config: Config) -> Self {
         Self {
@@ -127,7 +127,7 @@ impl<C: ContextObject> BuiltInProgram<C> {
     pub fn register_function(
         &mut self,
         name: &'static [u8],
-        function: BuiltInFunction<C>,
+        function: BuiltinFunction<C>,
     ) -> Result<(), EbpfError> {
         let key = ebpf::hash_symbol_name(name);
         if self.functions.insert(key, (name, function)).is_some() {
@@ -138,7 +138,7 @@ impl<C: ContextObject> BuiltInProgram<C> {
     }
 
     /// Get a symbol's function pointer
-    pub fn lookup_function(&self, key: u32) -> Option<(&'static [u8], BuiltInFunction<C>)> {
+    pub fn lookup_function(&self, key: u32) -> Option<(&'static [u8], BuiltinFunction<C>)> {
         self.functions.get(&key).cloned()
     }
 
@@ -151,11 +151,11 @@ impl<C: ContextObject> BuiltInProgram<C> {
                 0
             }
             + self.functions.capacity()
-                * mem::size_of::<(u32, (&'static [u8], BuiltInFunction<C>))>()
+                * mem::size_of::<(u32, (&'static [u8], BuiltinFunction<C>))>()
     }
 }
 
-impl<C: ContextObject> Default for BuiltInProgram<C> {
+impl<C: ContextObject> Default for BuiltinProgram<C> {
     fn default() -> Self {
         Self {
             config: None,
@@ -164,7 +164,7 @@ impl<C: ContextObject> Default for BuiltInProgram<C> {
     }
 }
 
-impl<C: ContextObject> Debug for BuiltInProgram<C> {
+impl<C: ContextObject> Debug for BuiltinProgram<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         writeln!(f, "{:?}", unsafe {
             std::mem::transmute::<_, &HashMap<u32, *const u8>>(&self.functions)
@@ -173,7 +173,7 @@ impl<C: ContextObject> Debug for BuiltInProgram<C> {
     }
 }
 
-impl<C: ContextObject> PartialEq for BuiltInProgram<C> {
+impl<C: ContextObject> PartialEq for BuiltinProgram<C> {
     fn eq(&self, other: &Self) -> bool {
         for ((a_key, a_function), (b_key, b_function)) in
             self.functions.iter().zip(other.functions.iter())
@@ -285,14 +285,14 @@ impl Default for Config {
 /// Static constructors for Executable
 impl<C: ContextObject> Executable<TautologyVerifier, C> {
     /// Creates an executable from an ELF file
-    pub fn from_elf(elf_bytes: &[u8], loader: Arc<BuiltInProgram<C>>) -> Result<Self, EbpfError> {
+    pub fn from_elf(elf_bytes: &[u8], loader: Arc<BuiltinProgram<C>>) -> Result<Self, EbpfError> {
         let executable = Executable::load(elf_bytes, loader)?;
         Ok(executable)
     }
     /// Creates an executable from machine code
     pub fn from_text_bytes(
         text_bytes: &[u8],
-        loader: Arc<BuiltInProgram<C>>,
+        loader: Arc<BuiltinProgram<C>>,
         function_registry: FunctionRegistry,
     ) -> Result<Self, EbpfError> {
         Executable::new_from_text_bytes(text_bytes, loader, function_registry)
@@ -445,7 +445,7 @@ pub struct RuntimeEnvironment<'a, C: ContextObject> {
 ///     elf::Executable,
 ///     memory_region::{MemoryMapping, MemoryRegion},
 ///     verifier::{TautologyVerifier, RequisiteVerifier},
-///     vm::{BuiltInProgram, Config, EbpfVm, FunctionRegistry, TestContextObject},
+///     vm::{BuiltinProgram, Config, EbpfVm, FunctionRegistry, TestContextObject},
 /// };
 ///
 /// let prog = &[
@@ -455,7 +455,7 @@ pub struct RuntimeEnvironment<'a, C: ContextObject> {
 ///     0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd
 /// ];
 ///
-/// let loader = std::sync::Arc::new(BuiltInProgram::new_loader(Config::default()));
+/// let loader = std::sync::Arc::new(BuiltinProgram::new_loader(Config::default()));
 /// let function_registry = FunctionRegistry::default();
 /// let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(prog, loader, function_registry).unwrap();
 /// let verified_executable = Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use crate::{
     jit::{JitCompiler, OperandSize},
     verifier::Verifier,

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 // Copyright 2017 Rich Lane <lanerl@gmail.com>
 //
 // Licensed under the Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0> or

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -11,7 +11,7 @@ extern crate test_utils;
 use solana_rbpf::{
     assembler::assemble,
     ebpf,
-    vm::{BuiltInProgram, Config, TestContextObject},
+    vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::sync::Arc;
 use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
@@ -19,7 +19,7 @@ use test_utils::{TCP_SACK_ASM, TCP_SACK_BIN};
 fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
     let executable = assemble::<TestContextObject>(
         src,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )?;
     let (_program_vm_addr, program) = executable.get_text_bytes();
     Ok((0..program.len() / ebpf::INSN_SIZE)
@@ -541,7 +541,7 @@ fn test_large_immediate() {
 fn test_tcp_sack() {
     let executable = assemble::<TestContextObject>(
         TCP_SACK_ASM,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let (_program_vm_addr, program) = executable.get_text_bytes();

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -10,7 +10,7 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     assembler::assemble,
     static_analysis::Analysis,
-    vm::{BuiltInProgram, Config, TestContextObject},
+    vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::sync::Arc;
 
@@ -18,7 +18,7 @@ use std::sync::Arc;
 macro_rules! disasm {
     ($src:expr) => {{
         let src = $src;
-        let loader = BuiltInProgram::new_loader(Config {
+        let loader = BuiltinProgram::new_loader(Config {
             enable_symbol_and_section_labels: true,
             ..Config::default()
         });

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -25,7 +25,7 @@ use solana_rbpf::{
     syscalls,
     verifier::{RequisiteVerifier, TautologyVerifier},
     vm::{
-        BuiltInProgram, Config, ContextObject, FunctionRegistry, ProgramResult, TestContextObject,
+        BuiltinProgram, Config, ContextObject, FunctionRegistry, ProgramResult, TestContextObject,
     },
 };
 use std::{fs::File, io::Read, sync::Arc};
@@ -130,7 +130,7 @@ macro_rules! test_interpreter_and_jit_asm {
     ($source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $expected_result:expr $(,)?) => {
         #[allow(unused_mut)]
         {
-            let mut loader = BuiltInProgram::new_loader($config);
+            let mut loader = BuiltinProgram::new_loader($config);
             $(test_interpreter_and_jit!(register, loader, $location => $syscall_function);)*
             let loader = Arc::new(loader);
             let mut executable = assemble($source, loader).unwrap();
@@ -156,7 +156,7 @@ macro_rules! test_interpreter_and_jit_elf {
         file.read_to_end(&mut elf).unwrap();
         #[allow(unused_mut)]
         {
-            let mut loader = BuiltInProgram::new_loader($config);
+            let mut loader = BuiltinProgram::new_loader($config);
             $(test_interpreter_and_jit!(register, loader, $location => $syscall_function);)*
             let loader = Arc::new(loader);
             let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(&elf, loader).unwrap();
@@ -2567,7 +2567,7 @@ fn test_err_mem_access_out_of_bound() {
     prog[0] = ebpf::LD_DW_IMM;
     prog[16] = ebpf::ST_B_IMM;
     prog[24] = ebpf::EXIT;
-    let loader = Arc::new(BuiltInProgram::new_loader(Config::default()));
+    let loader = Arc::new(BuiltinProgram::new_loader(Config::default()));
     for address in [0x2u64, 0x8002u64, 0x80000002u64, 0x8000000000000002u64] {
         LittleEndian::write_u32(&mut prog[4..], address as u32);
         LittleEndian::write_u32(&mut prog[12..], (address >> 32) as u32);
@@ -3006,7 +3006,7 @@ fn nested_vm_syscall(
     };
     #[allow(unused_mut)]
     if depth > 0 {
-        let mut loader = BuiltInProgram::new_loader(Config::default());
+        let mut loader = BuiltinProgram::new_loader(Config::default());
         loader
             .register_function(b"nested_vm_syscall", nested_vm_syscall)
             .unwrap();
@@ -3426,7 +3426,7 @@ fn test_err_call_unresolved() {
 
 #[test]
 fn test_err_unresolved_elf() {
-    let mut loader = BuiltInProgram::new_loader(Config {
+    let mut loader = BuiltinProgram::new_loader(Config {
         reject_broken_elfs: true,
         ..Config::default()
     });
@@ -3817,7 +3817,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     let mem_size = 1024 * 1024;
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog,
-        Arc::new(BuiltInProgram::new_loader(Config {
+        Arc::new(BuiltinProgram::new_loader(Config {
             enable_instruction_tracing: true,
             ..Config::default()
         })),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 #![cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
 // Copyright 2020 Solana Maintainers <maintainers@solana.com>
 //

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -27,7 +27,7 @@ use solana_rbpf::{
     ebpf,
     elf::Executable,
     verifier::{RequisiteVerifier, TautologyVerifier, Verifier, VerifierError},
-    vm::{BuiltInProgram, Config, FunctionRegistry, TestContextObject},
+    vm::{BuiltinProgram, Config, FunctionRegistry, TestContextObject},
 };
 use std::sync::Arc;
 use test_utils::create_vm;
@@ -57,7 +57,7 @@ fn test_verifier_success() {
         "
         mov32 r0, 0xBEE
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let verified_executable =
@@ -80,7 +80,7 @@ fn test_verifier_fail() {
         "
         mov32 r0, 0xBEE
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -95,7 +95,7 @@ fn test_verifier_err_div_by_zero_imm() {
         mov32 r0, 1
         div32 r0, 0
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -112,7 +112,7 @@ fn test_verifier_err_endian_size() {
     ];
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
         FunctionRegistry::default(),
     )
     .unwrap();
@@ -130,7 +130,7 @@ fn test_verifier_err_incomplete_lddw() {
     ];
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
         FunctionRegistry::default(),
     )
     .unwrap();
@@ -147,7 +147,7 @@ fn test_verifier_err_invalid_reg_dst() {
             "
             mov r11, 1
             exit",
-            Arc::new(BuiltInProgram::new_loader(Config {
+            Arc::new(BuiltinProgram::new_loader(Config {
                 dynamic_stack_frames,
                 ..Config::default()
             })),
@@ -172,7 +172,7 @@ fn test_verifier_err_invalid_reg_src() {
             "
             mov r0, r11
             exit",
-            Arc::new(BuiltInProgram::new_loader(Config {
+            Arc::new(BuiltinProgram::new_loader(Config {
                 dynamic_stack_frames,
                 ..Config::default()
             })),
@@ -195,7 +195,7 @@ fn test_verifier_resize_stack_ptr_success() {
         sub r11, 1
         add r11, 1
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config {
+        Arc::new(BuiltinProgram::new_loader(Config {
             enable_stack_frame_gaps: false,
             ..Config::default()
         })),
@@ -213,7 +213,7 @@ fn test_verifier_err_jmp_lddw() {
         ja +1
         lddw r0, 0x1122334455667788
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -228,7 +228,7 @@ fn test_verifier_err_call_lddw() {
         call 1
         lddw r0, 0x1122334455667788
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -243,7 +243,7 @@ fn test_verifier_err_function_fallthrough() {
         mov r0, r1
         function_foo:
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -257,7 +257,7 @@ fn test_verifier_err_jmp_out() {
         "
         ja +2
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -271,7 +271,7 @@ fn test_verifier_err_jmp_out_start() {
         "
         ja -2
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -287,7 +287,7 @@ fn test_verifier_err_unknown_opcode() {
     ];
     let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
         prog,
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
         FunctionRegistry::default(),
     )
     .unwrap();
@@ -302,7 +302,7 @@ fn test_verifier_err_write_r10() {
         "
         mov r10, 1
         exit",
-        Arc::new(BuiltInProgram::new_loader(Config::default())),
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
     )
     .unwrap();
     let _verified_executable =
@@ -339,7 +339,7 @@ fn test_verifier_err_all_shift_overflows() {
         let assembly = format!("\n{overflowing_instruction}\nexit");
         let executable = assemble::<TestContextObject>(
             &assembly,
-            Arc::new(BuiltInProgram::new_loader(Config::default())),
+            Arc::new(BuiltinProgram::new_loader(Config::default())),
         )
         .unwrap();
         let result = Executable::<RequisiteVerifier, TestContextObject>::verified(executable)
@@ -371,7 +371,7 @@ fn test_sdiv_disabled() {
             let assembly = format!("\n{instruction}\nexit");
             let executable = assemble::<TestContextObject>(
                 &assembly,
-                Arc::new(BuiltInProgram::new_loader(Config {
+                Arc::new(BuiltinProgram::new_loader(Config {
                     enable_sdiv,
                     ..Config::default()
                 })),


### PR DESCRIPTION
Adjustments for efficient equality check in the mono repo.
Also, spelling consistency.