### PR TITLE
Add new `syscall` instruction to the verifier

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -10,6 +10,7 @@ extern crate solana_rbpf;
 extern crate test;
 extern crate test_utils;
 
+use solana_rbpf::program::SyscallRegistry;
 use solana_rbpf::{
     elf::Executable,
     program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
@@ -27,6 +28,7 @@ fn loader() -> Arc<BuiltinProgram<TestContextObject>> {
     Arc::new(BuiltinProgram::new_loader(
         Config::default(),
         function_registry,
+        SyscallRegistry::default(),
     ))
 }
 

--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -10,10 +10,9 @@ extern crate solana_rbpf;
 extern crate test;
 extern crate test_utils;
 
-use solana_rbpf::program::SyscallRegistry;
 use solana_rbpf::{
     elf::Executable,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SyscallRegistry},
     syscalls,
     vm::{Config, TestContextObject},
 };

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -13,7 +13,7 @@ extern crate test;
 use solana_rbpf::{
     ebpf,
     memory_region::MemoryRegion,
-    program::{FunctionRegistry, SBPFVersion},
+    program::{FunctionRegistry, SBPFVersion, SyscallRegistry},
     vm::Config,
 };
 use solana_rbpf::{
@@ -88,6 +88,7 @@ fn bench_jit_vs_interpreter(
         Arc::new(BuiltinProgram::new_loader(
             config,
             FunctionRegistry::default(),
+            SyscallRegistry::default(),
         )),
     )
     .unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use solana_rbpf::{
     ebpf,
     elf::Executable,
     memory_region::{MemoryMapping, MemoryRegion},
-    program::{BuiltinProgram, FunctionRegistry},
+    program::{BuiltinProgram, FunctionRegistry, SyscallRegistry},
     static_analysis::Analysis,
     verifier::RequisiteVerifier,
     vm::{Config, DynamicAnalysis, EbpfVm, TestContextObject},
@@ -101,6 +101,7 @@ fn main() {
             ..Config::default()
         },
         FunctionRegistry::default(),
+        SyscallRegistry::default(),
     ));
     #[allow(unused_mut)]
     let mut executable = match matches.value_of("assembler") {

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     ebpf,
     elf::Executable,
     memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SyscallRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -29,7 +29,7 @@ fuzz_target!(|data: DumbFuzzData| {
     let prog = data.prog;
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
-    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+    let syscall_registry = SyscallRegistry::<BuiltinFunction<TestContextObject>>::default();
 
     if RequisiteVerifier::verify(&prog, &config, &SBPFVersion::V2, &function_registry, &syscall_registry).is_err() {
         // verify please
@@ -41,6 +41,7 @@ fuzz_target!(|data: DumbFuzzData| {
         std::sync::Arc::new(BuiltinProgram::new_loader(
             config,
             FunctionRegistry::default(),
+            syscall_registry,
         )),
         SBPFVersion::V2,
         function_registry,

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -10,7 +10,7 @@ use solana_rbpf::{
     elf::Executable,
     insn_builder::{Arch, IntoBytes},
     memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SyscallRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -33,7 +33,7 @@ fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog, data.arch);
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
-    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+    let syscall_registry = SyscallRegistry::<BuiltinFunction<TestContextObject>>::default();
 
     if RequisiteVerifier::verify(
         prog.into_bytes(),
@@ -53,6 +53,7 @@ fuzz_target!(|data: FuzzData| {
         std::sync::Arc::new(BuiltinProgram::new_loader(
             config,
             FunctionRegistry::default(),
+            syscall_registry,
         )),
         SBPFVersion::V2,
         function_registry,

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     elf::Executable,
     insn_builder::{Arch, Instruction, IntoBytes},
     memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SyscallRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -40,7 +40,7 @@ fuzz_target!(|data: FuzzData| {
         .push();
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
-    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+    let syscall_registry = SyscallRegistry::<BuiltinFunction<TestContextObject>>::default();
 
     if RequisiteVerifier::verify(
         prog.into_bytes(),
@@ -61,6 +61,7 @@ fuzz_target!(|data: FuzzData| {
         std::sync::Arc::new(BuiltinProgram::new_loader(
             config,
             FunctionRegistry::default(),
+            syscall_registry,
         )),
         SBPFVersion::V2,
         function_registry,

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -8,7 +8,7 @@ use solana_rbpf::{
     elf::Executable,
     insn_builder::IntoBytes,
     memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SyscallRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -30,7 +30,7 @@ fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
-    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+    let syscall_registry = SyscallRegistry::<BuiltinFunction<TestContextObject>>::default();
 
     if RequisiteVerifier::verify(
         prog.into_bytes(),
@@ -51,6 +51,7 @@ fuzz_target!(|data: FuzzData| {
         std::sync::Arc::new(BuiltinProgram::new_loader(
             config,
             FunctionRegistry::default(),
+            syscall_registry,
         )),
         SBPFVersion::V2,
         function_registry,

--- a/fuzz/fuzz_targets/verify_semantic_aware.rs
+++ b/fuzz/fuzz_targets/verify_semantic_aware.rs
@@ -5,7 +5,7 @@ use libfuzzer_sys::fuzz_target;
 use semantic_aware::*;
 use solana_rbpf::{
     insn_builder::IntoBytes,
-    program::{BuiltinFunction, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, FunctionRegistry, SyscallRegistry, SBPFVersion},
     verifier::{RequisiteVerifier, Verifier},
     vm::TestContextObject,
 };
@@ -25,7 +25,7 @@ fuzz_target!(|data: FuzzData| {
     let prog = make_program(&data.prog);
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
-    let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
+    let syscall_registry = SyscallRegistry::<BuiltinFunction<TestContextObject>>::default();
 
     RequisiteVerifier::verify(
         prog.into_bytes(),

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1164,7 +1164,6 @@ mod test {
     use rand::{distributions::Uniform, Rng};
     use std::{fs::File, io::Read};
     use test_utils::assert_error;
-
     type ElfExecutable = Executable<TestContextObject>;
 
     fn loader() -> Arc<BuiltinProgram<TestContextObject>> {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1147,6 +1147,7 @@ pub(crate) fn get_ro_region(ro_section: &Section, elf: &[u8]) -> MemoryRegion {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::program::SyscallRegistry;
     use crate::{
         elf_parser::{
             // FIXME consts::{ELFCLASS32, ELFDATA2MSB, ET_REL},
@@ -1163,6 +1164,7 @@ mod test {
     use rand::{distributions::Uniform, Rng};
     use std::{fs::File, io::Read};
     use test_utils::assert_error;
+
     type ElfExecutable = Executable<TestContextObject>;
 
     fn loader() -> Arc<BuiltinProgram<TestContextObject>> {
@@ -1177,6 +1179,7 @@ mod test {
         Arc::new(BuiltinProgram::new_loader(
             Config::default(),
             function_registry,
+            SyscallRegistry::default(),
         ))
     }
 
@@ -1932,6 +1935,7 @@ mod test {
                 ..Config::default()
             },
             FunctionRegistry::default(),
+            SyscallRegistry::default(),
         );
         let elf_bytes = std::fs::read("tests/elfs/syscall_reloc_64_32_sbpfv1.so")
             .expect("failed to read elf file");

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -107,6 +107,9 @@ pub enum ElfError {
     /// Invalid program header
     #[error("Invalid ELF program header")]
     InvalidProgramHeader,
+    /// Invalid syscall code
+    #[error("Invalid syscall code")]
+    InvalidSyscallCode,
 }
 
 impl From<ElfParserError> for ElfError {
@@ -315,7 +318,7 @@ impl<C: ContextObject> Executable<C> {
             self.get_config(),
             self.get_sbpf_version(),
             self.get_function_registry(),
-            self.loader.get_function_registry(),
+            self.loader.get_syscall_registry(),
         )?;
         Ok(())
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1696,7 +1696,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
 mod tests {
     use super::*;
     use crate::{
-        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+        program::{
+            BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion, SyscallRegistry,
+        },
         syscalls,
         vm::TestContextObject,
     };
@@ -1748,7 +1750,8 @@ mod tests {
         function_registry
             .register_function_hashed(*b"gather_bytes", syscalls::SyscallGatherBytes::vm)
             .unwrap();
-        let loader = BuiltinProgram::new_loader(config, function_registry);
+        let syscall_registry = SyscallRegistry::default();
+        let loader = BuiltinProgram::new_loader(config, function_registry, syscall_registry);
         let mut function_registry = FunctionRegistry::default();
         function_registry
             .register_function(8, *b"function_foo", 8)

--- a/src/program.rs
+++ b/src/program.rs
@@ -216,7 +216,7 @@ impl<T: Copy + PartialEq> FunctionRegistry<T> {
     }
 }
 
-/// A syscall registry to operate with static syscalls represented by integers.
+/// A registry to operate with static syscalls represented by integers.
 #[derive(PartialEq, Eq)]
 pub struct SyscallRegistry<T> {
     look_up: Vec<(Vec<u8>, T)>,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -12,13 +12,13 @@
 
 //! Verifies that the bytecode is valid for the given config.
 
+use crate::program::SyscallRegistry;
 use crate::{
     ebpf,
     program::{BuiltinFunction, FunctionRegistry, SBPFVersion},
     vm::{Config, ContextObject},
 };
 use thiserror::Error;
-use crate::program::SyscallRegistry;
 
 /// Error definitions
 #[derive(Debug, Error, Eq, PartialEq)]
@@ -214,12 +214,11 @@ fn check_callx_register(
 fn check_syscall<C: ContextObject>(
     code: usize,
     pc: usize,
-    registry: &SyscallRegistry<BuiltinFunction<C>>
+    registry: &SyscallRegistry<BuiltinFunction<C>>,
 ) -> Result<(), VerifierError> {
-    registry.lookup_syscall(code).map_or(
-        Err(VerifierError::InvalidFunction(pc)),
-        |_| Ok(())
-    )
+    registry
+        .lookup_syscall(code)
+        .map_or(Err(VerifierError::InvalidFunction(pc)), |_| Ok(()))
 }
 
 /// Mandatory verifier for solana programs to run on-chain

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -12,10 +12,9 @@
 
 //! Verifies that the bytecode is valid for the given config.
 
-use crate::program::SyscallRegistry;
 use crate::{
     ebpf,
-    program::{BuiltinFunction, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, FunctionRegistry, SBPFVersion, SyscallRegistry},
     vm::{Config, ContextObject},
 };
 use thiserror::Error;

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -8,7 +8,7 @@
 extern crate solana_rbpf;
 extern crate test_utils;
 
-use solana_rbpf::program::{FunctionRegistry, SBPFVersion};
+use solana_rbpf::program::{FunctionRegistry, SBPFVersion, SyscallRegistry};
 use solana_rbpf::vm::Config;
 use solana_rbpf::{assembler::assemble, ebpf, program::BuiltinProgram, vm::TestContextObject};
 use std::sync::Arc;
@@ -19,7 +19,11 @@ fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
 }
 
 fn asm_with_config(src: &str, config: Config) -> Result<Vec<ebpf::Insn>, String> {
-    let loader = BuiltinProgram::new_loader(config, FunctionRegistry::default());
+    let loader = BuiltinProgram::new_loader(
+        config,
+        FunctionRegistry::default(),
+        SyscallRegistry::default(),
+    );
     let executable = assemble::<TestContextObject>(src, Arc::new(loader))?;
     let (_program_vm_addr, program) = executable.get_text_bytes();
     Ok((0..program.len() / ebpf::INSN_SIZE)
@@ -527,6 +531,7 @@ fn test_tcp_sack() {
         Arc::new(BuiltinProgram::new_loader(
             config,
             FunctionRegistry::default(),
+            SyscallRegistry::default(),
         )),
     )
     .unwrap();

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -7,7 +7,7 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate solana_rbpf;
-use solana_rbpf::program::SBPFVersion;
+use solana_rbpf::program::{SBPFVersion, SyscallRegistry};
 use solana_rbpf::{
     assembler::assemble,
     program::{BuiltinProgram, FunctionRegistry},
@@ -27,7 +27,11 @@ macro_rules! disasm {
     }};
     ($src:expr, $config:expr) => {{
         let src = $src;
-        let loader = BuiltinProgram::new_loader($config, FunctionRegistry::default());
+        let loader = BuiltinProgram::new_loader(
+            $config,
+            FunctionRegistry::default(),
+            SyscallRegistry::default(),
+        );
         let executable = assemble::<TestContextObject>(src, Arc::new(loader)).unwrap();
         let analysis = Analysis::from_executable(&executable).unwrap();
         let mut reasm = Vec::new();

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3454,6 +3454,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
                 ..Config::default()
             },
             FunctionRegistry::default(),
+            SyscallRegistry::default(),
         )),
         SBPFVersion::V2,
         FunctionRegistry::default(),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -15,14 +15,13 @@ extern crate thiserror;
 use byteorder::{ByteOrder, LittleEndian};
 #[cfg(all(not(windows), target_arch = "x86_64"))]
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
-use solana_rbpf::program::SyscallRegistry;
 use solana_rbpf::{
     assembler::assemble,
     declare_builtin_function, ebpf,
     elf::Executable,
     error::{EbpfError, ProgramResult},
     memory_region::{AccessType, MemoryMapping, MemoryRegion},
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion, SyscallRegistry},
     static_analysis::Analysis,
     syscalls,
     verifier::RequisiteVerifier,

--- a/tests/exercise_instructions.rs
+++ b/tests/exercise_instructions.rs
@@ -17,7 +17,7 @@ use solana_rbpf::{
     assembler::assemble,
     ebpf,
     memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion, SyscallRegistry},
     static_analysis::Analysis,
     verifier::RequisiteVerifier,
     vm::{Config, ContextObject, TestContextObject},
@@ -124,7 +124,7 @@ macro_rules! test_interpreter_and_jit_asm {
             config.enable_instruction_tracing = true;
             let mut function_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
             $(test_interpreter_and_jit!(register, function_registry, $location => $syscall_function);)*
-            let loader = Arc::new(BuiltinProgram::new_loader(config, function_registry));
+            let loader = Arc::new(BuiltinProgram::new_loader(config, function_registry, SyscallRegistry::default()));
             let mut executable = assemble($source, loader).unwrap();
             test_interpreter_and_jit!(executable, $mem, $context_object);
         }

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -22,6 +22,7 @@
 extern crate solana_rbpf;
 extern crate thiserror;
 
+use solana_rbpf::program::SyscallRegistry;
 use solana_rbpf::{
     assembler::assemble,
     ebpf,
@@ -34,7 +35,6 @@ use solana_rbpf::{
 use std::sync::Arc;
 use test_utils::{assert_error, create_vm};
 use thiserror::Error;
-use solana_rbpf::program::SyscallRegistry;
 
 /// Error definitions
 #[derive(Debug, Error)]
@@ -329,9 +329,8 @@ fn test_verifier_known_syscall() {
         0x95, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // syscall 1
         0x9d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // return
     ];
-    let syscalls : Vec<(Vec<u8>, BuiltinFunction<TestContextObject>)> = vec![
-        (b"my_syscall".to_vec(), syscalls::SyscallString::vm)
-    ];
+    let syscalls: Vec<(Vec<u8>, BuiltinFunction<TestContextObject>)> =
+        vec![(b"my_syscall".to_vec(), syscalls::SyscallString::vm)];
     let syscall_registry = SyscallRegistry::<BuiltinFunction<TestContextObject>>::new(syscalls);
 
     let executable = Executable::<TestContextObject>::from_text_bytes(


### PR DESCRIPTION
This PR adds the new syscall instruction to the verifier. It also introduces a data structure to hold syscall registration. 

The idea is that Agave will have a data structure to properly organize registrations and then pass the vector directly to rBPF `SyscallRegistry::new()`. I deemed that this part did not belong in there.

Modifications to the jitter, interpreter and a tidier organization to the execution tests will come in follow up PRs.