### PR TITLE
Add new `syscall` instruction to interpreter and jitter

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -271,7 +271,7 @@ pub fn disassemble_instruction<C: ContextObject>(
                 function_name
             } else {
                 name = "syscall";
-                loader.get_function_registry().lookup_by_key(insn.imm as u32).map(|(function_name, _)| String::from_utf8_lossy(function_name).to_string()).unwrap_or_else(|| "[invalid]".to_string())
+                loader.get_sparse_function_registry().lookup_by_key(insn.imm as u32).map(|(function_name, _)| String::from_utf8_lossy(function_name).to_string()).unwrap_or_else(|| "[invalid]".to_string())
             };
             desc = format!("{name} {function_name}");
         },

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -315,7 +315,7 @@ impl<C: ContextObject> Executable<C> {
             self.get_config(),
             self.get_sbpf_version(),
             self.get_function_registry(),
-            self.loader.get_sparse_function_registry(),
+            self.loader.get_dense_function_registry(),
         )?;
         Ok(())
     }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -315,7 +315,7 @@ impl<C: ContextObject> Executable<C> {
             self.get_config(),
             self.get_sbpf_version(),
             self.get_function_registry(),
-            self.loader.get_function_registry(),
+            self.loader.get_sparse_function_registry(),
         )?;
         Ok(())
     }
