### PR TITLE
Feature - `EbpfVm::invoke_function()`

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -16,7 +16,7 @@ use crate::{
     ebpf::{self, STACK_PTR_REG},
     elf::Executable,
     error::{EbpfError, ProgramResult},
-    vm::{get_runtime_environment_key, Config, ContextObject, EbpfVm},
+    vm::{Config, ContextObject, EbpfVm},
 };
 
 /// Virtual memory operation helper.
@@ -475,14 +475,8 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                         resolved = true;
 
                         self.vm.due_insn_count = self.vm.previous_instruction_meter - self.vm.due_insn_count;
-                        function(
-                            unsafe { (self.vm as *mut _ as *mut u64).offset(get_runtime_environment_key() as isize) as *mut _ },
-                            self.reg[1],
-                            self.reg[2],
-                            self.reg[3],
-                            self.reg[4],
-                            self.reg[5],
-                        );
+                        self.vm.registers[0..6].copy_from_slice(&self.reg[0..6]);
+                        self.vm.invoke_function(function);
                         self.vm.due_insn_count = 0;
                         self.reg[0] = match &self.vm.program_result {
                             ProgramResult::Ok(value) => *value,

--- a/src/program.rs
+++ b/src/program.rs
@@ -296,7 +296,7 @@ macro_rules! declare_builtin_function {
         $arg_d:ident : u64,
         $arg_e:ident : u64,
         $memory_mapping:ident : &mut $MemoryMapping:ty,
-    ) -> Result<u64, $Error:ty> $rust:tt) => {
+    ) -> $Result:ty { $($rust:tt)* }) => {
         $(#[$attr])*
         pub struct $name {}
         impl $name {
@@ -309,8 +309,8 @@ macro_rules! declare_builtin_function {
                 $arg_d: u64,
                 $arg_e: u64,
                 $memory_mapping: &mut $MemoryMapping,
-            ) -> Result<u64, $Error> {
-                $rust
+            ) -> $Result {
+                $($rust)*
             }
             /// VM interface
             #[allow(clippy::too_many_arguments)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -18,7 +18,7 @@ use crate::{
     error::{EbpfError, ProgramResult},
     interpreter::Interpreter,
     memory_region::MemoryMapping,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
     static_analysis::{Analysis, TraceLogEntry},
 };
 use rand::Rng;
@@ -420,5 +420,20 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
         let mut result = ProgramResult::Ok(0);
         std::mem::swap(&mut result, &mut self.program_result);
         (instruction_count, result)
+    }
+
+    /// Invokes a built-in function
+    pub fn invoke_function(&mut self, function: BuiltinFunction<C>) {
+        function(
+            unsafe {
+                (self as *mut _ as *mut u64).offset(get_runtime_environment_key() as isize)
+                    as *mut _
+            },
+            self.registers[1],
+            self.registers[2],
+            self.registers[3],
+            self.registers[4],
+            self.registers[5],
+        );
     }
 }


### PR DESCRIPTION
Convenience helper so that the program runtime does not have to deal with encrypting the vm pointer.