### PR TITLE
Process `return` instruction in verifier, interpreter and jitter

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -567,6 +567,11 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
             }
             ebpf::RETURN
             | ebpf::EXIT       => {
+                if (insn.opc == ebpf::EXIT && self.executable.get_sbpf_version().static_syscalls())
+                    || (insn.opc == ebpf::RETURN && !self.executable.get_sbpf_version().static_syscalls()) {
+                    throw_error!(self, EbpfError::UnsupportedInstruction);
+                }
+
                 if self.vm.call_depth == 0 {
                     if config.enable_instruction_meter && self.vm.due_insn_count > self.vm.previous_instruction_meter {
                         throw_error!(self, EbpfError::ExceededMaxInstructions);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -747,6 +747,10 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 },
                 ebpf::RETURN
                 | ebpf::EXIT      => {
+                    if (insn.opc == ebpf::EXIT && self.executable.get_sbpf_version().static_syscalls())
+                        || (insn.opc == ebpf::RETURN && !self.executable.get_sbpf_version().static_syscalls()) {
+                        return Err(EbpfError::UnsupportedInstruction);
+                    }
                     self.emit_validate_instruction_count(true, Some(self.pc));
 
                     let call_depth_access = X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::CallDepth));

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -390,8 +390,8 @@ impl Verifier for RequisiteVerifier {
                 ebpf::CALL_IMM   if sbpf_version.static_syscalls() && insn.src == 0 => { check_call_target(insn.imm as u32, syscall_registry)?; },
                 ebpf::CALL_IMM   => {},
                 ebpf::CALL_REG   => { check_callx_register(&insn, insn_ptr, sbpf_version)?; },
-                ebpf::EXIT       => {},
-                ebpf::RETURN     => {},
+                ebpf::EXIT       if !sbpf_version.static_syscalls()   => {},
+                ebpf::RETURN     if sbpf_version.static_syscalls()    => {},
 
                 _                => {
                     return Err(VerifierError::UnknownOpCode(insn.opc, insn_ptr));


### PR DESCRIPTION
This PR depends on #609 and implements `return` in the verifier, interpreter and jitter.