### PR TITLE
Refactor - Remove generic parameter `Verifier` from `Executable`

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -13,7 +13,6 @@ extern crate test_utils;
 use solana_rbpf::{
     elf::{Executable, FunctionRegistry},
     syscalls,
-    verifier::TautologyVerifier,
     vm::{BuiltinFunction, BuiltinProgram, Config, TestContextObject},
 };
 use std::{fs::File, io::Read, sync::Arc};
@@ -36,9 +35,7 @@ fn bench_load_sbpfv1(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     let loader = loader();
-    bencher.iter(|| {
-        Executable::<TautologyVerifier, TestContextObject>::from_elf(&elf, loader.clone()).unwrap()
-    });
+    bencher.iter(|| Executable::<TestContextObject>::from_elf(&elf, loader.clone()).unwrap());
 }
 
 #[bench]
@@ -47,7 +44,5 @@ fn bench_load_sbpfv2(bencher: &mut Bencher) {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     let loader = loader();
-    bencher.iter(|| {
-        Executable::<TautologyVerifier, TestContextObject>::from_elf(&elf, loader.clone()).unwrap()
-    });
+    bencher.iter(|| Executable::<TestContextObject>::from_elf(&elf, loader.clone()).unwrap());
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -26,13 +26,12 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let executable =
         Executable::<TestContextObject>::from_elf(&elf, Arc::new(BuiltinProgram::new_mock()))
             .unwrap();
-    let verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
     bencher.iter(|| {
         let mut context_object = TestContextObject::default();
         create_vm!(
             _vm,
-            &verified_executable,
+            &executable,
             &mut context_object,
             stack,
             heap,
@@ -48,10 +47,9 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/relative_call.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable =
+    let mut executable =
         Executable::<TestContextObject>::from_elf(&elf, Arc::new(BuiltinProgram::new_mock()))
             .unwrap();
-    let mut verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
-    bencher.iter(|| verified_executable.jit_compile().unwrap());
+    executable.verify::<RequisiteVerifier>().unwrap();
+    bencher.iter(|| executable.jit_compile().unwrap());
 }

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -11,7 +11,7 @@ extern crate test;
 
 use solana_rbpf::{
     elf::Executable,
-    verifier::{RequisiteVerifier, TautologyVerifier},
+    verifier::RequisiteVerifier,
     vm::{BuiltinProgram, TestContextObject},
 };
 use std::{fs::File, io::Read, sync::Arc};
@@ -23,13 +23,11 @@ fn bench_init_vm(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/relative_call.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
-        &elf,
-        Arc::new(BuiltinProgram::new_mock()),
-    )
-    .unwrap();
+    let executable =
+        Executable::<TestContextObject>::from_elf(&elf, Arc::new(BuiltinProgram::new_mock()))
+            .unwrap();
     let verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
     bencher.iter(|| {
         let mut context_object = TestContextObject::default();
         create_vm!(
@@ -50,12 +48,10 @@ fn bench_jit_compile(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/relative_call.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
-        &elf,
-        Arc::new(BuiltinProgram::new_mock()),
-    )
-    .unwrap();
+    let executable =
+        Executable::<TestContextObject>::from_elf(&elf, Arc::new(BuiltinProgram::new_mock()))
+            .unwrap();
     let mut verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
     bencher.iter(|| verified_executable.jit_compile().unwrap());
 }

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -13,7 +13,7 @@ use solana_rbpf::{
     ebpf,
     elf::{Executable, FunctionRegistry},
     memory_region::MemoryRegion,
-    verifier::{RequisiteVerifier, TautologyVerifier},
+    verifier::RequisiteVerifier,
     vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::{fs::File, io::Read, sync::Arc};
@@ -25,13 +25,11 @@ fn bench_init_interpreter_start(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/rodata_section.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
-        &elf,
-        Arc::new(BuiltinProgram::new_mock()),
-    )
-    .unwrap();
+    let executable =
+        Executable::<TestContextObject>::from_elf(&elf, Arc::new(BuiltinProgram::new_mock()))
+            .unwrap();
     let verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
     let mut context_object = TestContextObject::default();
     create_vm!(
         vm,
@@ -54,13 +52,11 @@ fn bench_init_jit_start(bencher: &mut Bencher) {
     let mut file = File::open("tests/elfs/rodata_section.so").unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_elf(
-        &elf,
-        Arc::new(BuiltinProgram::new_mock()),
-    )
-    .unwrap();
+    let executable =
+        Executable::<TestContextObject>::from_elf(&elf, Arc::new(BuiltinProgram::new_mock()))
+            .unwrap();
     let mut verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
     verified_executable.jit_compile().unwrap();
     let mut context_object = TestContextObject::default();
     create_vm!(
@@ -95,7 +91,7 @@ fn bench_jit_vs_interpreter(
     )
     .unwrap();
     let mut verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
     verified_executable.jit_compile().unwrap();
     let mut context_object = TestContextObject::default();
     let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -101,7 +101,8 @@ fn main() {
         },
         FunctionRegistry::default(),
     ));
-    let executable = match matches.value_of("assembler") {
+    #[allow(unused_mut)]
+    let mut executable = match matches.value_of("assembler") {
         Some(asm_file_name) => {
             let mut file = File::open(Path::new(asm_file_name)).unwrap();
             let mut source = Vec::new();
@@ -118,9 +119,7 @@ fn main() {
     }
     .unwrap();
 
-    #[allow(unused_mut)]
-    let verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 
     let mut mem = match matches.value_of("input").unwrap().parse::<usize>() {
         Ok(allocate) => vec![0u8; allocate],
@@ -133,7 +132,7 @@ fn main() {
     };
     #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
     if matches.value_of("use") == Some("jit") {
-        verified_executable.jit_compile().unwrap();
+        executable.jit_compile().unwrap();
     }
     let mut context_object = TestContextObject::new(
         matches
@@ -142,8 +141,8 @@ fn main() {
             .parse::<u64>()
             .unwrap(),
     );
-    let config = verified_executable.get_config();
-    let sbpf_version = verified_executable.get_sbpf_version();
+    let config = executable.get_config();
+    let sbpf_version = executable.get_sbpf_version();
     let mut stack = AlignedMemory::<{ ebpf::HOST_ALIGN }>::zero_filled(config.stack_size());
     let stack_len = stack.len();
     let mut heap = AlignedMemory::<{ ebpf::HOST_ALIGN }>::zero_filled(
@@ -154,7 +153,7 @@ fn main() {
             .unwrap(),
     );
     let regions: Vec<MemoryRegion> = vec![
-        verified_executable.get_ro_region(),
+        executable.get_ro_region(),
         MemoryRegion::new_writable_gapped(
             stack.as_slice_mut(),
             ebpf::MM_STACK_START,
@@ -171,8 +170,8 @@ fn main() {
     let memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();
 
     let mut vm = EbpfVm::new(
-        verified_executable.get_config(),
-        verified_executable.get_sbpf_version(),
+        executable.get_config(),
+        executable.get_sbpf_version(),
         &mut context_object,
         memory_mapping,
         stack_len,
@@ -183,7 +182,7 @@ fn main() {
         || matches.is_present("trace")
         || matches.is_present("profile")
     {
-        Some(Analysis::from_executable(&verified_executable).unwrap())
+        Some(Analysis::from_executable(&executable).unwrap())
     } else {
         None
     };
@@ -212,10 +211,8 @@ fn main() {
     if matches.value_of("use").unwrap() == "debugger" {
         vm.debug_port = Some(matches.value_of("port").unwrap().parse::<u16>().unwrap());
     }
-    let (instruction_count, result) = vm.execute_program(
-        &verified_executable,
-        matches.value_of("use").unwrap() != "jit",
-    );
+    let (instruction_count, result) =
+        vm.execute_program(&executable, matches.value_of("use").unwrap() != "jit");
     println!("Result: {result:?}");
     println!("Instruction Count: {instruction_count}");
     if matches.is_present("trace") {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use solana_rbpf::{
     elf::{Executable, FunctionRegistry},
     memory_region::{MemoryMapping, MemoryRegion},
     static_analysis::Analysis,
-    verifier::{RequisiteVerifier, TautologyVerifier},
+    verifier::RequisiteVerifier,
     vm::{BuiltinProgram, Config, DynamicAnalysis, EbpfVm, TestContextObject},
 };
 use std::{fs::File, io::Read, path::Path, sync::Arc};
@@ -112,7 +112,7 @@ fn main() {
             let mut file = File::open(Path::new(matches.value_of("elf").unwrap())).unwrap();
             let mut elf = Vec::new();
             file.read_to_end(&mut elf).unwrap();
-            Executable::<TautologyVerifier, TestContextObject>::from_elf(&elf, loader)
+            Executable::<TestContextObject>::from_elf(&elf, loader)
                 .map_err(|err| format!("Executable constructor failed: {err:?}"))
         }
     }
@@ -120,7 +120,7 @@ fn main() {
 
     #[allow(unused_mut)]
     let verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 
     let mut mem = match matches.value_of("input").unwrap().parse::<usize>() {
         Ok(allocate) => vec![0u8; allocate],

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -8,7 +8,6 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     elf::{Executable, FunctionRegistry, SBPFVersion},
     static_analysis::Analysis,
-    verifier::TautologyVerifier,
     vm::{BuiltinProgram, TestContextObject},
 };
 use std::sync::Arc;
@@ -32,7 +31,7 @@ fn main() {
         0x00, 0x00, 0x00, 0x00, 0x00,
     ];
     let loader = Arc::new(BuiltinProgram::new_mock());
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         program,
         loader,
         SBPFVersion::V2,

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -14,7 +14,6 @@ extern crate solana_rbpf;
 use solana_rbpf::{
     elf::{Executable, FunctionRegistry, SBPFVersion},
     static_analysis::Analysis,
-    verifier::TautologyVerifier,
     vm::{BuiltinProgram, TestContextObject},
 };
 use std::sync::Arc;
@@ -28,7 +27,7 @@ use std::sync::Arc;
 // * Print integers as integers, and not as strings containing their hexadecimal representation
 //   (just replace the relevant `format!()` calls by the commented values.
 fn to_json(program: &[u8]) -> String {
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         program,
         Arc::new(BuiltinProgram::new_mock()),
         SBPFVersion::V2,

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     ebpf,
     elf::{Executable, FunctionRegistry, SBPFVersion},
     memory_region::MemoryRegion,
-    verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
+    verifier::{RequisiteVerifier, Verifier},
     vm::{BuiltinProgram, TestContextObject},
 };
 use test_utils::create_vm;
@@ -33,7 +33,7 @@ fuzz_target!(|data: DumbFuzzData| {
         return;
     }
     let mut mem = data.mem;
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         &prog,
         std::sync::Arc::new(BuiltinProgram::new_loader(config, FunctionRegistry::default())),
         SBPFVersion::V2,

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -10,7 +10,7 @@ use solana_rbpf::{
     elf::{Executable, FunctionRegistry, SBPFVersion},
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
-    verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
+    verifier::{RequisiteVerifier, Verifier},
     vm::{BuiltinProgram, TestContextObject},
 };
 use test_utils::create_vm;
@@ -37,7 +37,7 @@ fuzz_target!(|data: FuzzData| {
         return;
     }
     let mut mem = data.mem;
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog.into_bytes(),
         std::sync::Arc::new(BuiltinProgram::new_loader(config, FunctionRegistry::default())),
         SBPFVersion::V2,

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     elf::{Executable, FunctionRegistry, SBPFVersion},
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
-    verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
+    verifier::{RequisiteVerifier, Verifier},
     vm::{BuiltinProgram, TestContextObject},
 };
 use test_utils::create_vm;
@@ -45,7 +45,7 @@ fuzz_target!(|data: FuzzData| {
     }
     let mut interp_mem = data.mem.clone();
     let mut jit_mem = data.mem;
-    let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let mut executable = Executable::<TestContextObject>::from_text_bytes(
         prog.into_bytes(),
         std::sync::Arc::new(BuiltinProgram::new_loader(config, FunctionRegistry::default())),
         SBPFVersion::V2,

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -9,7 +9,7 @@ use solana_rbpf::{
     insn_builder::IntoBytes,
     memory_region::MemoryRegion,
     static_analysis::Analysis,
-    verifier::{RequisiteVerifier, TautologyVerifier, Verifier},
+    verifier::{RequisiteVerifier, Verifier},
     vm::{
         BuiltinProgram, ContextObject, TestContextObject,
     },
@@ -28,7 +28,7 @@ struct FuzzData {
     mem: Vec<u8>,
 }
 
-fn dump_insns<V: Verifier, C: ContextObject>(verified_executable: &Executable<V, C>) {
+fn dump_insns<C: ContextObject>(verified_executable: &Executable<C>) {
     let analysis = Analysis::from_executable(verified_executable).unwrap();
     eprint!("Using the following disassembly");
     analysis.disassemble(&mut std::io::stderr().lock()).unwrap();
@@ -44,7 +44,7 @@ fuzz_target!(|data: FuzzData| {
     }
     let mut interp_mem = data.mem.clone();
     let mut jit_mem = data.mem;
-    let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let mut executable = Executable::<TestContextObject>::from_text_bytes(
         prog.into_bytes(),
         std::sync::Arc::new(BuiltinProgram::new_loader(config, FunctionRegistry::default())),
         SBPFVersion::V2,

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -28,8 +28,8 @@ struct FuzzData {
     mem: Vec<u8>,
 }
 
-fn dump_insns<C: ContextObject>(verified_executable: &Executable<C>) {
-    let analysis = Analysis::from_executable(verified_executable).unwrap();
+fn dump_insns<C: ContextObject>(executable: &Executable<C>) {
+    let analysis = Analysis::from_executable(executable).unwrap();
     eprint!("Using the following disassembly");
     analysis.disassemble(&mut std::io::stderr().lock()).unwrap();
 }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -19,7 +19,6 @@ use crate::{
     },
     ebpf::{self, Insn},
     elf::{Executable, FunctionRegistry, SBPFVersion},
-    verifier::TautologyVerifier,
     vm::{BuiltinProgram, ContextObject},
 };
 use std::{collections::HashMap, sync::Arc};
@@ -218,7 +217,7 @@ fn insn(opc: u8, dst: i64, src: i64, off: i64, imm: i64) -> Result<Insn, String>
 pub fn assemble<C: ContextObject>(
     src: &str,
     loader: Arc<BuiltinProgram<C>>,
-) -> Result<Executable<TautologyVerifier, C>, String> {
+) -> Result<Executable<C>, String> {
     let sbpf_version = if loader.get_config().enable_sbpf_v2 {
         SBPFVersion::V2
     } else {
@@ -366,11 +365,6 @@ pub fn assemble<C: ContextObject>(
         .iter()
         .flat_map(|insn| insn.to_vec())
         .collect::<Vec<_>>();
-    Executable::<TautologyVerifier, C>::from_text_bytes(
-        &program,
-        loader,
-        sbpf_version,
-        function_registry,
-    )
-    .map_err(|err| format!("Executable constructor {err:?}"))
+    Executable::<C>::from_text_bytes(&program, loader, sbpf_version, function_registry)
+        .map_err(|err| format!("Executable constructor {err:?}"))
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -497,14 +497,14 @@ impl<C: ContextObject> Executable<C> {
     }
 
     /// Verify the executable
-    pub fn verified<V: Verifier>(executable: Executable<C>) -> Result<Self, EbpfError> {
+    pub fn verify<V: Verifier>(&self) -> Result<(), EbpfError> {
         <V as Verifier>::verify(
-            executable.get_text_bytes().1,
-            executable.get_config(),
-            executable.get_sbpf_version(),
-            executable.get_function_registry(),
+            self.get_text_bytes().1,
+            self.get_config(),
+            self.get_sbpf_version(),
+            self.get_function_registry(),
         )?;
-        Ok(executable)
+        Ok(())
     }
 
     /// JIT compile the executable

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     error::EbpfError,
     memory_region::MemoryRegion,
-    verifier::{TautologyVerifier, Verifier},
+    verifier::Verifier,
     vm::{BuiltinProgram, Config, ContextObject},
 };
 
@@ -32,7 +32,6 @@ use byteorder::{ByteOrder, LittleEndian};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::Debug,
-    marker::PhantomData,
     mem,
     ops::Range,
     str,
@@ -409,9 +408,7 @@ impl<T: Copy + PartialEq> FunctionRegistry<T> {
 
 /// Elf loader/relocator
 #[derive(Debug, PartialEq)]
-pub struct Executable<V: Verifier, C: ContextObject> {
-    /// Verifier that verified this program
-    _verifier: PhantomData<V>,
+pub struct Executable<C: ContextObject> {
     /// Loaded and executable elf
     elf_bytes: AlignedMemory<{ HOST_ALIGN }>,
     /// Required SBPF capabilities
@@ -431,7 +428,7 @@ pub struct Executable<V: Verifier, C: ContextObject> {
     compiled_program: Option<JitProgram>,
 }
 
-impl<V: Verifier, C: ContextObject> Executable<V, C> {
+impl<C: ContextObject> Executable<C> {
     /// Get the configuration settings
     pub fn get_config(&self) -> &Config {
         self.loader.get_config()
@@ -500,22 +497,20 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
     }
 
     /// Verify the executable
-    pub fn verified(executable: Executable<TautologyVerifier, C>) -> Result<Self, EbpfError> {
+    pub fn verified<V: Verifier>(executable: Executable<C>) -> Result<Self, EbpfError> {
         <V as Verifier>::verify(
             executable.get_text_bytes().1,
             executable.get_config(),
             executable.get_sbpf_version(),
             executable.get_function_registry(),
         )?;
-        Ok(unsafe {
-            std::mem::transmute::<Executable<TautologyVerifier, C>, Executable<V, C>>(executable)
-        })
+        Ok(executable)
     }
 
     /// JIT compile the executable
     #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
     pub fn jit_compile(&mut self) -> Result<(), crate::error::EbpfError> {
-        let jit = JitCompiler::<V, C>::new(self)?;
+        let jit = JitCompiler::<C>::new(self)?;
         self.compiled_program = Some(jit.compile()?);
         Ok(())
     }
@@ -547,7 +542,6 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
             0
         };
         Ok(Self {
-            _verifier: PhantomData,
             elf_bytes,
             sbpf_version,
             ro_section: Section::Borrowed(0, 0..text_bytes.len()),
@@ -678,7 +672,6 @@ impl<V: Verifier, C: ContextObject> Executable<V, C> {
         )?;
 
         Ok(Self {
-            _verifier: PhantomData,
             elf_bytes,
             sbpf_version,
             ro_section,
@@ -1408,7 +1401,7 @@ mod test {
     use rand::{distributions::Uniform, Rng};
     use std::{fs::File, io::Read};
     use test_utils::assert_error;
-    type ElfExecutable = Executable<TautologyVerifier, TestContextObject>;
+    type ElfExecutable = Executable<TestContextObject>;
 
     fn loader() -> Arc<BuiltinProgram<TestContextObject>> {
         let mut function_registry =
@@ -1533,7 +1526,7 @@ mod test {
             .expect("failed to read elf file");
         let elf = ElfExecutable::load(&elf_bytes, loader.clone()).expect("validation failed");
         let parsed_elf = NewParser::parse(&elf_bytes).unwrap();
-        let executable: &Executable<TautologyVerifier, TestContextObject> = &elf;
+        let executable: &Executable<TestContextObject> = &elf;
         assert_eq!(0, executable.get_entrypoint_instruction_offset());
 
         let write_header = |header: Elf64Ehdr| unsafe {
@@ -1548,7 +1541,7 @@ mod test {
         header.e_entry += 8;
         let elf_bytes = write_header(header.clone());
         let elf = ElfExecutable::load(&elf_bytes, loader.clone()).expect("validation failed");
-        let executable: &Executable<TautologyVerifier, TestContextObject> = &elf;
+        let executable: &Executable<TestContextObject> = &elf;
         assert_eq!(1, executable.get_entrypoint_instruction_offset());
 
         header.e_entry = 1;
@@ -1575,7 +1568,7 @@ mod test {
         header.e_entry = initial_e_entry;
         let elf_bytes = write_header(header);
         let elf = ElfExecutable::load(&elf_bytes, loader).expect("validation failed");
-        let executable: &Executable<TautologyVerifier, TestContextObject> = &elf;
+        let executable: &Executable<TestContextObject> = &elf;
         assert_eq!(0, executable.get_entrypoint_instruction_offset());
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -16,7 +16,6 @@ use crate::{
     ebpf::{self, STACK_PTR_REG},
     elf::Executable,
     error::EbpfError,
-    verifier::Verifier,
     vm::{Config, ContextObject, EbpfVm, ProgramResult},
 };
 use std::convert::TryInto;
@@ -65,9 +64,9 @@ pub enum DebugState {
 }
 
 /// State of an interpreter
-pub struct Interpreter<'a, 'b, V: Verifier, C: ContextObject> {
+pub struct Interpreter<'a, 'b, C: ContextObject> {
     pub(crate) vm: &'a mut EbpfVm<'b, C>,
-    pub(crate) executable: &'a Executable<V, C>,
+    pub(crate) executable: &'a Executable<C>,
     pub(crate) program: &'a [u8],
     pub(crate) program_vm_addr: u64,
     pub(crate) due_insn_count: u64,
@@ -83,11 +82,11 @@ pub struct Interpreter<'a, 'b, V: Verifier, C: ContextObject> {
     pub(crate) breakpoints: Vec<u64>,
 }
 
-impl<'a, 'b, V: Verifier, C: ContextObject> Interpreter<'a, 'b, V, C> {
+impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
     /// Creates a new interpreter state
     pub fn new(
         vm: &'a mut EbpfVm<'b, C>,
-        executable: &'a Executable<V, C>,
+        executable: &'a Executable<C>,
         registers: [u64; 12],
     ) -> Self {
         let (program_vm_addr, program) = executable.get_text_bytes();

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -6,7 +6,6 @@ use crate::{
     ebpf,
     elf::Executable,
     error::EbpfError,
-    verifier::{TautologyVerifier, Verifier},
     vm::{ContextObject, DynamicAnalysis, TestContextObject},
 };
 use rustc_demangle::demangle;
@@ -127,7 +126,7 @@ impl Default for CfgNode {
 /// Result of the executable analysis
 pub struct Analysis<'a> {
     /// The program which is analyzed
-    executable: &'a Executable<TautologyVerifier, TestContextObject>,
+    executable: &'a Executable<TestContextObject>,
     /// Plain list of instructions as they occur in the executable
     pub instructions: Vec<ebpf::Insn>,
     /// Functions in the executable
@@ -148,8 +147,8 @@ pub struct Analysis<'a> {
 
 impl<'a> Analysis<'a> {
     /// Analyze an executable statically
-    pub fn from_executable<V: Verifier, C: ContextObject>(
-        executable: &'a Executable<V, C>,
+    pub fn from_executable<C: ContextObject>(
+        executable: &'a Executable<C>,
     ) -> Result<Self, EbpfError> {
         let (_program_vm_addr, program) = executable.get_text_bytes();
         let mut functions = BTreeMap::new();

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -382,17 +382,3 @@ impl Verifier for RequisiteVerifier {
         Ok(())
     }
 }
-
-/// Passes all inputs. Used to mark executables as unverified.
-#[derive(Debug)]
-pub struct TautologyVerifier {}
-impl Verifier for TautologyVerifier {
-    fn verify(
-        _prog: &[u8],
-        _config: &Config,
-        _sbpf_version: &SBPFVersion,
-        _function_registry: &FunctionRegistry<usize>,
-    ) -> std::result::Result<(), VerifierError> {
-        Ok(())
-    }
-}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -19,7 +19,6 @@ use crate::{
     interpreter::Interpreter,
     memory_region::MemoryMapping,
     static_analysis::{Analysis, TraceLogEntry},
-    verifier::{TautologyVerifier, Verifier},
 };
 use std::{collections::BTreeMap, fmt::Debug, mem, sync::Arc};
 
@@ -234,7 +233,7 @@ impl Default for Config {
 }
 
 /// Static constructors for Executable
-impl<C: ContextObject> Executable<TautologyVerifier, C> {
+impl<C: ContextObject> Executable<C> {
     /// Creates an executable from an ELF file
     pub fn from_elf(elf_bytes: &[u8], loader: Arc<BuiltinProgram<C>>) -> Result<Self, EbpfError> {
         let executable = Executable::load(elf_bytes, loader)?;
@@ -362,7 +361,7 @@ pub struct CallFrame {
 ///     ebpf,
 ///     elf::{Executable, FunctionRegistry, SBPFVersion},
 ///     memory_region::{MemoryMapping, MemoryRegion},
-///     verifier::{TautologyVerifier, RequisiteVerifier},
+///     verifier::{RequisiteVerifier},
 ///     vm::{BuiltinProgram, Config, EbpfVm, TestContextObject},
 /// };
 ///
@@ -375,8 +374,8 @@ pub struct CallFrame {
 ///
 /// let loader = std::sync::Arc::new(BuiltinProgram::new_mock());
 /// let function_registry = FunctionRegistry::default();
-/// let mut executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(prog, loader, SBPFVersion::V2, function_registry).unwrap();
-/// let verified_executable = Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+/// let mut executable = Executable::<TestContextObject>::from_text_bytes(prog, loader, SBPFVersion::V2, function_registry).unwrap();
+/// let verified_executable = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 /// let mut context_object = TestContextObject::new(1);
 /// let config = verified_executable.get_config();
 /// let sbpf_version = verified_executable.get_sbpf_version();
@@ -477,9 +476,9 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
     /// Execute the program
     ///
     /// If interpreted = `false` then the JIT compiled executable is used.
-    pub fn execute_program<V: Verifier>(
+    pub fn execute_program(
         &mut self,
-        executable: &Executable<V, C>,
+        executable: &Executable<C>,
         interpreted: bool,
     ) -> (u64, ProgramResult) {
         let mut registers = [0u64; 12];

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -375,17 +375,17 @@ pub struct CallFrame {
 /// let loader = std::sync::Arc::new(BuiltinProgram::new_mock());
 /// let function_registry = FunctionRegistry::default();
 /// let mut executable = Executable::<TestContextObject>::from_text_bytes(prog, loader, SBPFVersion::V2, function_registry).unwrap();
-/// let verified_executable = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+/// executable.verify::<RequisiteVerifier>().unwrap();
 /// let mut context_object = TestContextObject::new(1);
-/// let config = verified_executable.get_config();
-/// let sbpf_version = verified_executable.get_sbpf_version();
+/// let config = executable.get_config();
+/// let sbpf_version = executable.get_sbpf_version();
 ///
 /// let mut stack = AlignedMemory::<{ebpf::HOST_ALIGN}>::zero_filled(config.stack_size());
 /// let stack_len = stack.len();
 /// let mut heap = AlignedMemory::<{ebpf::HOST_ALIGN}>::with_capacity(0);
 ///
 /// let regions: Vec<MemoryRegion> = vec![
-///     verified_executable.get_ro_region(),
+///     executable.get_ro_region(),
 ///     MemoryRegion::new_writable(
 ///         stack.as_slice_mut(),
 ///         ebpf::MM_STACK_START,
@@ -398,7 +398,7 @@ pub struct CallFrame {
 ///
 /// let mut vm = EbpfVm::new(config, sbpf_version, &mut context_object, memory_mapping, stack_len);
 ///
-/// let (instruction_count, result) = vm.execute_program(&verified_executable, true);
+/// let (instruction_count, result) = vm.execute_program(&executable, true);
 /// assert_eq!(instruction_count, 1);
 /// assert_eq!(result.unwrap(), 0);
 /// ```

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use crate::{
     jit::{JitCompiler, OperandSize},
-    verifier::Verifier,
     vm::ContextObject,
 };
 
@@ -103,7 +102,7 @@ impl X86Instruction {
     };
 
     #[inline]
-    pub fn emit<V: Verifier, C: ContextObject>(&self, jit: &mut JitCompiler<V, C>) {
+    pub fn emit<C: ContextObject>(&self, jit: &mut JitCompiler<C>) {
         debug_assert!(!matches!(self.size, OperandSize::S0));
         let mut rex = X86Rex {
             w: matches!(self.size, OperandSize::S64),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -14,7 +14,6 @@ use solana_rbpf::{
     elf::Executable,
     error::EbpfError,
     memory_region::{MemoryCowCallback, MemoryMapping, MemoryRegion},
-    verifier::Verifier,
     vm::ContextObject,
 };
 
@@ -159,8 +158,8 @@ pub const TCP_SACK_NOMATCH: [u8; 66] = [
     0x9e, 0x27, //
 ];
 
-pub fn create_memory_mapping<'a, V: Verifier, C: ContextObject>(
-    executable: &'a Executable<V, C>,
+pub fn create_memory_mapping<'a, C: ContextObject>(
+    executable: &'a Executable<C>,
     stack: &'a mut AlignedMemory<{ HOST_ALIGN }>,
     heap: &'a mut AlignedMemory<{ HOST_ALIGN }>,
     additional_regions: Vec<MemoryRegion>,

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -26,7 +26,7 @@ use solana_rbpf::{
     assembler::assemble,
     ebpf,
     elf::{Executable, FunctionRegistry, SBPFVersion},
-    verifier::{RequisiteVerifier, TautologyVerifier, Verifier, VerifierError},
+    verifier::{RequisiteVerifier, Verifier, VerifierError},
     vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::sync::Arc;
@@ -38,6 +38,18 @@ use thiserror::Error;
 pub enum VerifierTestError {
     #[error("{0}")]
     Rejected(String),
+}
+
+struct TautologyVerifier {}
+impl Verifier for TautologyVerifier {
+    fn verify(
+        _prog: &[u8],
+        _config: &Config,
+        _sbpf_version: &SBPFVersion,
+        _function_registry: &FunctionRegistry<usize>,
+    ) -> std::result::Result<(), VerifierError> {
+        Ok(())
+    }
 }
 
 struct ContradictionVerifier {}

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -62,7 +62,7 @@ fn test_verifier_success() {
     )
     .unwrap();
     let verified_executable =
-        Executable::<TautologyVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<TautologyVerifier>(executable).unwrap();
     create_vm!(
         _vm,
         &verified_executable,
@@ -85,7 +85,7 @@ fn test_verifier_fail() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<ContradictionVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<ContradictionVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_verifier_err_div_by_zero_imm() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn test_verifier_err_endian_size() {
         0xb7, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
         Arc::new(BuiltinProgram::new_mock()),
         SBPFVersion::V2,
@@ -119,7 +119,7 @@ fn test_verifier_err_endian_size() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn test_verifier_err_incomplete_lddw() {
         0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
         Arc::new(BuiltinProgram::new_mock()),
         SBPFVersion::V1,
@@ -138,7 +138,7 @@ fn test_verifier_err_incomplete_lddw() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn test_verifier_err_invalid_reg_dst() {
             )),
         )
         .unwrap();
-        let result = Executable::<RequisiteVerifier, TestContextObject>::verified(executable)
+        let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
             .map_err(|err| format!("Executable constructor {err:?}"));
 
         assert_eq!(
@@ -187,7 +187,7 @@ fn test_verifier_err_invalid_reg_src() {
             )),
         )
         .unwrap();
-        let result = Executable::<RequisiteVerifier, TestContextObject>::verified(executable)
+        let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
             .map_err(|err| format!("Executable constructor {err:?}"));
 
         assert_eq!(
@@ -214,7 +214,7 @@ fn test_verifier_resize_stack_ptr_success() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -229,7 +229,7 @@ fn test_verifier_err_jmp_lddw() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -244,7 +244,7 @@ fn test_verifier_err_call_lddw() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -259,7 +259,7 @@ fn test_verifier_err_function_fallthrough() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -273,7 +273,7 @@ fn test_verifier_err_jmp_out() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -287,7 +287,7 @@ fn test_verifier_err_jmp_out_start() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -297,7 +297,7 @@ fn test_verifier_err_unknown_opcode() {
         0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
         0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     ];
-    let executable = Executable::<TautologyVerifier, TestContextObject>::from_text_bytes(
+    let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
         Arc::new(BuiltinProgram::new_mock()),
         SBPFVersion::V2,
@@ -305,7 +305,7 @@ fn test_verifier_err_unknown_opcode() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -319,7 +319,7 @@ fn test_verifier_err_write_r10() {
     )
     .unwrap();
     let _verified_executable =
-        Executable::<RequisiteVerifier, TestContextObject>::verified(executable).unwrap();
+        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
 }
 
 #[test]
@@ -352,7 +352,7 @@ fn test_verifier_err_all_shift_overflows() {
         let assembly = format!("\n{overflowing_instruction}\nexit");
         let executable =
             assemble::<TestContextObject>(&assembly, Arc::new(BuiltinProgram::new_mock())).unwrap();
-        let result = Executable::<RequisiteVerifier, TestContextObject>::verified(executable)
+        let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
             .map_err(|err| format!("Executable constructor {err:?}"));
         match expected {
             Ok(()) => assert!(result.is_ok()),
@@ -390,7 +390,7 @@ fn test_sdiv_disabled() {
                 )),
             )
             .unwrap();
-            let result = Executable::<RequisiteVerifier, TestContextObject>::verified(executable)
+            let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
                 .map_err(|err| format!("Executable constructor {err:?}"));
             if enable_sbpf_v2 {
                 assert!(result.is_ok());

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -30,7 +30,7 @@ use solana_rbpf::{
     vm::{BuiltinProgram, Config, TestContextObject},
 };
 use std::sync::Arc;
-use test_utils::create_vm;
+use test_utils::{assert_error, create_vm};
 use thiserror::Error;
 
 /// Error definitions
@@ -73,11 +73,10 @@ fn test_verifier_success() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let verified_executable =
-        Executable::<TestContextObject>::verified::<TautologyVerifier>(executable).unwrap();
+    executable.verify::<TautologyVerifier>().unwrap();
     create_vm!(
         _vm,
-        &verified_executable,
+        &executable,
         &mut TestContextObject::default(),
         stack,
         heap,
@@ -96,8 +95,7 @@ fn test_verifier_fail() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<ContradictionVerifier>(executable).unwrap();
+    executable.verify::<ContradictionVerifier>().unwrap();
 }
 
 #[test]
@@ -111,8 +109,7 @@ fn test_verifier_err_div_by_zero_imm() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -130,8 +127,7 @@ fn test_verifier_err_endian_size() {
         FunctionRegistry::default(),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -149,8 +145,7 @@ fn test_verifier_err_incomplete_lddw() {
         FunctionRegistry::default(),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -171,13 +166,8 @@ fn test_verifier_err_invalid_reg_dst() {
             )),
         )
         .unwrap();
-        let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
-            .map_err(|err| format!("Executable constructor {err:?}"));
-
-        assert_eq!(
-            result.unwrap_err(),
-            "Executable constructor VerifierError(InvalidDestinationRegister(29))"
-        );
+        let result = executable.verify::<RequisiteVerifier>();
+        assert_error!(result, "VerifierError(InvalidDestinationRegister(29))");
     }
 }
 
@@ -199,13 +189,8 @@ fn test_verifier_err_invalid_reg_src() {
             )),
         )
         .unwrap();
-        let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
-            .map_err(|err| format!("Executable constructor {err:?}"));
-
-        assert_eq!(
-            result.unwrap_err(),
-            "Executable constructor VerifierError(InvalidSourceRegister(29))"
-        );
+        let result = executable.verify::<RequisiteVerifier>();
+        assert_error!(result, "VerifierError(InvalidSourceRegister(29))");
     }
 }
 
@@ -225,8 +210,7 @@ fn test_verifier_resize_stack_ptr_success() {
         )),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -240,8 +224,7 @@ fn test_verifier_err_jmp_lddw() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -255,8 +238,7 @@ fn test_verifier_err_call_lddw() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -270,8 +252,7 @@ fn test_verifier_err_function_fallthrough() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -284,8 +265,7 @@ fn test_verifier_err_jmp_out() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -298,8 +278,7 @@ fn test_verifier_err_jmp_out_start() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -316,8 +295,7 @@ fn test_verifier_err_unknown_opcode() {
         FunctionRegistry::default(),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -330,8 +308,7 @@ fn test_verifier_err_write_r10() {
         Arc::new(BuiltinProgram::new_mock()),
     )
     .unwrap();
-    let _verified_executable =
-        Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable).unwrap();
+    executable.verify::<RequisiteVerifier>().unwrap();
 }
 
 #[test]
@@ -364,17 +341,10 @@ fn test_verifier_err_all_shift_overflows() {
         let assembly = format!("\n{overflowing_instruction}\nexit");
         let executable =
             assemble::<TestContextObject>(&assembly, Arc::new(BuiltinProgram::new_mock())).unwrap();
-        let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
-            .map_err(|err| format!("Executable constructor {err:?}"));
+        let result = executable.verify::<RequisiteVerifier>();
         match expected {
             Ok(()) => assert!(result.is_ok()),
-            Err(overflow_msg) => match result {
-                Err(err) => assert_eq!(
-                    err,
-                    format!("Executable constructor VerifierError({overflow_msg})"),
-                ),
-                _ => panic!("Expected error"),
-            },
+            Err(overflow_msg) => assert_error!(result, "VerifierError({overflow_msg})"),
         }
     }
 }
@@ -402,18 +372,15 @@ fn test_sdiv_disabled() {
                 )),
             )
             .unwrap();
-            let result = Executable::<TestContextObject>::verified::<RequisiteVerifier>(executable)
-                .map_err(|err| format!("Executable constructor {err:?}"));
+            let result = executable.verify::<RequisiteVerifier>();
             if enable_sbpf_v2 {
                 assert!(result.is_ok());
             } else {
-                assert_eq!(
-                    result.unwrap_err(),
-                    format!(
-                        "Executable constructor VerifierError(UnknownOpCode({}, {}))",
-                        opc,
-                        ebpf::ELF_INSN_DUMP_OFFSET
-                    ),
+                assert_error!(
+                    result,
+                    "VerifierError(UnknownOpCode({}, {}))",
+                    opc,
+                    ebpf::ELF_INSN_DUMP_OFFSET
                 );
             }
         }


### PR DESCRIPTION
In the monorepo we can now cache that a program was verified with the current `vm::Config` and skip verification when re-loading these programs. But that requires an `unsafe` transmutation to circumvent the protection here in RBPF against precisely this usage pattern. See https://github.com/solana-labs/solana/pull/32722#discussion_r1288858519.

Thus, we will just remove the type safety here as the check is effectively done at runtime now, in the loaded programs cache.