### PR TITLE
Do not pass `SBPFVersion` by reference

### DIFF
--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -73,7 +73,7 @@ macro_rules! bench_gapped_randomized_access_with_1024_entries {
                     )];
                     let config = Config::default();
                     let memory_mapping =
-                        $mem::new(memory_regions, &config, &SBPFVersion::V2).unwrap();
+                        $mem::new(memory_regions, &config, SBPFVersion::V2).unwrap();
                     let mut prng = new_prng!();
                     bencher.iter(|| {
                         assert!(memory_mapping
@@ -111,7 +111,7 @@ macro_rules! bench_randomized_access_with_0001_entry {
             let content = vec![0; 1024 * 2];
             let memory_regions = vec![MemoryRegion::new_readonly(&content[..], 0x100000000)];
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, &SBPFVersion::V2).unwrap();
+            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V2).unwrap();
             let mut prng = new_prng!();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
@@ -145,7 +145,7 @@ macro_rules! bench_randomized_access_with_n_entries {
             let (memory_regions, end_address) =
                 generate_memory_regions($n, MemoryState::Readable, Some(&mut prng));
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, &SBPFVersion::V2).unwrap();
+            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V2).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
                     AccessType::Load,
@@ -194,7 +194,7 @@ macro_rules! bench_randomized_mapping_with_n_entries {
             let (memory_regions, _end_address) =
                 generate_memory_regions($n, MemoryState::Readable, Some(&mut prng));
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, &SBPFVersion::V2).unwrap();
+            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V2).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);
             });
@@ -243,7 +243,7 @@ macro_rules! bench_mapping_with_n_entries {
             let (memory_regions, _end_address) =
                 generate_memory_regions($n, MemoryState::Readable, None);
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, &SBPFVersion::V2).unwrap();
+            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V2).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);
             });
@@ -301,7 +301,7 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation, vm_add
             MemoryRegion::new_writable(&mut mem2, 0x100000000 + 8),
         ],
         &config,