@@ -1071,7 +1071,10 @@ impl<C: ContextObject> Executable<C> {
                             .entry(symbol.st_name)
                             .or_insert_with(|| ebpf::hash_symbol_name(name));
                         if config.reject_broken_elfs
-                            && loader.get_function_registry().lookup_by_key(hash).is_none()
+                            && loader
+                                .get_sparse_function_registry()
+                                .lookup_by_key(hash)
+                                .is_none()
                         {
                             return Err(ElfError::UnresolvedSymbol(
                                 String::from_utf8_lossy(name).to_string(),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -12,11 +12,11 @@
 
 //! Interpreter for eBPF programs.
 
-use crate::program::BuiltinFunction;
 use crate::{
     ebpf::{self, STACK_PTR_REG},
     elf::Executable,
     error::{EbpfError, ProgramResult},
+    program::BuiltinFunction,
     vm::{Config, ContextObject, EbpfVm},
 };
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -536,7 +536,7 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                 };
 
                 if external {
-                    if let Some((_function_name, function)) = self.executable.get_loader().get_function_registry().lookup_by_key(insn.imm as u32) {
+                    if let Some((_function_name, function)) = self.executable.get_loader().get_sparse_function_registry().lookup_by_key(insn.imm as u32) {
                         resolved = true;
 
                         self.vm.due_insn_count = self.vm.previous_instruction_meter - self.vm.due_insn_count;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -12,6 +12,7 @@
 
 //! Interpreter for eBPF programs.
 
+use crate::program::BuiltinFunction;
 use crate::{
     ebpf::{self, STACK_PTR_REG},
     elf::Executable,
@@ -526,46 +527,34 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
 
             // Do not delegate the check to the verifier, since self.registered functions can be
             // changed after the program has been verified.
-            ebpf::CALL_IMM
-            | ebpf::SYSCALL if insn.opc == ebpf::CALL_IMM || self.executable.get_sbpf_version().static_syscalls() => {
-                let mut resolved = false;
-                let (external, internal) = if self.executable.get_sbpf_version().static_syscalls() {
-                    (insn.src == 0, insn.src != 0)
+            ebpf::CALL_IMM => {
+                if let Some((_, function)) = self.executable.get_loader().get_sparse_function_registry().lookup_by_key(insn.imm as u32) {
+                    // SBPFv1 syscall
+                    self.reg[0] = match self.dispatch_syscall(function) {
+                        ProgramResult::Ok(value) => *value,
+                        ProgramResult::Err(_err) => return false,
+                    };
+                } else if let Some((_, target_pc)) = self.executable.get_function_registry().lookup_by_key(insn.imm as u32) {
+                    // make BPF to BPF call
+                    if !self.push_frame(config) {
+                        return false;
+                    }
+                    check_pc!(self, next_pc, target_pc as u64);
                 } else {
-                    (true, true)
-                };
-
-                if external {
-                    if let Some((_function_name, function)) = self.executable.get_loader().get_sparse_function_registry().lookup_by_key(insn.imm as u32) {
-                        resolved = true;
-
-                        self.vm.due_insn_count = self.vm.previous_instruction_meter - self.vm.due_insn_count;
-                        self.vm.registers[0..6].copy_from_slice(&self.reg[0..6]);
-                        self.vm.invoke_function(function);
-                        self.vm.due_insn_count = 0;
-                        self.reg[0] = match &self.vm.program_result {
-                            ProgramResult::Ok(value) => *value,
-                            ProgramResult::Err(_err) => return false,
-                        };
-                    }
-                }
-
-                if internal && !resolved {
-                    if let Some((_function_name, target_pc)) = self.executable.get_function_registry().lookup_by_key(insn.imm as u32) {
-                        resolved = true;
-
-                        // make BPF to BPF call
-                        if !self.push_frame(config) {
-                            return false;
-                        }
-                        check_pc!(self, next_pc, target_pc as u64);
-                    }
-                }
-
-                if !resolved {
                     throw_error!(self, EbpfError::UnsupportedInstruction);
                 }
             }
+            ebpf::SYSCALL if self.executable.get_sbpf_version().static_syscalls() => {
+                if let Some((_, function)) = self.executable.get_loader().get_dense_function_registry().lookup_by_key(insn.imm as u32) {
+                    // SBPFv2 syscall
+                    self.reg[0] = match self.dispatch_syscall(function) {
+                        ProgramResult::Ok(value) => *value,
+                        ProgramResult::Err(_err) => return false,
+                    };
+                } else {
+                    throw_error!(self, EbpfError::UnsupportedInstruction);
+                }
+            },
             ebpf::RETURN
             | ebpf::EXIT       => {
                 if (insn.opc == ebpf::EXIT && self.executable.get_sbpf_version().static_syscalls())
@@ -599,5 +588,13 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
 
         self.reg[11] = next_pc;
         true
+    }
+
+    fn dispatch_syscall(&mut self, function: BuiltinFunction<C>) -> &ProgramResult {
+        self.vm.due_insn_count = self.vm.previous_instruction_meter - self.vm.due_insn_count;
+        self.vm.registers[0..6].copy_from_slice(&self.reg[0..6]);
+        self.vm.invoke_function(function);
+        self.vm.due_insn_count = 0;
+        &self.vm.program_result
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -23,7 +23,6 @@ use rand::{
 };
 use std::{fmt::Debug, mem, ptr};
 
-use crate::program::BuiltinFunction;
 use crate::{
     ebpf::{self, FIRST_SCRATCH_REG, FRAME_PTR_REG, INSN_SIZE, SCRATCH_REGS, STACK_PTR_REG},
     elf::Executable,
@@ -32,6 +31,7 @@ use crate::{
         allocate_pages, free_pages, get_system_page_size, protect_pages, round_to_page_size,
     },
     memory_region::{AccessType, MemoryMapping},
+    program::BuiltinFunction,
     vm::{get_runtime_environment_key, Config, ContextObject, EbpfVm},
     x86::*,
 };

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -717,7 +717,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     };
 
                     if external {
-                        if let Some((_function_name, function)) = self.executable.get_loader().get_function_registry().lookup_by_key(insn.imm as u32) {
+                        if let Some((_function_name, function)) = self.executable.get_loader().get_sparse_function_registry().lookup_by_key(insn.imm as u32) {
                             self.emit_validate_and_profile_instruction_count(false, Some(0));
                             self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, REGISTER_SCRATCH, function as usize as i64));
                             self.emit_ins(X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_EXTERNAL_FUNCTION_CALL, 5)));

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -23,6 +23,7 @@ use rand::{
 };
 use std::{fmt::Debug, mem, ptr};
 
+use crate::program::BuiltinFunction;
 use crate::{
     ebpf::{self, FIRST_SCRATCH_REG, FRAME_PTR_REG, INSN_SIZE, SCRATCH_REGS, STACK_PTR_REG},
     elf::Executable,
@@ -705,37 +706,23 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 ebpf::JSLT_REG   => self.emit_conditional_branch_reg(0x8c, false, src, dst, target_pc),
                 ebpf::JSLE_IMM   => self.emit_conditional_branch_imm(0x8e, false, insn.imm, dst, target_pc),
                 ebpf::JSLE_REG   => self.emit_conditional_branch_reg(0x8e, false, src, dst, target_pc),
-                ebpf::CALL_IMM | ebpf::SYSCALL
-                if insn.opc == ebpf::CALL_IMM || self.executable.get_sbpf_version().static_syscalls() => {
+                ebpf::CALL_IMM => {
                     // For JIT, external functions MUST be registered at compile time.
-
-                    let mut resolved = false;
-                    let (external, internal) = if self.executable.get_sbpf_version().static_syscalls() {
-                        (insn.src == 0, insn.src != 0)
+                    if let Some((_, function)) = self.executable.get_loader().get_sparse_function_registry().lookup_by_key(insn.imm as u32) {
+                        // SBPFv1 syscall
+                        self.emit_syscall_dispatch(function);
+                    } else if let Some((_function_name, target_pc)) = self.executable.get_function_registry().lookup_by_key(insn.imm as u32) {
+                        // BPF to BPF call
+                        self.emit_internal_call(Value::Constant64(target_pc as i64, true));
                     } else {
-                        (true, true)
-                    };
-
-                    if external {
-                        if let Some((_function_name, function)) = self.executable.get_loader().get_sparse_function_registry().lookup_by_key(insn.imm as u32) {
-                            self.emit_validate_and_profile_instruction_count(false, Some(0));
-                            self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, REGISTER_SCRATCH, function as usize as i64));
-                            self.emit_ins(X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_EXTERNAL_FUNCTION_CALL, 5)));
-                            self.emit_undo_profile_instruction_count(0);
-                            resolved = true;
-                        }
+                        self.emit_throw_unsupported_instruction();
                     }
-
-                    if internal {
-                        if let Some((_function_name, target_pc)) = self.executable.get_function_registry().lookup_by_key(insn.imm as u32) {
-                            self.emit_internal_call(Value::Constant64(target_pc as i64, true));
-                            resolved = true;
-                        }
-                    }
-
-                    if !resolved {
-                        self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, REGISTER_SCRATCH, self.pc as i64));
-                        self.emit_ins(X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 5)));
+                },
+                ebpf::SYSCALL if self.executable.get_sbpf_version().static_syscalls() => {
+                    if let Some((_, function)) = self.executable.get_loader().get_dense_function_registry().lookup_by_key(insn.imm as u32) {
+                        self.emit_syscall_dispatch(function);
+                    } else {
+                        self.emit_throw_unsupported_instruction();
                     }
                 },
                 ebpf::CALL_REG  => {
@@ -1133,6 +1120,20 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         for reg in REGISTER_MAP.iter().skip(FIRST_SCRATCH_REG).take(SCRATCH_REGS).rev() {
             self.emit_ins(X86Instruction::pop(*reg));
         }
+    }
+
+    #[inline]
+    fn emit_syscall_dispatch(&mut self, function: BuiltinFunction<C>) {
+        self.emit_validate_and_profile_instruction_count(false, Some(0));
+        self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, REGISTER_SCRATCH, function as usize as i64));
+        self.emit_ins(X86Instruction::call_immediate(self.relative_to_anchor(ANCHOR_EXTERNAL_FUNCTION_CALL, 5)));
+        self.emit_undo_profile_instruction_count(0);
+    }
+
+    #[inline]
+    fn emit_throw_unsupported_instruction(&mut self) {
+        self.emit_ins(X86Instruction::load_immediate(OperandSize::S64, REGISTER_SCRATCH, self.pc as i64));
+        self.emit_ins(X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_CALL_UNSUPPORTED_INSTRUCTION, 5)));
     }
 
     #[inline]

