### PR TITLE
Revert - Moves Config::optimize_rodata into SBPFVersion (#477)

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -14,6 +14,7 @@ pub struct ConfigTemplate {
     sanitize_user_provided_values: bool,
     encrypt_environment_registers: bool,
     reject_callx_r10: bool,
+    optimize_rodata: bool,
 }
 
 impl<'a> Arbitrary<'a> for ConfigTemplate {
@@ -28,6 +29,7 @@ impl<'a> Arbitrary<'a> for ConfigTemplate {
             sanitize_user_provided_values: bools & (1 << 3) != 0,
             encrypt_environment_registers: bools & (1 << 4) != 0,
             reject_callx_r10: bools & (1 << 6) != 0,
+            optimize_rodata: bools & (1 << 9) != 0,
         })
     }
 
@@ -51,6 +53,7 @@ impl From<ConfigTemplate> for Config {
                 sanitize_user_provided_values,
                 encrypt_environment_registers,
                 reject_callx_r10,
+                optimize_rodata,
             } => Config {
                 max_call_depth,
                 enable_stack_frame_gaps,
@@ -65,6 +68,7 @@ impl From<ConfigTemplate> for Config {
                     0
                 },
                 reject_callx_r10,
+                optimize_rodata,
                 ..Default::default()
             },
         }

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -122,7 +122,7 @@ impl MemoryRegion {
     /// Convert a virtual machine address into a host address
     pub fn vm_to_host(&self, vm_addr: u64, len: u64) -> ProgramResult {
         // This can happen if a region starts at an offset from the base region
-        // address, eg with rodata regions if sbpf_version.optimize_rodata()=true, see
+        // address, eg with rodata regions if config.optimize_rodata = true, see
         // Elf::get_ro_region.
         if vm_addr < self.vm_addr {
             return ProgramResult::Err(Box::new(EbpfError::InvalidVirtualAddress(vm_addr)));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -228,6 +228,8 @@ pub struct Config {
     pub external_internal_function_hash_collision: bool,
     /// Have the verifier reject "callx r10"
     pub reject_callx_r10: bool,
+    /// Avoid copying read only sections when possible
+    pub optimize_rodata: bool,
     /// Use the new ELF parser
     pub new_elf_parser: bool,
     /// Use aligned memory mapping
@@ -263,6 +265,7 @@ impl Default for Config {
                 >> PROGRAM_ENVIRONMENT_KEY_SHIFT,
             external_internal_function_hash_collision: true,
             reject_callx_r10: true,
+            optimize_rodata: true,
             new_elf_parser: true,
             aligned_memory_mapping: true,
             enable_sbpf_v1: true,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3098,7 +3098,10 @@ fn test_load_elf_empty_rodata() {
 
 #[test]
 fn test_load_elf_rodata() {
-    let config = Config::default();
+    let config = Config {
+        optimize_rodata: true,
+        ..Config::default()
+    };
     test_interpreter_and_jit_elf!(
         "tests/elfs/rodata.so",
         config,
@@ -3111,7 +3114,10 @@ fn test_load_elf_rodata() {
 
 #[test]
 fn test_load_elf_rodata_sbpfv1() {
-    let config = Config::default();
+    let config = Config {
+        optimize_rodata: false,
+        ..Config::default()
+    };
     test_interpreter_and_jit_elf!(
         "tests/elfs/rodata_sbpfv1.so",
         config,


### PR DESCRIPTION
Issue is that SBPFv1 would no longer be able to have `optimize_rodata` and the logic for it was already present in [v0.2.31](https://github.com/solana-labs/rbpf/releases/tag/v0.2.31) which we have to stay compatible with.