### PR TITLE
Fix - `callx` encoding

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -304,7 +304,13 @@ pub fn assemble<C: ContextObject>(
                                 .map_err(|_| format!("Label hash collision {name}"))?;
                             insn(opc, 0, 1, 0, target_pc)
                         }
-                        (CallReg, [Register(dst)]) => insn(opc, 0, 0, 0, *dst),
+                        (CallReg, [Register(dst)]) => {
+                            if sbpf_version.callx_uses_src_reg() {
+                                insn(opc, 0, *dst, 0, 0)
+                            } else {
+                                insn(opc, 0, 0, 0, *dst)
+                            }
+                        }
                         (JumpConditional, [Register(dst), Register(src), Label(label)]) => insn(
                             opc | ebpf::BPF_X,
                             *dst,

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -269,7 +269,7 @@ pub fn disassemble_instruction<C: ContextObject>(
             };
             desc = format!("{name} {function_name}");
         },
-        ebpf::CALL_REG   => { name = "callx"; desc = format!("{} r{}", name, insn.imm); },
+        ebpf::CALL_REG   => { name = "callx"; desc = format!("{} r{}", name, if sbpf_version.callx_uses_src_reg() { insn.src } else { insn.imm as u8 }); },
         ebpf::EXIT       => { name = "exit"; desc = name.to_string(); },
 
         _                => { name = "unknown"; desc = format!("{} opcode={:#x}", name, insn.opc); },

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -230,6 +230,11 @@ impl SBPFVersion {
         self != &SBPFVersion::V1
     }
 
+    /// Use src reg instead of imm in callx
+    pub fn callx_uses_src_reg(&self) -> bool {
+        self != &SBPFVersion::V1
+    }
+
     /// Ensure that rodata sections don't exceed their maximum allowed size and
     /// overlap with the stack
     pub fn reject_rodata_stack_overlap(&self) -> bool {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -621,7 +621,12 @@ impl<'a, V: Verifier, C: ContextObject> JitCompiler<'a, V, C> {
                     }
                 },
                 ebpf::CALL_REG  => {
-                    self.emit_internal_call(Value::Register(REGISTER_MAP[insn.imm as usize]));
+                    let target_pc = if self.executable.get_sbpf_version().callx_uses_src_reg() {
+                        src
+                    } else {
+                        REGISTER_MAP[insn.imm as usize]
+                    };
+                    self.emit_internal_call(Value::Register(target_pc));
                 },
                 ebpf::EXIT      => {
                     let call_depth_access = X86IndirectAccess::Offset(self.slot_on_environment_stack(RuntimeEnvironmentSlot::CallDepth));

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -116,7 +116,7 @@ fn test_jeq() {
 fn test_call_reg() {
     assert_eq!(
         asm("callx r3"),
-        Ok(vec![insn(0, ebpf::CALL_REG, 0, 0, 0, 3)])
+        Ok(vec![insn(0, ebpf::CALL_REG, 0, 3, 0, 0)])
     );
 }
 


### PR DESCRIPTION
Currently callx encodes its target register in the `imm` field, but it should use the `src` register field instead.

The instruction info in llvm would need to be patched here:
https://github.com/solana-labs/llvm-project/blob/7b8db05b564faffb522434b73b7082662171f94a/llvm/lib/Target/BPF/BPFInstrInfo.td#L508