### PR TITLE
Refactor - `emit_product_quotient_remainder()` in JIT

### DIFF
--- a/src/x86.rs
+++ b/src/x86.rs
@@ -409,7 +409,7 @@ impl X86Instruction {
 
     /// Convert word to doubleword or doubleword to quadword
     #[inline]
-    pub const fn dividend_sign_extension(size: OperandSize) -> Self {
+    pub const fn sign_extend_rax_rdx(size: OperandSize) -> Self {
         exclude_operand_sizes!(size, OperandSize::S0 | OperandSize::S8 | OperandSize::S16);
         Self {
             size,


### PR DESCRIPTION
This is a preparation for the upcoming changes to `mul`, `div`, `mod` instructions and their encoding. This PR is alone is incomplete and changes to the ISA / instruction encoding are planned.