### PR TITLE
Lazily calculate target pc for `CALL_IMM`

### DIFF
--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -38,7 +38,7 @@ fn to_json(program: &[u8]) -> String {
     let analysis = Analysis::from_executable(&executable).unwrap();
 
     let mut json_insns = vec![];
-    for insn in analysis.instructions.iter() {
+    for (pc, insn) in analysis.instructions.iter().enumerate() {
         json_insns.push(object!(
             "opc"  => format!("{:#x}", insn.opc), // => insn.opc,
             "dst"  => format!("{:#x}", insn.dst), // => insn.dst,
@@ -53,7 +53,8 @@ fn to_json(program: &[u8]) -> String {
             // has no effect and the complete value is printed anyway.
             "imm"  => format!("{:#x}", insn.imm as i32), // => insn.imm,
             "desc" => analysis.disassemble_instruction(
-                insn
+                insn,
+                pc
             ),
         ));
     }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -111,7 +111,8 @@ fn jmp_reg_str(name: &str, insn: &ebpf::Insn, cfg_nodes: &BTreeMap<usize, CfgNod
 /// Disassemble an eBPF instruction
 #[rustfmt::skip]
 pub fn disassemble_instruction<C: ContextObject>(
-    insn: &ebpf::Insn, 
+    insn: &ebpf::Insn,
+    pc: usize,
     cfg_nodes: &BTreeMap<usize, CfgNode>,
     function_registry: &FunctionRegistry<usize>,
     loader: &BuiltinProgram<C>,
@@ -265,7 +266,8 @@ pub fn disassemble_instruction<C: ContextObject>(
         ebpf::JSLE_IMM   => { name = "jsle"; desc = jmp_imm_str(name, insn, cfg_nodes); },
         ebpf::JSLE_REG   => { name = "jsle"; desc = jmp_reg_str(name, insn, cfg_nodes); },
         ebpf::CALL_IMM   => {
-            let function_name = function_registry.lookup_by_key(insn.imm as u32).map(|(function_name, _)| String::from_utf8_lossy(function_name).to_string());
+            let key = sbpf_version.calculate_call_imm_target_pc(pc, insn.imm);
+            let function_name = function_registry.lookup_by_key(key).map(|(function_name, _)| String::from_utf8_lossy(function_name).to_string());
             let function_name = if let Some(function_name) = function_name {
                 name = "call";
                 function_name

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -799,10 +799,7 @@ impl<C: ContextObject> Executable<C> {
             .ok_or(ElfError::ValueOutOfBounds)?;
         for i in 0..instruction_count {
             let insn = ebpf::get_insn(text_bytes, i);
-            if insn.opc == ebpf::CALL_IMM
-                && insn.imm != -1
-                && !(sbpf_version.static_syscalls() && insn.src == 0)
-            {
+            if insn.opc == ebpf::CALL_IMM && insn.imm != -1 {
                 let target_pc = (i as isize)
                     .saturating_add(1)
                     .saturating_add(insn.imm as isize);
@@ -820,11 +817,13 @@ impl<C: ContextObject> Executable<C> {
                     name.as_bytes(),
                     target_pc as usize,
                 )?;
-                let offset = i.saturating_mul(ebpf::INSN_SIZE).saturating_add(4);
-                let checked_slice = text_bytes
-                    .get_mut(offset..offset.saturating_add(4))
-                    .ok_or(ElfError::ValueOutOfBounds)?;
-                LittleEndian::write_u32(checked_slice, key);
+                if !sbpf_version.static_syscalls() {
+                    let offset = i.saturating_mul(ebpf::INSN_SIZE).saturating_add(4);
+                    let checked_slice = text_bytes
+                        .get_mut(offset..offset.saturating_add(4))
+                        .ok_or(ElfError::ValueOutOfBounds)?;
+                    LittleEndian::write_u32(checked_slice, key);
+                }
             }
         }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -551,7 +551,16 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
                 }
 
                 if internal && !resolved {
-                    if let Some((_function_name, target_pc)) = self.executable.get_function_registry().lookup_by_key(insn.imm as u32) {
+                    if let Some((_function_name, target_pc)) =
+                        self.executable
+                            .get_function_registry()
+                            .lookup_by_key(
+                                self
+                                    .executable
+                                    .get_sbpf_version()
+                                    .calculate_call_imm_target_pc(self.reg[11] as usize, insn.imm)
+                            )
+                    {
                         resolved = true;
 
                         // make BPF to BPF call

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -727,9 +727,18 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     }
 
                     if internal {
-                        if let Some((_function_name, target_pc)) = self.executable.get_function_registry().lookup_by_key(insn.imm as u32) {
-                            self.emit_internal_call(Value::Constant64(target_pc as i64, true));
-                            resolved = true;
+                        if let Some((_function_name, target_pc)) =
+                            self.executable
+                                .get_function_registry()
+                                .lookup_by_key(
+                                    self
+                                        .executable
+                                        .get_sbpf_version()
+                                        .calculate_call_imm_target_pc(self.pc, insn.imm)
+                                )
+                        {
+                                self.emit_internal_call(Value::Constant64(target_pc as i64, true));
+                                resolved = true;
                         }
                     }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -81,6 +81,16 @@ impl SBPFVersion {
         self != SBPFVersion::V1
     }
 
+    /// Calculate the target program counter for a CALL_IMM instruction depending on
+    /// the SBPF version.
+    pub fn calculate_call_imm_target_pc(self, pc: usize, imm: i64) -> u32 {
+        if self.static_syscalls() {
+            (pc as i64).saturating_add(imm).saturating_add(1) as u32
+        } else {
+            imm as u32
+        }
+    }
+
     /// Move opcodes of memory instructions into ALU instruction classes
     pub fn move_memory_instruction_classes(self) -> bool {
         self != SBPFVersion::V1

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -391,10 +391,11 @@ impl Verifier for RequisiteVerifier {
                 ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr, &function_range)?; },
                 ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr, &function_range)?; },
                 ebpf::CALL_IMM   if sbpf_version.static_syscalls() => {
+                    let target_pc = sbpf_version.calculate_call_imm_target_pc(insn_ptr, insn.imm);
                     check_call_target(
-                        insn.imm as u32,
+                        target_pc,
                         function_registry,
-                        VerifierError::InvalidFunction(insn.imm as usize)
+                        VerifierError::InvalidFunction(target_pc as usize)
                     )?;
                 },
                 ebpf::CALL_IMM   => {},

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -152,7 +152,7 @@ fn test_call_reg() {
 fn test_call_imm() {
     assert_eq!(
         asm("call 299"),
-        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 1, 0, 300)])
+        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 1, 0, 299)])
     );
 }
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -2962,8 +2962,9 @@ fn test_err_exit_capped() {
     );
     test_interpreter_and_jit_asm!(
         "
-        call 1
+        call function_foo
         exit
+        function_foo:
         mov r0, r0
         exit
         ",

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -348,7 +348,7 @@ fn test_verifier_err_unknown_opcode() {
 }
 
 #[test]
-#[should_panic(expected = "InvalidFunction(1811268606)")]
+#[should_panic(expected = "InvalidFunction(1811268607)")]
 fn test_verifier_unknown_sycall() {
     let prog = &[
         0x85, 0x00, 0x00, 0x00, 0xfe, 0xc3, 0xf5, 0x6b, // call 0x6bf5c3fe


### PR DESCRIPTION
In SBPFv2, the `CALL_IMM` instruction only contains relative addresses in its immediate field, so we do not need to relocate it during loading.

Also, this PR addresses the comment https://github.com/solana-labs/rbpf/pull/620/files#r1822346064, properly evaluating the address in the verifier and during execution.