### PR TITLE
Refactor - Make `declare_builtin_function` receive a generic ContextObject

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -296,8 +296,8 @@ impl<C: ContextObject> std::fmt::Debug for BuiltinProgram<C> {
 /// Generates an adapter for a BuiltinFunction between the Rust and the VM interface
 #[macro_export]
 macro_rules! declare_builtin_function {
-    ($(#[$attr:meta])* $name:ident $(<$($generic_ident:tt : $generic_type:tt),+>)?, fn rust(
-        $vm:ident : &mut $ContextObject:ty,
+    ($(#[$attr:meta])* $name:ident $(<$($generic_ident:tt : $generic_type:tt),+>)?, fn rust<$generic_ctx:tt>(
+        $vm:ident : &mut $generic_ctx_arg:tt,
         $arg_a:ident : u64,
         $arg_b:ident : u64,
         $arg_c:ident : u64,
@@ -309,8 +309,8 @@ macro_rules! declare_builtin_function {
         pub struct $name {}
         impl $name {
             /// Rust interface
-            pub fn rust $(<$($generic_ident : $generic_type),+>)? (
-                $vm: &mut $ContextObject,
+            pub fn rust<$generic_ctx: $crate::vm::ContextObject, $($($generic_ident : $generic_type),+)?> (
+                $vm: &mut $generic_ctx,
                 $arg_a: u64,
                 $arg_b: u64,
                 $arg_c: u64,
@@ -322,17 +322,16 @@ macro_rules! declare_builtin_function {
             }
             /// VM interface
             #[allow(clippy::too_many_arguments)]
-            pub fn vm $(<$($generic_ident : $generic_type),+>)? (
-                $vm: *mut $crate::vm::EbpfVm<$ContextObject>,
+            pub fn vm<$generic_ctx: $crate::vm::ContextObject, $($($generic_ident : $generic_type),+)?> (
+                $vm: *mut $crate::vm::EbpfVm<$generic_ctx>,
                 $arg_a: u64,
                 $arg_b: u64,
                 $arg_c: u64,
                 $arg_d: u64,
                 $arg_e: u64,
             ) {
-                use $crate::vm::ContextObject;
                 let vm = unsafe {
-                    &mut *($vm.cast::<u64>().offset(-($crate::vm::get_runtime_environment_key() as isize)).cast::<$crate::vm::EbpfVm<$ContextObject>>())
+                    &mut *($vm.cast::<u64>().offset(-($crate::vm::get_runtime_environment_key() as isize)).cast::<$crate::vm::EbpfVm<$generic_ctx>>())
                 };
                 let config = vm.loader.get_config();
                 if config.enable_instruction_meter {

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -25,7 +25,6 @@ use crate::{
     declare_builtin_function,
     error::EbpfError,
     memory_region::{AccessType, MemoryMapping},
-    vm::TestContextObject,
 };
 use std::{slice::from_raw_parts, str::from_utf8};
 
@@ -33,8 +32,8 @@ declare_builtin_function!(
     /// Prints its **last three** arguments to standard output. The **first two** arguments are
     /// **unused**. Returns the number of bytes written.
     SyscallTracePrintf,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         _arg1: u64,
         _arg2: u64,
         arg3: u64,
@@ -61,8 +60,8 @@ declare_builtin_function!(
     /// The idea is to assemble five bytes into a single `u64`. For compatibility with the syscalls API,
     /// each argument must be a `u64`.
     SyscallGatherBytes,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         arg1: u64,
         arg2: u64,
         arg3: u64,
@@ -85,8 +84,8 @@ declare_builtin_function!(
     /// The memory is directly modified, and the syscall returns 0 in all
     /// cases. Arguments 3 to 5 are unused.
     SyscallMemFrob,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         vm_addr: u64,
         len: u64,
         _arg3: u64,
@@ -110,8 +109,8 @@ declare_builtin_function!(
 declare_builtin_function!(
     /// C-like `strcmp`, return 0 if the strings are equal, and a non-null value otherwise.
     SyscallStrCmp,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         arg1: u64,
         arg2: u64,
         _arg3: u64,
@@ -148,8 +147,8 @@ declare_builtin_function!(
 declare_builtin_function!(
     /// Prints a NULL-terminated UTF-8 string.
     SyscallString,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         vm_addr: u64,
         len: u64,
         _arg3: u64,
@@ -173,8 +172,8 @@ declare_builtin_function!(
 declare_builtin_function!(
     /// Prints the five arguments formated as u64 in decimal.
     SyscallU64,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         arg1: u64,
         arg2: u64,
         arg3: u64,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -2658,8 +2658,8 @@ fn test_call_memfrob() {
 declare_builtin_function!(
     /// For test_nested_vm_syscall()
     SyscallNestedVm,
-    fn rust(
-        _context_object: &mut TestContextObject,
+    fn rust<T>(
+        _context_object: &mut T,
         depth: u64,
         throw: u64,
         _arg3: u64,


### PR DESCRIPTION
The macro `declare_builtin_function` unnecessarily requires a coded type that implements the trait `ContextObject`. Alternatively, we can modify the macro to accept a generic type that implements the trait.

The idea behind this change is to use the macro for creating a tombstone function for static syscalls when they are deactivated behind a feature gate. Having the generic type allows the tombstone to work with Agave's `InvokeContext` type.