--- a/src/program.rs
+++ b/src/program.rs
@@ -274,8 +274,8 @@ impl<C: ContextObject> BuiltinProgram<C> {
         }
     }
 
-    /// Create a new loader with both dense and sparse function registrations
-    /// Use `BuiltinProgram::register_function` to register.
+    /// Create a new loader with both dense and sparse function indexation
+    /// Use `BuiltinProgram::register_function` for registrations.
     pub fn new_loader_with_dense_registration(config: Config) -> Self {
         Self {
             config: Some(Box::new(config)),

--- a/src/program.rs
+++ b/src/program.rs
@@ -153,7 +153,11 @@ impl<T: Copy + PartialEq> FunctionRegistry<T> {
             } else {
                 ebpf::hash_symbol_name(&usize::from(value).to_le_bytes())
             };
-            if loader.get_function_registry().lookup_by_key(hash).is_some() {
+            if loader
+                .get_sparse_function_registry()
+                .lookup_by_key(hash)
+                .is_some()
+            {
                 return Err(ElfError::SymbolHashCollision(hash));
             }
             hash
@@ -228,13 +232,17 @@ pub type BuiltinFunction<C> = fn(*mut EbpfVm<C>, u64, u64, u64, u64, u64);
 pub struct BuiltinProgram<C: ContextObject> {
     /// Holds the Config if this is a loader program
     config: Option<Box<Config>>,
-    /// Function pointers by symbol
-    functions: FunctionRegistry<BuiltinFunction<C>>,
+    /// Function pointers by symbol with sparse indexing
+    sparse_registry: FunctionRegistry<BuiltinFunction<C>>,
+    /// Function pointers by symbol with dense indexing
+    dense_registry: FunctionRegistry<BuiltinFunction<C>>,
 }
 
 impl<C: ContextObject> PartialEq for BuiltinProgram<C> {
     fn eq(&self, other: &Self) -> bool {
-        self.config.eq(&other.config) && self.functions.eq(&other.functions)
+        self.config.eq(&other.config)
+            && self.sparse_registry.eq(&other.sparse_registry)
+            && self.dense_registry.eq(&other.dense_registry)
     }
 }
 
@@ -243,7 +251,8 @@ impl<C: ContextObject> BuiltinProgram<C> {
     pub fn new_loader(config: Config, functions: FunctionRegistry<BuiltinFunction<C>>) -> Self {
         Self {
             config: Some(Box::new(config)),
-            functions,
+            sparse_registry: functions,
+            dense_registry: FunctionRegistry::default(),
         }
     }
 
@@ -251,7 +260,8 @@ impl<C: ContextObject> BuiltinProgram<C> {
     pub fn new_builtin(functions: FunctionRegistry<BuiltinFunction<C>>) -> Self {
         Self {
             config: None,
-            functions,
+            sparse_registry: functions,
+            dense_registry: FunctionRegistry::default(),
         }
     }
 
@@ -259,7 +269,18 @@ impl<C: ContextObject> BuiltinProgram<C> {
     pub fn new_mock() -> Self {
         Self {
             config: Some(Box::default()),
-            functions: FunctionRegistry::default(),
+            sparse_registry: FunctionRegistry::default(),
+            dense_registry: FunctionRegistry::default(),
+        }
+    }
+
+    /// Create a new loader with both dense and sparse function registrations
+    /// Use `BuiltinProgram::register_function` to register.
+    pub fn new_loader_with_dense_registration(config: Config) -> Self {
+        Self {
+            config: Some(Box::new(config)),
+            sparse_registry: FunctionRegistry::default(),
+            dense_registry: FunctionRegistry::default(),
         }
     }
 
@@ -269,8 +290,8 @@ impl<C: ContextObject> BuiltinProgram<C> {
     }
 
     /// Get the function registry
-    pub fn get_function_registry(&self) -> &FunctionRegistry<BuiltinFunction<C>> {
-        &self.functions
+    pub fn get_sparse_function_registry(&self) -> &FunctionRegistry<BuiltinFunction<C>> {
+        &self.sparse_registry
     }
 
     /// Calculate memory size
@@ -281,18 +302,40 @@ impl<C: ContextObject> BuiltinProgram<C> {
             } else {
                 0
             })
-            .saturating_add(self.functions.mem_size())
+            .saturating_add(self.sparse_registry.mem_size())
+            .saturating_add(self.dense_registry.mem_size())
+    }
+
+    /// Register a function both in the sparse and dense registries
+    pub fn register_function(
+        &mut self,
+        name: &str,
+        value: BuiltinFunction<C>,
+        dense_key: u32,
+    ) -> Result<(), ElfError> {
+        self.sparse_registry.register_function_hashed(name, value)?;
+        self.dense_registry
+            .register_function(dense_key, name, value)
     }
 }
 
 impl<C: ContextObject> std::fmt::Debug for BuiltinProgram<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        writeln!(f, "{:?}", unsafe {
-            // `derive(Debug)` does not know that `C: ContextObject` does not need to implement `Debug`
-            std::mem::transmute::<&FunctionRegistry<BuiltinFunction<C>>, &FunctionRegistry<usize>>(
-                &self.functions,
-            )
-        })?;
+        unsafe {
+            writeln!(
+                f,
+                "sparse: {:?}\n dense: {:?}",
+                // `derive(Debug)` does not know that `C: ContextObject` does not need to implement `Debug`
+                std::mem::transmute::<
+                    &FunctionRegistry<BuiltinFunction<C>>,
+                    &FunctionRegistry<usize>,
+                >(&self.sparse_registry,),
+                std::mem::transmute::<
+                    &FunctionRegistry<BuiltinFunction<C>>,
+                    &FunctionRegistry<usize>,
+                >(&self.dense_registry,)
+            )?;
+        }
         Ok(())
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -289,9 +289,14 @@ impl<C: ContextObject> BuiltinProgram<C> {
         self.config.as_ref().unwrap()
     }
 
-    /// Get the function registry
+    /// Get the sparse function registry
     pub fn get_sparse_function_registry(&self) -> &FunctionRegistry<BuiltinFunction<C>> {
         &self.sparse_registry
+    }
+
+    /// Get the dense function registry
+    pub fn get_dense_function_registry(&self) -> &FunctionRegistry<BuiltinFunction<C>> {
+        &self.dense_registry
     }
 
     /// Calculate memory size

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -236,7 +236,7 @@ impl<'a> Analysis<'a> {
                     if let Some((function_name, _function)) = self
                         .executable
                         .get_loader()
-                        .get_function_registry()
+                        .get_sparse_function_registry()
                         .lookup_by_key(insn.imm as u32)
                     {
                         if function_name == b"abort" {

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -1999,6 +1999,10 @@ fn test_stack1() {
 
 #[test]
 fn test_stack2() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         stb [r10-4], 0x01
@@ -2017,6 +2021,7 @@ fn test_stack2() {
         syscall bpf_gather_bytes
         xor r0, 0x2a2a2a2a
         exit",
+        config,
         [],
         (
             "bpf_mem_frob" => syscalls::SyscallMemFrob::vm,
@@ -2029,6 +2034,10 @@ fn test_stack2() {
 
 #[test]
 fn test_string_stack() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov r1, 0x78636261
@@ -2059,6 +2068,7 @@ fn test_string_stack() {
         jeq r1, r6, +1
         mov r0, 0x0
         exit",
+        config,
         [],
         (
             "bpf_str_cmp" => syscalls::SyscallStrCmp::vm,
@@ -2367,6 +2377,10 @@ fn test_bpf_to_bpf_scratch_registers() {
 
 #[test]
 fn test_syscall_parameter_on_stack() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, r10
@@ -2375,6 +2389,7 @@ fn test_syscall_parameter_on_stack() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
+        config,
         [],
         (
             "bpf_syscall_string" => syscalls::SyscallString::vm,
@@ -2559,12 +2574,17 @@ fn test_call_save() {
 
 #[test]
 fn test_err_syscall_string() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, 0x0
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
+        config,
         [72, 101, 108, 108, 111],
         (
             "bpf_syscall_string" => syscalls::SyscallString::vm,
@@ -2576,12 +2596,17 @@ fn test_err_syscall_string() {
 
 #[test]
 fn test_syscall_string() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r2, 0x5
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
+        config,
         [72, 101, 108, 108, 111],
         (
             "bpf_syscall_string" => syscalls::SyscallString::vm,
@@ -2593,6 +2618,10 @@ fn test_syscall_string() {
 
 #[test]
 fn test_syscall() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, 0xAA
@@ -2603,6 +2632,7 @@ fn test_syscall() {
         syscall bpf_syscall_u64
         mov64 r0, 0x0
         exit",
+        config,
         [],
         (
             "bpf_syscall_u64" => syscalls::SyscallU64::vm,
@@ -2614,6 +2644,10 @@ fn test_syscall() {
 
 #[test]
 fn test_call_gather_bytes() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov r1, 1
@@ -2623,6 +2657,7 @@ fn test_call_gather_bytes() {
         mov r5, 5
         syscall bpf_gather_bytes
         exit",
+        config,
         [],
         (
             "bpf_gather_bytes" => syscalls::SyscallGatherBytes::vm,
@@ -2634,6 +2669,10 @@ fn test_call_gather_bytes() {
 
 #[test]
 fn test_call_memfrob() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov r6, r1
@@ -2643,6 +2682,7 @@ fn test_call_memfrob() {
         ldxdw r0, [r6]
         be64 r0
         exit",
+        config,
         [
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
         ],
@@ -2684,7 +2724,11 @@ declare_builtin_function!(
             function_registry
                 .register_function_hashed(*b"nested_vm_syscall", SyscallNestedVm::vm)
                 .unwrap();
-            let loader = BuiltinProgram::new_loader(Config::default(), function_registry);
+            let config = Config {
+                enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+                ..Config::default()
+            };
+            let loader = BuiltinProgram::new_loader(config, function_registry);
             let mem = [depth as u8 - 1, throw as u8];
             let mut executable = assemble::<TestContextObject>(
                 "
@@ -2780,12 +2824,17 @@ fn test_tight_infinite_recursion_callx() {
 
 #[test]
 fn test_instruction_count_syscall() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r2, 0x5
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
+        config,
         [72, 101, 108, 108, 111],
         (
             "bpf_syscall_string" => syscalls::SyscallString::vm,
@@ -2797,12 +2846,17 @@ fn test_instruction_count_syscall() {
 
 #[test]
 fn test_err_instruction_count_syscall_capped() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r2, 0x5
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
+        config,
         [72, 101, 108, 108, 111],
         (
             "bpf_syscall_string" => syscalls::SyscallString::vm,
@@ -2814,6 +2868,10 @@ fn test_err_instruction_count_syscall_capped() {
 
 #[test]
 fn test_err_non_terminate_capped() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r6, 0x0
@@ -2826,6 +2884,7 @@ fn test_err_non_terminate_capped() {
         add64 r6, 0x1
         ja -0x8
         exit",
+        config.clone(),
         [],
         (
             "bpf_trace_printf" => syscalls::SyscallTracePrintf::vm,
@@ -2845,6 +2904,7 @@ fn test_err_non_terminate_capped() {
         add64 r6, 0x1
         ja -0x8
         exit",
+        config,
         [],
         (
             "bpf_trace_printf" => syscalls::SyscallTracePrintf::vm,
@@ -2952,6 +3012,10 @@ fn test_far_jumps() {
 
 #[test]
 fn test_symbol_relocation() {
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
+        ..Config::default()
+    };
     test_interpreter_and_jit_asm!(
         "
         mov64 r1, r10
@@ -2960,6 +3024,7 @@ fn test_symbol_relocation() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
+        config,
         [72, 101, 108, 108, 111],
         (
             "bpf_syscall_string" => syscalls::SyscallString::vm,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -163,6 +163,31 @@ macro_rules! test_interpreter_and_jit_asm {
     };
 }
 
+macro_rules! test_syscall_asm {
+    (register, $loader:expr, $syscall_number:literal => $syscall_name:expr => $syscall_function:expr) => {
+        let _ = $loader.register_function($syscall_name, $syscall_function, $syscall_number).unwrap();
+    };
+
+    ($source:tt, $mem:tt, ($($syscall_number:literal => $syscall_name:expr => $syscall_function:expr),*$(,)?), $context_object:expr, $expected_result:expr $(,)?) => {
+        let mut config = Config {
+            enable_instruction_tracing: true,
+            ..Config::default()
+        };
+        for sbpf_version in [SBPFVersion::V1, SBPFVersion::V2] {
+            config.enabled_sbpf_versions = sbpf_version..=sbpf_version;
+            let src = if sbpf_version == SBPFVersion::V1 {
+                format!($source, $($syscall_name, )*)
+            } else {
+                format!($source, $($syscall_number, )*)
+            };
+            let mut loader = BuiltinProgram::new_loader_with_dense_registration(config.clone());
+            $(test_syscall_asm!(register, loader, $syscall_number => $syscall_name => $syscall_function);)*
+            let mut executable = assemble(src.as_str(), Arc::new(loader)).unwrap();
+            test_interpreter_and_jit!(executable, $mem, $context_object, $expected_result);
+        }
+    };
+}
+
 macro_rules! test_interpreter_and_jit_elf {
     ($verify:literal, $source:tt, $config:tt, $mem:tt, ($($location:expr => $syscall_function:expr),* $(,)?), $context_object:expr, $expected_result:expr $(,)?) => {
         let mut file = File::open($source).unwrap();
@@ -1999,12 +2024,8 @@ fn test_stack1() {
 
 #[test]
 fn test_stack2() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
-        "
+    test_syscall_asm!(
+         "
         stb [r10-4], 0x01
         stb [r10-3], 0x02
         stb [r10-2], 0x03
@@ -2012,20 +2033,19 @@ fn test_stack2() {
         mov r1, r10
         mov r2, 0x4
         sub r1, r2
-        syscall bpf_mem_frob
+        syscall {}
         mov r1, 0
         ldxb r2, [r10-4]
         ldxb r3, [r10-3]
         ldxb r4, [r10-2]
         ldxb r5, [r10-1]
-        syscall bpf_gather_bytes
+        syscall {}
         xor r0, 0x2a2a2a2a
         exit",
-        config,
         [],
         (
-            "bpf_mem_frob" => syscalls::SyscallMemFrob::vm,
-            "bpf_gather_bytes" => syscalls::SyscallGatherBytes::vm,
+               1 => "bpf_mem_frob" => syscalls::SyscallMemFrob::vm,
+               2 => "bpf_gather_bytes" => syscalls::SyscallGatherBytes::vm,
         ),
         TestContextObject::new(16),
         ProgramResult::Ok(0x01020304),
@@ -2034,11 +2054,7 @@ fn test_stack2() {
 
 #[test]
 fn test_string_stack() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov r1, 0x78636261
         stxw [r10-8], r1
@@ -2050,7 +2066,7 @@ fn test_string_stack() {
         mov r1, r10
         add r1, -8
         mov r2, r1
-        syscall bpf_str_cmp
+        syscall {}
         mov r1, r0
         mov r0, 0x1
         lsh r1, 0x20
@@ -2060,7 +2076,7 @@ fn test_string_stack() {
         add r1, -8
         mov r2, r10
         add r2, -16
-        syscall bpf_str_cmp
+        syscall {}
         mov r1, r0
         lsh r1, 0x20
         rsh r1, 0x20
@@ -2068,10 +2084,10 @@ fn test_string_stack() {
         jeq r1, r6, +1
         mov r0, 0x0
         exit",
-        config,
         [],
         (
-            "bpf_str_cmp" => syscalls::SyscallStrCmp::vm,
+            3 => "bpf_str_cmp" => syscalls::SyscallStrCmp::vm,
+            3 => "bpf_str_cmp" => syscalls::SyscallStrCmp::vm,
         ),
         TestContextObject::new(28),
         ProgramResult::Ok(0x0),
@@ -2377,22 +2393,17 @@ fn test_bpf_to_bpf_scratch_registers() {
 
 #[test]
 fn test_syscall_parameter_on_stack() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r1, r10
         add64 r1, -0x100
         mov64 r2, 0x1
-        syscall bpf_syscall_string
+        syscall {}
         mov64 r0, 0x0
         exit",
-        config,
         [],
         (
-            "bpf_syscall_string" => syscalls::SyscallString::vm,
+            1 => "bpf_syscall_string" => syscalls::SyscallString::vm,
         ),
         TestContextObject::new(6),
         ProgramResult::Ok(0),
@@ -2574,20 +2585,15 @@ fn test_call_save() {
 
 #[test]
 fn test_err_syscall_string() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r1, 0x0
-        syscall bpf_syscall_string
+        syscall {}
         mov64 r0, 0x0
         exit",
-        config,
         [72, 101, 108, 108, 111],
         (
-            "bpf_syscall_string" => syscalls::SyscallString::vm,
+            2 => "bpf_syscall_string" => syscalls::SyscallString::vm,
         ),
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::SyscallError(Box::new(EbpfError::AccessViolation(AccessType::Load, 0, 0, "unknown")))),
@@ -2596,20 +2602,15 @@ fn test_err_syscall_string() {
 
 #[test]
 fn test_syscall_string() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r2, 0x5
-        syscall bpf_syscall_string
+        syscall {}
         mov64 r0, 0x0
         exit",
-        config,
         [72, 101, 108, 108, 111],
         (
-            "bpf_syscall_string" => syscalls::SyscallString::vm,
+            1 => "bpf_syscall_string" => syscalls::SyscallString::vm,
         ),
         TestContextObject::new(4),
         ProgramResult::Ok(0),
@@ -2618,24 +2619,19 @@ fn test_syscall_string() {
 
 #[test]
 fn test_syscall() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r1, 0xAA
         mov64 r2, 0xBB
         mov64 r3, 0xCC
         mov64 r4, 0xDD
         mov64 r5, 0xEE
-        syscall bpf_syscall_u64
+        syscall {}
         mov64 r0, 0x0
         exit",
-        config,
         [],
         (
-            "bpf_syscall_u64" => syscalls::SyscallU64::vm,
+            3 => "bpf_syscall_u64" => syscalls::SyscallU64::vm,
         ),
         TestContextObject::new(8),
         ProgramResult::Ok(0),
@@ -2644,23 +2640,18 @@ fn test_syscall() {
 
 #[test]
 fn test_call_gather_bytes() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov r1, 1
         mov r2, 2
         mov r3, 3
         mov r4, 4
         mov r5, 5
-        syscall bpf_gather_bytes
+        syscall {}
         exit",
-        config,
         [],
         (
-            "bpf_gather_bytes" => syscalls::SyscallGatherBytes::vm,
+            1 => "bpf_gather_bytes" => syscalls::SyscallGatherBytes::vm,
         ),
         TestContextObject::new(7),
         ProgramResult::Ok(0x0102030405),
@@ -2669,25 +2660,20 @@ fn test_call_gather_bytes() {
 
 #[test]
 fn test_call_memfrob() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov r6, r1
         add r1, 2
         mov r2, 4
-        syscall bpf_mem_frob
+        syscall {}
         ldxdw r0, [r6]
         be64 r0
         exit",
-        config,
         [
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
         ],
         (
-            "bpf_mem_frob" => syscalls::SyscallMemFrob::vm,
+            2 => "bpf_mem_frob" => syscalls::SyscallMemFrob::vm,
         ),
         TestContextObject::new(7),
         ProgramResult::Ok(0x102292e2f2c0708),
@@ -2701,7 +2687,7 @@ declare_builtin_function!(
         _context_object: &mut TestContextObject,
         depth: u64,
         throw: u64,
-        _arg3: u64,
+        version: u64,
         _arg4: u64,
         _arg5: u64,
         _memory_mapping: &mut MemoryMapping,
@@ -2719,23 +2705,27 @@ declare_builtin_function!(
             };
         #[allow(unused_mut)]
         if depth > 0 {
-            let mut function_registry =
-                FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
-            function_registry
-                .register_function_hashed(*b"nested_vm_syscall", SyscallNestedVm::vm)
-                .unwrap();
-            let config = Config {
-                enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-                ..Config::default()
+            let mut config = Config::default();
+            let syscall_name = if version == 1 {
+                config.enabled_sbpf_versions = SBPFVersion::V1..=SBPFVersion::V1;
+                "nested_vm_syscall"
+            } else {
+                config.enabled_sbpf_versions = SBPFVersion::V2..=SBPFVersion::V2;
+                "1"
             };
-            let loader = BuiltinProgram::new_loader(config, function_registry);
-            let mem = [depth as u8 - 1, throw as u8];
-            let mut executable = assemble::<TestContextObject>(
+            let mut loader = BuiltinProgram::new_loader_with_dense_registration(config);
+            loader.register_function("nested_vm_syscall", SyscallNestedVm::vm, 1).unwrap();
+            let source_code = format!(
                 "
                 ldxb r2, [r1+1]
                 ldxb r1, [r1]
-                syscall nested_vm_syscall
+                syscall {}
                 exit",
+                syscall_name
+            );
+            let mem = [depth as u8 - 1, throw as u8];
+            let mut executable = assemble::<TestContextObject>(
+                source_code.as_str(),
                 Arc::new(loader),
             )
             .unwrap();
@@ -2755,9 +2745,17 @@ fn test_nested_vm_syscall() {
     let config = Config::default();
     let mut context_object = TestContextObject::default();
     let mut memory_mapping = MemoryMapping::new(vec![], &config, &SBPFVersion::V2).unwrap();
-    let result = SyscallNestedVm::rust(&mut context_object, 1, 0, 0, 0, 0, &mut memory_mapping);
-    assert!(result.unwrap() == 42);
-    let result = SyscallNestedVm::rust(&mut context_object, 1, 1, 0, 0, 0, &mut memory_mapping);
+
+    // SBPFv1
+    let result = SyscallNestedVm::rust(&mut context_object, 1, 0, 1, 0, 0, &mut memory_mapping);
+    assert_eq!(result.unwrap(), 42);
+    let result = SyscallNestedVm::rust(&mut context_object, 1, 1, 1, 0, 0, &mut memory_mapping);
+    assert_error!(result, "CallDepthExceeded");
+
+    // SBPFv2
+    let result = SyscallNestedVm::rust(&mut context_object, 1, 0, 2, 0, 0, &mut memory_mapping);
+    assert_eq!(result.unwrap(), 42);
+    let result = SyscallNestedVm::rust(&mut context_object, 1, 1, 2, 0, 0, &mut memory_mapping);
     assert_error!(result, "CallDepthExceeded");
 }
 
@@ -2824,20 +2822,15 @@ fn test_tight_infinite_recursion_callx() {
 
 #[test]
 fn test_instruction_count_syscall() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r2, 0x5
-        syscall bpf_syscall_string
+        syscall {}
         mov64 r0, 0x0
         exit",
-        config,
         [72, 101, 108, 108, 111],
         (
-            "bpf_syscall_string" => syscalls::SyscallString::vm,
+            1 => "bpf_syscall_string" => syscalls::SyscallString::vm,
         ),
         TestContextObject::new(4),
         ProgramResult::Ok(0),
@@ -2846,20 +2839,15 @@ fn test_instruction_count_syscall() {
 
 #[test]
 fn test_err_instruction_count_syscall_capped() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r2, 0x5
-        syscall bpf_syscall_string
+        syscall {}
         mov64 r0, 0x0
         exit",
-        config,
         [72, 101, 108, 108, 111],
         (
-            "bpf_syscall_string" => syscalls::SyscallString::vm,
+            1 => "bpf_syscall_string" => syscalls::SyscallString::vm,
         ),
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
@@ -2868,11 +2856,7 @@ fn test_err_instruction_count_syscall_capped() {
 
 #[test]
 fn test_err_non_terminate_capped() {
-    let config = Config {
-        enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
-        ..Config::default()
-    };
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r6, 0x0
         mov64 r1, 0x0
@@ -2880,19 +2864,18 @@ fn test_err_non_terminate_capped() {
         mov64 r3, 0x0
         mov64 r4, 0x0
         mov64 r5, r6
-        syscall bpf_trace_printf
+        syscall {}
         add64 r6, 0x1
         ja -0x8
         exit",
-        config.clone(),
         [],
         (
-            "bpf_trace_printf" => syscalls::SyscallTracePrintf::vm,
+            1 => "bpf_trace_printf" => syscalls::SyscallTracePrintf::vm,
         ),
         TestContextObject::new(7),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
-    test_interpreter_and_jit_asm!(
+    test_syscall_asm!(
         "
         mov64 r6, 0x0
         mov64 r1, 0x0
@@ -2900,14 +2883,13 @@ fn test_err_non_terminate_capped() {
         mov64 r3, 0x0
         mov64 r4, 0x0
         mov64 r5, r6
-        syscall bpf_trace_printf
+        syscall {}
         add64 r6, 0x1
         ja -0x8
         exit",
-        config,
         [],
         (
-            "bpf_trace_printf" => syscalls::SyscallTracePrintf::vm,
+            2 => "bpf_trace_printf" => syscalls::SyscallTracePrintf::vm,
         ),
         TestContextObject::new(1000),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
@@ -3013,6 +2995,7 @@ fn test_far_jumps() {
 #[test]
 fn test_symbol_relocation() {
     let config = Config {
+        // No relocations are necessary in SBFPv2
         enabled_sbpf_versions: SBPFVersion::V1..=SBPFVersion::V1,
         ..Config::default()
     };

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -4132,3 +4132,35 @@ fn test_invalid_exit_or_return() {
         );
     }
 }
+
+#[test]
+fn test_unregistered_syscall() {
+    let prog = &[
+        0xbf, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, // mov64 r0, 2
+        0x95, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, // syscall 2
+        0x9d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, // return
+    ];
+
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V2..=SBPFVersion::V2,
+        enable_instruction_tracing: true,
+        ..Config::default()
+    };
+
+    let loader = Arc::new(BuiltinProgram::new_loader_with_dense_registration(config));
+    let mut executable = Executable::<TestContextObject>::from_text_bytes(
+        prog,
+        loader,
+        SBPFVersion::V2,
+        FunctionRegistry::default(),
+    )
+    .unwrap();
+
+    test_interpreter_and_jit!(
+        false,
+        executable,
+        [],
+        TestContextObject::new(2),
+        ProgramResult::Err(EbpfError::UnsupportedInstruction),
+    );
+}

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -367,19 +367,17 @@ fn test_verifier_unknown_sycall() {
 #[test]
 fn test_verifier_known_syscall() {
     let prog = &[
-        0x85, 0x00, 0x00, 0x00, 0xfe, 0xc3, 0xf5, 0x6b, // call 0x6bf5c3fe
+        0x95, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, // syscall 2
         0x9d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // return
     ];
-    let mut function_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
-    function_registry
-        .register_function(0x6bf5c3fe, b"my_syscall", syscalls::SyscallString::vm)
+
+    let mut loader = BuiltinProgram::new_loader_with_dense_registration(Config::default());
+    loader
+        .register_function("my_syscall", syscalls::SyscallString::vm, 2)
         .unwrap();
     let executable = Executable::<TestContextObject>::from_text_bytes(
         prog,
-        Arc::new(BuiltinProgram::new_loader(
-            Config::default(),
-            function_registry,
-        )),
+        Arc::new(loader),
         SBPFVersion::V2,
         FunctionRegistry::default(),
     )
@@ -489,7 +487,7 @@ fn return_instr() {
         .unwrap();
         let result = executable.verify::<RequisiteVerifier>();
         if sbpf_version == SBPFVersion::V2 {
-            assert!(result.is_ok());
+            assert_error!(result, "VerifierError(InvalidSyscall(0))");
         } else {
             assert_error!(result, "VerifierError(UnknownOpCode(157, 2))");
         }


### PR DESCRIPTION
This PR builds on top of #620 and introduces the new syscall instruction to the interpreter and jitter. It revamps the execution tests to deal with two syscall models and write extra tests for the changed code fragments.