### PR TITLE
Fix - JIT instruction meter in `ExecutionOverrun`

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -731,8 +731,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         // Bumper in case there was no final exit
         if self.offset_in_text_section + MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION * 2 >= self.result.text_section.len() {
             return Err(EbpfError::ExhaustedTextSegment(self.pc));
-        }        
-        self.emit_validate_and_profile_instruction_count(true, false, Some(self.pc + 2));
+        }
+        self.emit_validate_and_profile_instruction_count(true, false, Some(self.pc + 1));
+        self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, REGISTER_SCRATCH, self.pc as i64)); // Save pc
         self.emit_set_exception_kind(EbpfError::ExecutionOverrun);
         self.emit_ins(X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_THROW_EXCEPTION, 5)));
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3454,11 +3454,46 @@ fn test_err_fixed_stack_out_of_bound() {
 }
 
 #[test]
+fn test_execution_overrun() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
+    test_interpreter_and_jit_asm!(
+        "
+        add r1, 0",
+        config.clone(),
+        [],
+        (),
+        TestContextObject::new(2),
+        ProgramResult::Err(EbpfError::ExecutionOverrun),
+    );
+    test_interpreter_and_jit_asm!(
+        "
+        add r1, 0",
+        config.clone(),
+        [],
+        (),
+        TestContextObject::new(1),
+        ProgramResult::Err(EbpfError::ExceededMaxInstructions),
+    );
+}
+
+#[test]
 fn test_lddw() {
     let config = Config {
         enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
         ..Config::default()
     };
+    test_interpreter_and_jit_asm!(
+        "
+        lddw r0, 0x1122334455667788",
+        config.clone(),
+        [],
+        (),
+        TestContextObject::new(2),
+        ProgramResult::Err(EbpfError::ExecutionOverrun),
+    );
     test_interpreter_and_jit_asm!(
         "
         lddw r0, 0x1122334455667788


### PR DESCRIPTION
Thanks to @ravyu-jump, @ripatel-fd and @topointon-jump for finding this.