### PR TITLE
BuiltinProgram::new_mock: use max_call_depth=64

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -246,7 +246,10 @@ impl<C: ContextObject> BuiltinProgram<C> {
     /// Constructs a mock loader built-in program
     pub fn new_mock() -> Self {
         Self {
-            config: Some(Box::default()),
+            config: Some(Box::new(Config {
+                max_call_depth: 64,
+                ..Config::default()
+            })),
             functions: FunctionRegistry::default(),
         }
     }


### PR DESCRIPTION
I'm adding code to bpf_loader in the validator that asserts that max_call_depth is the same value as `solana_program_runtime::compute_budget::MAX_CALL_DEPTH`. This change is needed so that the tests that use BuiltinProgram::new_mock() in the validator don't trigger the assert.