### PR TITLE
Refactor - Moves `runtime_environment_key` out of `Config` into a static variable

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -2,7 +2,7 @@ use std::mem::size_of;
 
 use arbitrary::{Arbitrary, Unstructured};
 
-use solana_rbpf::vm::{Config, PROGRAM_ENVIRONMENT_KEY_SHIFT};
+use solana_rbpf::vm::Config;
 
 #[derive(Debug)]
 pub struct ConfigTemplate {
@@ -12,7 +12,7 @@ pub struct ConfigTemplate {
     enable_stack_frame_gaps: bool,
     enable_symbol_and_section_labels: bool,
     sanitize_user_provided_values: bool,
-    encrypt_environment_registers: bool,
+    encrypt_runtime_environment: bool,
     reject_callx_r10: bool,
     optimize_rodata: bool,
 }
@@ -27,7 +27,7 @@ impl<'a> Arbitrary<'a> for ConfigTemplate {
             enable_stack_frame_gaps: bools & (1 << 0) != 0,
             enable_symbol_and_section_labels: bools & (1 << 1) != 0,
             sanitize_user_provided_values: bools & (1 << 3) != 0,
-            encrypt_environment_registers: bools & (1 << 4) != 0,
+            encrypt_runtime_environment: bools & (1 << 4) != 0,
             reject_callx_r10: bools & (1 << 6) != 0,
             optimize_rodata: bools & (1 << 9) != 0,
         })
@@ -51,7 +51,7 @@ impl From<ConfigTemplate> for Config {
                 enable_stack_frame_gaps,
                 enable_symbol_and_section_labels,
                 sanitize_user_provided_values,
-                encrypt_environment_registers,
+                encrypt_runtime_environment,
                 reject_callx_r10,
                 optimize_rodata,
             } => Config {
@@ -61,12 +61,7 @@ impl From<ConfigTemplate> for Config {
                 enable_symbol_and_section_labels,
                 noop_instruction_rate,
                 sanitize_user_provided_values,
-                runtime_environment_key: if encrypt_environment_registers {
-                    // Use a constant encryption key for reproducibility
-                    -946060820 >> PROGRAM_ENVIRONMENT_KEY_SHIFT
-                } else {
-                    0
-                },
+                encrypt_runtime_environment,
                 reject_callx_r10,
                 optimize_rodata,
                 ..Default::default()


### PR DESCRIPTION
Having `runtime_environment_key` inside `Config` is a bit of leaky abstraction as it requires the outside user to choose a key randomly and according to `PROGRAM_ENVIRONMENT_KEY_SHIFT`. It also prevents `Config::eq` from working properly as two identical configs but with different random keys would be considered different.