### PR TITLE
mmap: fd should be -1 when creating anonymous mappings

### DIFF
--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -102,7 +102,7 @@ pub unsafe fn allocate_pages(size_in_bytes: usize) -> Result<*mut u8, EbpfError>
         size_in_bytes,
         libc::PROT_READ | libc::PROT_WRITE,
         libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
-        0,
+        -1,
         0,
     );
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
Allocating anonymous with mmap() should have fd set to -1 in conforming code (as 0 is a valid value for a file descriptor).
Linux is forgiving about this however other OS's (FreeBSD) less so.
This trivial change fixes BPF programs on Solana/FreeBSD which are currently broken by this.
I have copied an extract from the linux 2 mmap page for reference below.
```
MAP_ANONYMOUS
The mapping is not backed by any file; its contents are initialized to zero.  The fd argument is ignored; however, some implementations
require fd to be -1 if MAP_ANONYMOUS (or MAP_ANON) is specified, and portable applications should ensure  this.   The  offset  argument
should be zero.  The use of MAP_ANONYMOUS in conjunction with MAP_SHARED is supported on Linux only since kernel 2.4.
```