### PR TITLE
Fix - Stops using assign for results as that drops the previously (non) existing value

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1329,10 +1329,10 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
 
         // Routine for allocating errors
         self.set_anchor(ANCHOR_ALLOCATE_EXCEPTION);
-        unsafe fn allocate_error(result: &mut ProgramResult) -> *mut EbpfError {
+        unsafe fn allocate_error(result: *mut ProgramResult) -> *mut EbpfError {
             let err_ptr = std::alloc::alloc(std::alloc::Layout::new::<EbpfError>()) as *mut EbpfError;
             assert!(!err_ptr.is_null(), "std::alloc::alloc() failed");
-            *result = ProgramResult::Err(Box::from_raw(err_ptr));
+            result.write(ProgramResult::Err(Box::from_raw(err_ptr)));
             err_ptr
         }
         self.emit_ins(X86Instruction::lea(OperandSize::S64, RBP, R10, Some(X86IndirectAccess::Offset(self.slot_on_environment_stack(RuntimeEnvironmentSlot::ProgramResult)))));


### PR DESCRIPTION
Further refactoring of the `Error` structure and its allocation is planned.