### PR TITLE
use only required goblin features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = { version = "1.0", optional = true, features = ["derive"] }
 byteorder = "1.2"
 combine = "3.8.1"
 gdbstub = { version = "0.6.2", optional = true }
-goblin = "0.5.1"
+goblin = { version = "0.5.1", default-features = false, features = ["elf32", "elf64", "endian_fd", "std"] }
 hash32 = "0.2.0"
 log = "0.4.2"
 rand = { version = "0.8.5", features = ["small_rng"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = { version = "1.0", optional = true, features = ["derive"] }
 byteorder = "1.2"
 combine = "3.8.1"
 gdbstub = { version = "0.6.2", optional = true }
-goblin = { version = "0.5.1", default-features = false, features = ["elf32", "elf64", "endian_fd", "std"] }
+goblin = { version = "0.5.1", default-features = false, features = ["elf32", "elf64", "endian_fd"] }
 hash32 = "0.2.0"
 log = "0.4.2"
 rand = { version = "0.8.5", features = ["small_rng"]}

--- a/src/elf_parser_glue.rs
+++ b/src/elf_parser_glue.rs
@@ -550,7 +550,6 @@ impl From<GoblinError> for ElfError {
             GoblinError::Malformed(string) => Self::FailedToParse(format!("malformed: {string}")),
             GoblinError::BadMagic(magic) => Self::FailedToParse(format!("bad magic: {magic:#x}")),
             GoblinError::Scroll(error) => Self::FailedToParse(format!("read-write: {error}")),
-            GoblinError::IO(error) => Self::FailedToParse(format!("io: {error}")),
             GoblinError::BufferTooShort(n, error) => {
                 Self::FailedToParse(format!("buffer too short {n} {error}"))
             }


### PR DESCRIPTION
By default goblin includes features that this crate doesn't use. Removing them cuts down compile time by 13% on my machine