-        &SBPFVersion::V2,
+        SBPFVersion::V2,
     )
     .unwrap();
 

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -31,7 +31,7 @@ fuzz_target!(|data: DumbFuzzData| {
     let function_registry = FunctionRegistry::default();
     let syscall_registry = FunctionRegistry::<BuiltinFunction<TestContextObject>>::default();
 
-    if RequisiteVerifier::verify(&prog, &config, &SBPFVersion::V2, &function_registry, &syscall_registry).is_err() {
+    if RequisiteVerifier::verify(&prog, &config, SBPFVersion::V2, &function_registry, &syscall_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -38,7 +38,7 @@ fuzz_target!(|data: FuzzData| {
     if RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
-        &SBPFVersion::V2,
+        SBPFVersion::V2,
         &function_registry,
         &syscall_registry,
     )

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -45,7 +45,7 @@ fuzz_target!(|data: FuzzData| {
     if RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
-        &SBPFVersion::V2,
+        SBPFVersion::V2,
         &function_registry,
         &syscall_registry,
     )

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -35,7 +35,7 @@ fuzz_target!(|data: FuzzData| {
     if RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
-        &SBPFVersion::V2,
+        SBPFVersion::V2,
         &function_registry,
         &syscall_registry,
     )

--- a/fuzz/fuzz_targets/verify_semantic_aware.rs
+++ b/fuzz/fuzz_targets/verify_semantic_aware.rs
@@ -30,7 +30,7 @@ fuzz_target!(|data: FuzzData| {
     RequisiteVerifier::verify(
         prog.into_bytes(),
         &config,
-        &SBPFVersion::V2,
+        SBPFVersion::V2,
         &function_registry,
         &syscall_registry,
     )

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -115,7 +115,7 @@ pub fn disassemble_instruction<C: ContextObject>(
     cfg_nodes: &BTreeMap<usize, CfgNode>,
     function_registry: &FunctionRegistry<usize>,
     loader: &BuiltinProgram<C>,
-    sbpf_version: &SBPFVersion,
+    sbpf_version: SBPFVersion,
 ) -> String {
     let name;
     let desc;

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -259,8 +259,8 @@ impl<C: ContextObject> Executable<C> {
     }
 
     /// Get the executable sbpf_version
-    pub fn get_sbpf_version(&self) -> &SBPFVersion {
-        &self.sbpf_version
+    pub fn get_sbpf_version(&self) -> SBPFVersion {
+        self.sbpf_version
     }
 
     /// Get the .text section virtual address and bytes

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -190,7 +190,7 @@ pub struct UnalignedMemoryMapping<'a> {
     /// VM configuration
     config: &'a Config,
     /// Executable sbpf_version
-    sbpf_version: &'a SBPFVersion,
+    sbpf_version: SBPFVersion,
     /// CoW callback
     cow_cb: Option<MemoryCowCallback>,
 }
@@ -242,7 +242,7 @@ impl<'a> UnalignedMemoryMapping<'a> {
         mut regions: Vec<MemoryRegion>,
         cow_cb: Option<MemoryCowCallback>,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         regions.sort();
         for index in 1..regions.len() {
@@ -272,7 +272,7 @@ impl<'a> UnalignedMemoryMapping<'a> {
     pub fn new(
         regions: Vec<MemoryRegion>,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         Self::new_internal(regions, None, config, sbpf_version)
     }
@@ -284,7 +284,7 @@ impl<'a> UnalignedMemoryMapping<'a> {
         regions: Vec<MemoryRegion>,
         cow_cb: MemoryCowCallback,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         Self::new_internal(regions, Some(cow_cb), config, sbpf_version)
     }
@@ -554,7 +554,7 @@ pub struct AlignedMemoryMapping<'a> {
     /// VM configuration
     config: &'a Config,
     /// Executable sbpf_version
-    sbpf_version: &'a SBPFVersion,
+    sbpf_version: SBPFVersion,
     /// CoW callback
     cow_cb: Option<MemoryCowCallback>,
 }
@@ -581,7 +581,7 @@ impl<'a> AlignedMemoryMapping<'a> {
         mut regions: Vec<MemoryRegion>,
         cow_cb: Option<MemoryCowCallback>,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         regions.insert(0, MemoryRegion::new_readonly(&[], 0));
         regions.sort();
@@ -607,7 +607,7 @@ impl<'a> AlignedMemoryMapping<'a> {
     pub fn new(
         regions: Vec<MemoryRegion>,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         Self::new_internal(regions, None, config, sbpf_version)
     }
@@ -619,7 +619,7 @@ impl<'a> AlignedMemoryMapping<'a> {
         regions: Vec<MemoryRegion>,
         cow_cb: MemoryCowCallback,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         Self::new_internal(regions, Some(cow_cb), config, sbpf_version)
     }
@@ -750,7 +750,7 @@ impl<'a> MemoryMapping<'a> {
     pub fn new(
         regions: Vec<MemoryRegion>,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         if config.aligned_memory_mapping {
             AlignedMemoryMapping::new(regions, config, sbpf_version).map(MemoryMapping::Aligned)
@@ -767,7 +767,7 @@ impl<'a> MemoryMapping<'a> {
         regions: Vec<MemoryRegion>,
         cow_cb: MemoryCowCallback,
         config: &'a Config,
-        sbpf_version: &'a SBPFVersion,
+        sbpf_version: SBPFVersion,
     ) -> Result<Self, EbpfError> {
         if config.aligned_memory_mapping {
             AlignedMemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version)
@@ -869,7 +869,7 @@ fn ensure_writable_region(region: &MemoryRegion, cow_cb: &Option<MemoryCowCallba
 /// Helper for map to generate errors
 fn generate_access_violation(
     config: &Config,
-    sbpf_version: &SBPFVersion,
+    sbpf_version: SBPFVersion,
     access_type: AccessType,
     vm_addr: u64,
     len: u64,
@@ -1026,13 +1026,13 @@ mod test {
     #[test]
     fn test_map_empty() {
         let config = Config::default();
-        let m = UnalignedMemoryMapping::new(vec![], &config, &SBPFVersion::V2).unwrap();
+        let m = UnalignedMemoryMapping::new(vec![], &config, SBPFVersion::V2).unwrap();
         assert_error!(
             m.map(AccessType::Load, ebpf::MM_INPUT_START, 8),
             "AccessViolation"
         );
 
-        let m = AlignedMemoryMapping::new(vec![], &config, &SBPFVersion::V2).unwrap();
+        let m = AlignedMemoryMapping::new(vec![], &config, SBPFVersion::V2).unwrap();
         assert_error!(
             m.map(AccessType::Load, ebpf::MM_INPUT_START, 8),
             "AccessViolation"
@@ -1053,7 +1053,7 @@ mod test {
                     MemoryRegion::new_writable_gapped(&mut mem1, ebpf::MM_STACK_START, 2),
                 ],
                 &config,
-                &SBPFVersion::V2,
+                SBPFVersion::V2,
             )
             .unwrap();
             for frame in 0..4 {
@@ -1081,7 +1081,7 @@ mod test {
                     MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + mem1.len() as u64 - 1),
                 ],
                 &config,
-                &SBPFVersion::V2,
+                SBPFVersion::V2,
             ),
             "InvalidMemoryRegion(1)"
         );
@@ -1091,7 +1091,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + mem1.len() as u64),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .is_ok());
     }
@@ -1117,7 +1117,7 @@ mod test {
                 ),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1191,7 +1191,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + 4),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         assert_error!(
@@ -1251,7 +1251,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_STACK_START),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         assert_error!(
@@ -1325,7 +1325,7 @@ mod test {
                 ),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1367,7 +1367,7 @@ mod test {
                 ),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         m.store(0x1122u16, ebpf::MM_INPUT_START).unwrap();
@@ -1394,7 +1394,7 @@ mod test {
         let m = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut mem1, ebpf::MM_INPUT_START)],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1428,7 +1428,7 @@ mod test {
                 MemoryRegion::new_writable(&mut mem2, ebpf::MM_INPUT_START + 7),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1456,7 +1456,7 @@ mod test {
         let m = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut mem1, ebpf::MM_INPUT_START)],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         m.store(0x11u8, ebpf::MM_INPUT_START).unwrap();
@@ -1474,7 +1474,7 @@ mod test {
                 MemoryRegion::new_writable(&mut mem2, ebpf::MM_INPUT_START + 4),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         m.store(0x1122334455667788u64, ebpf::MM_INPUT_START)
@@ -1500,7 +1500,7 @@ mod test {
         let m = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(&mem1, ebpf::MM_INPUT_START)],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         assert_eq!(m.load::<u8>(ebpf::MM_INPUT_START).unwrap(), 0xff);
@@ -1516,7 +1516,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + 4),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         assert_eq!(
@@ -1541,7 +1541,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + mem1.len() as u64),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
         m.store(0x11223344, ebpf::MM_INPUT_START).unwrap();
@@ -1559,7 +1559,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_INPUT_START + mem1.len() as u64),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1631,7 +1631,7 @@ mod test {
                 MemoryRegion::new_readonly(&mem2, ebpf::MM_STACK_START),
             ],
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1688,7 +1688,7 @@ mod test {
                     Ok(c.borrow().as_slice().as_ptr() as u64)
                 }),
                 &config,
-                &SBPFVersion::V2,
+                SBPFVersion::V2,
             )
             .unwrap();
 
@@ -1721,7 +1721,7 @@ mod test {
                     Ok(c.borrow().as_slice().as_ptr() as u64)
                 }),
                 &config,
-                &SBPFVersion::V2,
+                SBPFVersion::V2,
             )
             .unwrap();
 
@@ -1766,7 +1766,7 @@ mod test {
                     Ok(c.borrow().as_slice().as_ptr() as u64)
                 }),
                 &config,
-                &SBPFVersion::V2,
+                SBPFVersion::V2,
             )
             .unwrap();
 
@@ -1786,7 +1786,7 @@ mod test {
             vec![MemoryRegion::new_cow(&original, ebpf::MM_RODATA_START, 42)],
             Box::new(|_| Err(())),
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 
@@ -1803,7 +1803,7 @@ mod test {
             vec![MemoryRegion::new_cow(&original, ebpf::MM_RODATA_START, 42)],
             Box::new(|_| Err(())),
             &config,
-            &SBPFVersion::V2,
+            SBPFVersion::V2,
         )
         .unwrap();
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -21,69 +21,69 @@ pub enum SBPFVersion {
 
 impl SBPFVersion {
     /// Implicitly perform sign extension of results
-    pub fn implicit_sign_extension_of_results(&self) -> bool {
-        self == &SBPFVersion::V1
+    pub fn implicit_sign_extension_of_results(self) -> bool {
+        self == SBPFVersion::V1
     }
 
     /// Enable the little-endian byte swap instructions
-    pub fn enable_le(&self) -> bool {
-        self == &SBPFVersion::V1
+    pub fn enable_le(self) -> bool {
+        self == SBPFVersion::V1
     }
 
     /// Enable the negation instruction
-    pub fn enable_neg(&self) -> bool {
-        self == &SBPFVersion::V1
+    pub fn enable_neg(self) -> bool {
+        self == SBPFVersion::V1
     }
 
     /// Swaps the reg and imm operands of the subtraction instruction
-    pub fn swap_sub_reg_imm_operands(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn swap_sub_reg_imm_operands(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Enable the only two slots long instruction: LD_DW_IMM
-    pub fn enable_lddw(&self) -> bool {
-        self == &SBPFVersion::V1
+    pub fn enable_lddw(self) -> bool {
+        self == SBPFVersion::V1
     }
 
     /// Enable the BPF_PQR instruction class
-    pub fn enable_pqr(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn enable_pqr(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Use src reg instead of imm in callx
-    pub fn callx_uses_src_reg(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn callx_uses_src_reg(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Ensure that rodata sections don't exceed their maximum allowed size and
     /// overlap with the stack
-    pub fn reject_rodata_stack_overlap(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn reject_rodata_stack_overlap(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Allow sh_addr != sh_offset in elf sections.
-    pub fn enable_elf_vaddr(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn enable_elf_vaddr(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Separates the bytecode from the read only data in virtual address space
-    pub fn enable_lower_bytecode_vaddr(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn enable_lower_bytecode_vaddr(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Use dynamic stack frame sizes
-    pub fn dynamic_stack_frames(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn dynamic_stack_frames(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Support syscalls via pseudo calls (insn.src = 0)
-    pub fn static_syscalls(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn static_syscalls(self) -> bool {
+        self != SBPFVersion::V1
     }
 
     /// Move opcodes of memory instructions into ALU instruction classes
-    pub fn move_memory_instruction_classes(&self) -> bool {
-        self != &SBPFVersion::V1
+    pub fn move_memory_instruction_classes(self) -> bool {
+        self != SBPFVersion::V1
     }
 }
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -88,7 +88,7 @@ pub trait Verifier {
     fn verify<C: ContextObject>(
         prog: &[u8],
         config: &Config,
-        sbpf_version: &SBPFVersion,
+        sbpf_version: SBPFVersion,
         function_registry: &FunctionRegistry<usize>,
         syscall_registry: &FunctionRegistry<BuiltinFunction<C>>,
     ) -> Result<(), VerifierError>;
@@ -172,7 +172,7 @@ fn check_registers(
     insn: &ebpf::Insn,
     store: bool,
     insn_ptr: usize,
-    sbpf_version: &SBPFVersion,
+    sbpf_version: SBPFVersion,
 ) -> Result<(), VerifierError> {
     if insn.src > 10 {
         return Err(VerifierError::InvalidSourceRegister(insn_ptr));
@@ -201,7 +201,7 @@ fn check_imm_shift(insn: &ebpf::Insn, insn_ptr: usize, imm_bits: u64) -> Result<
 fn check_callx_register(
     insn: &ebpf::Insn,
     insn_ptr: usize,
-    sbpf_version: &SBPFVersion,
+    sbpf_version: SBPFVersion,
 ) -> Result<(), VerifierError> {
     let reg = if sbpf_version.callx_uses_src_reg() {
         insn.src as i64
@@ -220,7 +220,7 @@ pub struct RequisiteVerifier {}
 impl Verifier for RequisiteVerifier {
     /// Check the program against the verifier's rules
     #[rustfmt::skip]
-    fn verify<C: ContextObject>(prog: &[u8], _config: &Config, sbpf_version: &SBPFVersion, function_registry: &FunctionRegistry<usize>, syscall_registry: &FunctionRegistry<BuiltinFunction<C>>) -> Result<(), VerifierError> {
+    fn verify<C: ContextObject>(prog: &[u8], _config: &Config, sbpf_version: SBPFVersion, function_registry: &FunctionRegistry<usize>, syscall_registry: &FunctionRegistry<BuiltinFunction<C>>) -> Result<(), VerifierError> {
         check_prog_len(prog)?;
 
         let program_range = 0..prog.len() / ebpf::INSN_SIZE;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -323,7 +323,7 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
     /// Creates a new virtual machine instance.
     pub fn new(
         loader: Arc<BuiltinProgram<C>>,
-        sbpf_version: &SBPFVersion,
+        sbpf_version: SBPFVersion,
         context_object: &'a mut C,
         mut memory_mapping: MemoryMapping<'a>,
         stack_len: usize,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -2710,7 +2710,7 @@ declare_builtin_function!(
 fn test_nested_vm_syscall() {
     let config = Config::default();
     let mut context_object = TestContextObject::default();
-    let mut memory_mapping = MemoryMapping::new(vec![], &config, &SBPFVersion::V2).unwrap();
+    let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V2).unwrap();
     let result = SyscallNestedVm::rust(&mut context_object, 1, 0, 0, 0, 0, &mut memory_mapping);
     assert!(result.unwrap() == 42);
     let result = SyscallNestedVm::rust(&mut context_object, 1, 1, 0, 0, 0, &mut memory_mapping);

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -47,7 +47,7 @@ impl Verifier for TautologyVerifier {
     fn verify<C: ContextObject>(
         _prog: &[u8],
         _config: &Config,
-        _sbpf_version: &SBPFVersion,
+        _sbpf_version: SBPFVersion,
         _function_registry: &FunctionRegistry<usize>,
         _syscall_registry: &FunctionRegistry<BuiltinFunction<C>>,
     ) -> std::result::Result<(), VerifierError> {
@@ -60,7 +60,7 @@ impl Verifier for ContradictionVerifier {
     fn verify<C: ContextObject>(
         _prog: &[u8],
         _config: &Config,
-        _sbpf_version: &SBPFVersion,
+        _sbpf_version: SBPFVersion,
         _function_registry: &FunctionRegistry<usize>,
         _syscall_registry: &FunctionRegistry<BuiltinFunction<C>>,
     ) -> std::result::Result<(), VerifierError> {


### PR DESCRIPTION
`SBPFVersion` is represented as an integer, so using it with references is inefficient. We can remove all references and copy it everywhere.