### PR TITLE
Check if syscall is valid during verification

### DIFF
--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     ebpf,
     elf::Executable,
     memory_region::MemoryRegion,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -29,7 +29,9 @@ fuzz_target!(|data: DumbFuzzData| {
     let prog = data.prog;
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
-    if RequisiteVerifier::verify(&prog, &config, &SBPFVersion::V2, &function_registry).is_err() {
+    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+
+    if RequisiteVerifier::verify(&prog, &config, &SBPFVersion::V2, &function_registry, &syscall_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -10,7 +10,7 @@ use solana_rbpf::{
     elf::Executable,
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -33,11 +33,14 @@ fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog, data.arch);
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
+    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+
     if RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
         &SBPFVersion::V2,
         &function_registry,
+        &syscall_registry,
     )
     .is_err()
     {

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     elf::Executable,
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -40,11 +40,14 @@ fuzz_target!(|data: FuzzData| {
         .push();
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
+    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+
     if RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
         &SBPFVersion::V2,
         &function_registry,
+        &syscall_registry,
     )
     .is_err()
     {

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     elf::Executable,
     insn_builder::IntoBytes,
     memory_region::MemoryRegion,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -30,11 +30,14 @@ fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
+    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+
     if RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
         &SBPFVersion::V2,
         &function_registry,
+        &syscall_registry,
     )
     .is_err()
     {

--- a/fuzz/fuzz_targets/verify_semantic_aware.rs
+++ b/fuzz/fuzz_targets/verify_semantic_aware.rs
@@ -5,8 +5,9 @@ use libfuzzer_sys::fuzz_target;
 use semantic_aware::*;
 use solana_rbpf::{
     insn_builder::IntoBytes,
-    program::{FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, FunctionRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
+    vm::TestContextObject,
 };
 
 use crate::common::ConfigTemplate;
@@ -24,11 +25,14 @@ fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
+    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+
     RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
         &SBPFVersion::V2,
         &function_registry,
+        &syscall_registry,
     )
     .unwrap();
 });

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -315,6 +315,7 @@ impl<C: ContextObject> Executable<C> {
             self.get_config(),
             self.get_sbpf_version(),
             self.get_function_registry(),
+            self.loader.get_function_registry(),
         )?;
         Ok(())
     }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -2692,11 +2692,6 @@ fn test_err_instruction_count_syscall_capped() {
 
 #[test]
 fn test_non_terminate_early() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-
     test_interpreter_and_jit_asm!(
         "
         mov64 r6, 0x0
@@ -2705,15 +2700,14 @@ fn test_non_terminate_early() {
         mov64 r3, 0x0
         mov64 r4, 0x0
         mov64 r5, r6
-        syscall Unresolved
+        callx r6
         add64 r6, 0x1
         ja -0x8
         exit",
-        config.clone(),
         [],
         (),
         TestContextObject::new(7),
-        ProgramResult::Err(EbpfError::UnsupportedInstruction),
+        ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
 }
 
@@ -2776,21 +2770,15 @@ fn test_err_capped_before_exception() {
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
 
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, 0x0
         mov64 r2, 0x0
         add64 r0, 0x0
         add64 r0, 0x0
-        syscall Unresolved
+        callx r2
         add64 r0, 0x0
         exit",
-        config.clone(),
         [],
         (),
         TestContextObject::new(4),


### PR DESCRIPTION
Upon the activation of static syscalls, we'll no longer emit errors when a program contains an unknown syscall. This PR modifies the verifier so that we error out when this is the case.