### PR TITLE
Refactor - Adds a reference to the loader in the VM

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -171,7 +171,7 @@ fn main() {
     let memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();
 
     let mut vm = EbpfVm::new(
-        executable.get_config(),
+        executable.get_loader().clone(),
         executable.get_sbpf_version(),
         &mut context_object,
         memory_mapping,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1628,7 +1628,7 @@ mod tests {
         let executable = create_mockup_executable(&[]);
         let mut context_object = TestContextObject::new(0);
         let env = EbpfVm::new(
-            executable.get_config(),
+            executable.get_loader().clone(),
             executable.get_sbpf_version(),
             &mut context_object,
             MemoryMapping::new_identity(),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -208,7 +208,7 @@ macro_rules! create_vm {
         )
         .unwrap();
         let mut $vm_name = solana_rbpf::vm::EbpfVm::new(
-            $verified_executable.get_config(),
+            $verified_executable.get_loader().clone(),
             $verified_executable.get_sbpf_version(),
             $context_object,
             memory_mapping,


### PR DESCRIPTION
This enables us to have a single `Config` when a VM runs multiple `Executable`s.