### PR TITLE
Fix - JIT randomized start padding length

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -28,6 +28,7 @@ use crate::{
 const MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH: usize = 4096;
 const MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION: usize = 110;
 const MACHINE_CODE_PER_INSTRUCTION_METER_CHECKPOINT: usize = 13;
+const MAX_START_PADDING_LENGTH: usize = 256;
 
 pub struct JitProgram {
     /// OS page size in bytes and the alignment of the sections
@@ -340,7 +341,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             }
         }
 
-        let mut code_length_estimate = MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION * pc;
+        let mut code_length_estimate = MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH + MAX_START_PADDING_LENGTH + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION * pc;
         if config.noop_instruction_rate != 0 {
             code_length_estimate += code_length_estimate / config.noop_instruction_rate as usize;
         }
@@ -377,7 +378,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
 
         // Randomized padding at the start before random intervals begin
         if self.config.noop_instruction_rate != 0 {
-            for _ in 0..self.diversification_rng.gen_range(0..self.config.noop_instruction_rate) {
+            for _ in 0..self.diversification_rng.gen_range(0..MAX_START_PADDING_LENGTH) {
                 // X86Instruction::noop().emit(self)?;
                 self.emit::<u8>(0x90);
             }

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -180,7 +180,9 @@ impl<'a> Analysis<'a> {
         }
         let mut result = Self {
             // Removes the generic ContextObject which is safe because we are not going to execute the program
-            executable: unsafe { std::mem::transmute(executable) },
+            executable: unsafe {
+                std::mem::transmute::<&Executable<C>, &Executable<TestContextObject>>(executable)
+            },
             instructions,
             functions,
             cfg_nodes: BTreeMap::new(),


### PR DESCRIPTION
Currently the randomized start padding can get ridiculously long if `noop_instruction_rate` is configured ridiculously high. Instead, it should just be a small constant for a maximum length.