### PR TITLE
Refactor - vm interface of `BuiltinFunction`s

### DIFF
--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -12,7 +12,6 @@ pub struct ConfigTemplate {
     enable_stack_frame_gaps: bool,
     enable_symbol_and_section_labels: bool,
     sanitize_user_provided_values: bool,
-    encrypt_runtime_environment: bool,
     reject_callx_r10: bool,
     optimize_rodata: bool,
 }
@@ -27,7 +26,6 @@ impl<'a> Arbitrary<'a> for ConfigTemplate {
             enable_stack_frame_gaps: bools & (1 << 0) != 0,
             enable_symbol_and_section_labels: bools & (1 << 1) != 0,
             sanitize_user_provided_values: bools & (1 << 3) != 0,
-            encrypt_runtime_environment: bools & (1 << 4) != 0,
             reject_callx_r10: bools & (1 << 6) != 0,
             optimize_rodata: bools & (1 << 9) != 0,
         })
@@ -51,7 +49,6 @@ impl From<ConfigTemplate> for Config {
                 enable_stack_frame_gaps,
                 enable_symbol_and_section_labels,
                 sanitize_user_provided_values,
-                encrypt_runtime_environment,
                 reject_callx_r10,
                 optimize_rodata,
             } => Config {
@@ -61,7 +58,6 @@ impl From<ConfigTemplate> for Config {
                 enable_symbol_and_section_labels,
                 noop_instruction_rate,
                 sanitize_user_provided_values,
-                encrypt_runtime_environment,
                 reject_callx_r10,
                 optimize_rodata,
                 ..Default::default()

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -476,9 +476,7 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                     if let Some((_function_name, function)) = self.executable.get_loader().get_function_registry().lookup_by_key(insn.imm as u32) {
                         resolved = true;
 
-                        if config.enable_instruction_meter {
-                            self.vm.context_object_pointer.consume(self.due_insn_count);
-                        }
+                        self.vm.previous_instruction_meter = self.due_insn_count;
                         self.due_insn_count = 0;
                         function(
                             &mut self.vm,
@@ -492,9 +490,6 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                             ProgramResult::Ok(value) => *value,
                             ProgramResult::Err(_err) => return false,
                         };
-                        if config.enable_instruction_meter {
-                            self.vm.previous_instruction_meter = self.vm.context_object_pointer.get_remaining();
-                        }
                     }
                 }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -481,14 +481,12 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                         }
                         self.due_insn_count = 0;
                         function(
-                            self.vm.context_object_pointer,
+                            &mut self.vm,
                             self.reg[1],
                             self.reg[2],
                             self.reg[3],
                             self.reg[4],
                             self.reg[5],
-                            &mut self.vm.memory_mapping,
-                            &mut self.vm.program_result,
                         );
                         self.reg[0] = match &self.vm.program_result {
                             ProgramResult::Ok(value) => *value,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -16,7 +16,7 @@ use crate::{
     ebpf::{self, STACK_PTR_REG},
     elf::Executable,
     error::EbpfError,
-    vm::{Config, ContextObject, EbpfVm, ProgramResult},
+    vm::{get_runtime_environment_key, Config, ContextObject, EbpfVm, ProgramResult},
 };
 
 /// Virtual memory operation helper.
@@ -479,7 +479,7 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                         self.vm.previous_instruction_meter = self.due_insn_count;
                         self.due_insn_count = 0;
                         function(
-                            &mut self.vm,
+                            unsafe { (self.vm as *mut _ as *mut u64).offset(get_runtime_environment_key() as isize) as *mut _ },
                             self.reg[1],
                             self.reg[2],
                             self.reg[3],

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1394,7 +1394,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             Argument { index: 3, value: Value::Register(ARGUMENT_REGISTERS[3]) },
             Argument { index: 2, value: Value::Register(ARGUMENT_REGISTERS[2]) },
             Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[1]) },
