### PR TITLE
Derive copy for SBPFVersion

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -47,7 +47,7 @@ enum InstructionType {
     NoOperand,
 }
 
-fn make_instruction_map(sbpf_version: &SBPFVersion) -> HashMap<String, (InstructionType, u8)> {
+fn make_instruction_map(sbpf_version: SBPFVersion) -> HashMap<String, (InstructionType, u8)> {
     let mut result = HashMap::new();
 
     let alu_binary_ops = [
@@ -313,10 +313,10 @@ pub fn assemble<C: ContextObject>(
     src: &str,
     loader: Arc<BuiltinProgram<C>>,
 ) -> Result<Executable<C>, String> {
-    let sbpf_version = loader.get_config().enabled_sbpf_versions.end().clone();
+    let sbpf_version = *loader.get_config().enabled_sbpf_versions.end();
 
     let statements = parse(src)?;
-    let instruction_map = make_instruction_map(&sbpf_version);
+    let instruction_map = make_instruction_map(sbpf_version);
     let mut insn_ptr = 0;
     let mut function_registry = FunctionRegistry::default();
     let mut labels = HashMap::new();

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1736,7 +1736,7 @@ mod tests {
     }
 
     fn create_mockup_executable(config: Config, program: &[u8]) -> Executable<TestContextObject> {
-        let sbpf_version = config.enabled_sbpf_versions.end().clone();
+        let sbpf_version = *config.enabled_sbpf_versions.end();
         let mut function_registry =
             FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
         function_registry
@@ -1769,7 +1769,7 @@ mod tests {
             let empty_program_machine_code_length = {
                 let config = Config {
                     noop_instruction_rate: 0,
-                    enabled_sbpf_versions: sbpf_version.clone()..=sbpf_version.clone(),
+                    enabled_sbpf_versions: sbpf_version..=sbpf_version,
                     ..Config::default()
                 };
                 let mut executable = create_mockup_executable(config, &prog[0..0]);
@@ -1780,7 +1780,7 @@ mod tests {
                     .machine_code_length()
             };
             assert!(empty_program_machine_code_length <= MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH);
-            empty_program_machine_code_length_per_version[sbpf_version.clone() as usize] =
+            empty_program_machine_code_length_per_version[sbpf_version as usize] =
                 empty_program_machine_code_length;
         }
 
@@ -1814,7 +1814,7 @@ mod tests {
 
         for sbpf_version in [SBPFVersion::V1, SBPFVersion::V2] {
             let empty_program_machine_code_length =
-                empty_program_machine_code_length_per_version[sbpf_version.clone() as usize];
+                empty_program_machine_code_length_per_version[sbpf_version as usize];
 
             for mut opcode in 0x00..=0xFF {
                 let (registers, immediate) = match opcode {
@@ -1841,7 +1841,7 @@ mod tests {
                 }
                 let config = Config {
                     noop_instruction_rate: 0,
-                    enabled_sbpf_versions: sbpf_version.clone()..=sbpf_version.clone(),
+                    enabled_sbpf_versions: sbpf_version..=sbpf_version,
                     ..Config::default()
                 };
                 let mut executable = create_mockup_executable(config, &prog);

--- a/src/program.rs
+++ b/src/program.rs
@@ -9,7 +9,7 @@ use {
 };
 
 /// Defines a set of sbpf_version of an executable
-#[derive(Debug, PartialEq, PartialOrd, Eq, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Clone, Copy)]
 pub enum SBPFVersion {
     /// The legacy format
     V1,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -919,7 +919,7 @@ fn test_err_divide_overflow() {
 fn test_memory_instructions() {
     for sbpf_version in [SBPFVersion::V1, SBPFVersion::V2] {
         let config = Config {
-            enabled_sbpf_versions: sbpf_version.clone()..=sbpf_version,
+            enabled_sbpf_versions: sbpf_version..=sbpf_version,
             ..Config::default()
         };
 

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -409,7 +409,7 @@ fn test_sdiv_disabled() {
                 &assembly,
                 Arc::new(BuiltinProgram::new_loader(
                     Config {
-                        enabled_sbpf_versions: SBPFVersion::V1..=highest_sbpf_version.clone(),
+                        enabled_sbpf_versions: SBPFVersion::V1..=highest_sbpf_version,
                         ..Config::default()
                     },
                     FunctionRegistry::default(),


### PR DESCRIPTION
`enum SBPF` is represented by an integer, so we can derive `Copy` for it and avoid unnecessary clones.