### PR TITLE
Fix - Verify imm not offset in CALL_IMM

### DIFF
--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -78,7 +78,7 @@ fuzz_target!(|data: FuzzData| {
     #[allow(unused)]
     let (_interp_ins_count, interp_res) = interp_vm.execute_program(&executable, true);
 
-    #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     if executable.jit_compile().is_ok() {
         let mut jit_mem = data.mem;
         let mut jit_context_object = TestContextObject::new(1 << 16);

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -68,7 +68,7 @@ fuzz_target!(|data: FuzzData| {
     #[allow(unused)]
     let (_interp_ins_count, interp_res) = interp_vm.execute_program(&executable, true);
 
-    #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
     if executable.jit_compile().is_ok() {
         let mut jit_mem = data.mem;
         let mut jit_context_object = TestContextObject::new(1 << 16);
@@ -85,8 +85,8 @@ fuzz_target!(|data: FuzzData| {
         let (_jit_ins_count, jit_res) = jit_vm.execute_program(&executable, false);
         if format!("{:?}", interp_res) != format!("{:?}", jit_res) {
             // spot check: there's a meaningless bug where ExceededMaxInstructions is different due to jump calculations
-            if interp_res_str.contains("ExceededMaxInstructions")
-                && jit_res_str.contains("ExceededMaxInstructions")
+            if format!("{:?}", interp_res).contains("ExceededMaxInstructions")
+                && format!("{:?}", jit_res).contains("ExceededMaxInstructions")
             {
                 return;
             }


### PR DESCRIPTION
Only relevant if `sbpf_version.static_syscalls()` is enabled.