-            Argument { index: 0, value: Value::RegisterPlusConstant32(REGISTER_PTR_TO_VM, self.slot_in_vm(RuntimeEnvironmentSlot::HostStackPointer), false) },
+            Argument { index: 0, value: Value::Register(REGISTER_PTR_TO_VM) },
         ], None);
         if self.config.enable_instruction_meter {
             self.emit_ins(X86Instruction::load(OperandSize::S64, REGISTER_PTR_TO_VM, REGISTER_INSTRUCTION_METER, X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::PreviousInstructionMeter)))); // REGISTER_INSTRUCTION_METER = *PreviousInstructionMeter;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1407,14 +1407,12 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             ], None);
         }
         self.emit_rust_call(Value::Register(REGISTER_SCRATCH), &[
-            Argument { index: 7, value: Value::RegisterPlusConstant32(REGISTER_PTR_TO_VM, self.slot_in_vm(RuntimeEnvironmentSlot::ProgramResult), false) },
-            Argument { index: 6, value: Value::RegisterPlusConstant32(REGISTER_PTR_TO_VM, self.slot_in_vm(RuntimeEnvironmentSlot::MemoryMapping), false) },
             Argument { index: 5, value: Value::Register(ARGUMENT_REGISTERS[5]) },
             Argument { index: 4, value: Value::Register(ARGUMENT_REGISTERS[4]) },
             Argument { index: 3, value: Value::Register(ARGUMENT_REGISTERS[3]) },
             Argument { index: 2, value: Value::Register(ARGUMENT_REGISTERS[2]) },
             Argument { index: 1, value: Value::Register(ARGUMENT_REGISTERS[1]) },
-            Argument { index: 0, value: Value::RegisterIndirect(REGISTER_PTR_TO_VM, self.slot_in_vm(RuntimeEnvironmentSlot::ContextObjectPointer), false) },
+            Argument { index: 0, value: Value::RegisterPlusConstant32(REGISTER_PTR_TO_VM, self.slot_in_vm(RuntimeEnvironmentSlot::HostStackPointer), false) },
         ], None);
         if self.config.enable_instruction_meter {
             self.emit_rust_call(Value::Constant64(C::get_remaining as *const u8 as i64, false), &[

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -249,11 +249,12 @@ enum RuntimeEnvironmentSlot {
     StackPointer = 2,
     ContextObjectPointer = 3,
     PreviousInstructionMeter = 4,
-    StopwatchNumerator = 5,
-    StopwatchDenominator = 6,
-    Registers = 7,
-    ProgramResult = 19,
-    MemoryMapping = 27,
+    DueInsnCount = 5,
+    StopwatchNumerator = 6,
+    StopwatchDenominator = 7,
+    Registers = 8,
+    ProgramResult = 20,
+    MemoryMapping = 28,
 }
 
 /* Explaination of the Instruction Meter
@@ -1386,7 +1387,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.set_anchor(ANCHOR_EXTERNAL_FUNCTION_CALL);
         self.emit_ins(X86Instruction::push_immediate(OperandSize::S64, -1)); // Used as PC value in error case, acts as stack padding otherwise
         if self.config.enable_instruction_meter {
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, 0, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::PreviousInstructionMeter))))); // *PreviousInstructionMeter -= REGISTER_INSTRUCTION_METER;
+            self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::DueInsnCount)))); // *DueInsnCount = REGISTER_INSTRUCTION_METER;
         }
         self.emit_rust_call(Value::Register(REGISTER_SCRATCH), &[
             Argument { index: 5, value: Value::Register(ARGUMENT_REGISTERS[5]) },
@@ -1627,6 +1628,7 @@ mod tests {
         check_slot!(env, stack_pointer, StackPointer);
         check_slot!(env, context_object_pointer, ContextObjectPointer);
         check_slot!(env, previous_instruction_meter, PreviousInstructionMeter);
+        check_slot!(env, due_insn_count, DueInsnCount);
         check_slot!(env, stopwatch_numerator, StopwatchNumerator);
         check_slot!(env, stopwatch_denominator, StopwatchDenominator);
         check_slot!(env, registers, Registers);

--- a/src/program.rs
+++ b/src/program.rs
@@ -304,10 +304,18 @@ macro_rules! declare_builtin_function {
                 arg_d: u64,
                 arg_e: u64,
             ) {
+                use $crate::vm::ContextObject;
+                let config = vm.loader.get_config();
+                if config.enable_instruction_meter {
+                    vm.context_object_pointer.consume(vm.previous_instruction_meter);
+                }
                 let converted_result: $crate::vm::ProgramResult = Self::rust(
                     vm.context_object_pointer, arg_a, arg_b, arg_c, arg_d, arg_e, &mut vm.memory_mapping,
                 ).into();
                 vm.program_result = converted_result;
+                if config.enable_instruction_meter {
+                    vm.previous_instruction_meter = vm.context_object_pointer.get_remaining();
+                }
             }
         }
     };

--- a/src/program.rs
+++ b/src/program.rs
@@ -310,7 +310,7 @@ macro_rules! declare_builtin_function {
                 };
                 let config = vm.loader.get_config();
                 if config.enable_instruction_meter {
-                    vm.context_object_pointer.consume(vm.previous_instruction_meter);
+                    vm.context_object_pointer.consume(vm.previous_instruction_meter - vm.due_insn_count);
                 }
                 let converted_result: $crate::vm::ProgramResult = Self::rust(
                     vm.context_object_pointer, arg_a, arg_b, arg_c, arg_d, arg_e, &mut vm.memory_mapping,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -481,12 +481,7 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
                     Ok(compiled_program) => compiled_program,
                     Err(error) => return (0, ProgramResult::Err(error)),
                 };
-                let instruction_meter_final =
-                    compiled_program.invoke(config, self, self.registers).max(0) as u64;
-                self.due_insn_count = self
-                    .context_object_pointer
-                    .get_remaining()
-                    .saturating_sub(instruction_meter_final);
+                compiled_program.invoke(config, self, self.registers);
             }
             #[cfg(not(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64")))]
             {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -376,6 +376,8 @@ pub struct EbpfVm<'a, C: ContextObject> {
     pub context_object_pointer: &'a mut C,
     /// Last return value of instruction_meter.get_remaining()
     pub previous_instruction_meter: u64,
+    /// Outstanding value to instruction_meter.consume()
+    pub due_insn_count: u64,
     /// CPU cycles accumulated by the stop watch
     pub stopwatch_numerator: u64,
     /// Number of times the stop watch was used
@@ -422,6 +424,7 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
             stack_pointer,
             context_object_pointer: context_object,
             previous_instruction_meter: 0,
+            due_insn_count: 0,
             stopwatch_numerator: 0,
             stopwatch_denominator: 0,
             registers: [0u64; 12],
@@ -454,8 +457,9 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
             0
         };
         self.previous_instruction_meter = initial_insn_count;
+        self.due_insn_count = 0;
         self.program_result = ProgramResult::Ok(0);
-        let due_insn_count = if interpreted {
+        if interpreted {
             #[cfg(feature = "debugger")]
             let debug_port = self.debug_port.clone();
             let mut interpreter = Interpreter::new(self, executable, self.registers);
@@ -467,7 +471,6 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
             }
             #[cfg(not(feature = "debugger"))]
             while interpreter.step() {}
-            interpreter.due_insn_count
         } else {
             #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
             {
@@ -480,9 +483,10 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
                 };
                 let instruction_meter_final =
                     compiled_program.invoke(config, self, self.registers).max(0) as u64;
-                self.context_object_pointer
+                self.due_insn_count = self
+                    .context_object_pointer
                     .get_remaining()
-                    .saturating_sub(instruction_meter_final)
+                    .saturating_sub(instruction_meter_final);
             }
             #[cfg(not(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64")))]
             {
@@ -490,7 +494,7 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
             }
         };
         let instruction_count = if config.enable_instruction_meter {
-            self.context_object_pointer.consume(due_insn_count);
+            self.context_object_pointer.consume(self.due_insn_count);
             initial_insn_count.saturating_sub(self.context_object_pointer.get_remaining())
         } else {
             0

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -29,7 +29,9 @@ use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 /// 3 bits for 8 Byte alignment, and 1 bit to have encoding space for the RuntimeEnvironment.
 const PROGRAM_ENVIRONMENT_KEY_SHIFT: u32 = 4;
 static RUNTIME_ENVIRONMENT_KEY: std::sync::OnceLock<i32> = std::sync::OnceLock::<i32>::new();
-pub(crate) fn get_runtime_environment_key() -> i32 {
+
+/// Returns (and if not done before generates) the encryption key for the VM pointer
+pub fn get_runtime_environment_key() -> i32 {
     *RUNTIME_ENVIRONMENT_KEY
         .get_or_init(|| rand::thread_rng().gen::<i32>() >> PROGRAM_ENVIRONMENT_KEY_SHIFT)
 }


### PR DESCRIPTION
This drastically simplifies the vm interface of `BuiltinFunction`s so that it becomes a lot closer to the vm internal call interface:
- Instead of passing `ContextObject`, `MemoryMapping` and `ProgramResult` the encrypted pointer to the entire EbpfVm is passed, which is then decrypted and decomposed inside `declare_builtin_function()`. Thanks to #534, this does not even require swapping of argument registers.
- The instruction metering around syscalls from the interpreter and JIT was moved into `declare_builtin_function()`, which does not only deduplicate the logic, but also allows LLVM to optimize the register allocation, spilling and perform inlining, effectively reducing the cost of a syscall from three context switches between the VM and Rust ABI, down to one.

Unfortunately, encrypt_runtime_environment is now no longer optional as we can not read the config of the VM without dereferencing the potentially encrypted VM pointer.